### PR TITLE
Calendar container height

### DIFF
--- a/src/aria/widgets/calendar/CalendarTemplate.tpl
+++ b/src/aria/widgets/calendar/CalendarTemplate.tpl
@@ -99,7 +99,10 @@
                     </tr>
                 {/foreach}
                 {for ;nbweeks<=5;nbweeks++}
-                    <tr><td colspan="${settings.showWeekNumbers?8:7}" style="border: 1px solid; visibility: hidden;">&nbsp;</td></tr>
+                    <tr>
+                        {if settings.showWeekNumbers}<td class="${skin.baseCSS}weekNumber" style="visibility: hidden;">&nbsp;</td>{/if}
+                        <td class="${skin.baseCSS}day" colspan="7" style="visibility: hidden;">&nbsp;</td>
+                    </tr>
                 {/for}
             </tbody>
         </table>


### PR DESCRIPTION
Calendar months displaying on 5 weeks had a different height with respect to those displayed on 6 weeks. The invisible table line added at the bottom was not taking into account skin properties defined for the calendar.

This commit fixes the issue.
