### PR TITLE
Add IResourcesHandler interface to LCResourcesHandler

### DIFF
--- a/src/aria/resources/handlers/LCResourcesHandler.js
+++ b/src/aria/resources/handlers/LCResourcesHandler.js
@@ -26,6 +26,7 @@
      */
     Aria.classDefinition({
         $classpath : "aria.resources.handlers.LCResourcesHandler",
+        $implements : ["aria.resources.handlers.IResourcesHandler"],
         $dependencies : ["aria.utils.String", "aria.resources.handlers.LCResourcesHandlerBean"],
         $statics : {
             /**


### PR DESCRIPTION
Class aria.resources.handlers.LCResourcesHandler implicitely implements interface aria.resources.handlers.IResourcesHandler but the interface implementation was not declared previously.
