### PR TITLE
Support for {on error} in TPLs

### DIFF
--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -85,7 +85,8 @@ Aria.classDefinition({
             change : true,
             paste : true,
             cut : true,
-            submit : true
+            submit : true,
+            error : true
         };
 
         // note that the change event does not bubble on all browsers (e.g.: on IE) but is necessary as it is the only


### PR DESCRIPTION
Currently there's a warning when trying to write {on error { .. } /} in the template, while it's perfectly valid, e.g. for images (<img onerror="imageLoadFailed()">).
