### PR TITLE
Fix 0 width for dialog with scrollbars and block templates

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -159,7 +159,6 @@ Aria.classDefinition({
             var maxWidth = math.min(this._cfg.maxWidth, viewport.width);
             this._div = new aria.widgets.container.Div({
                 sclass : this._skinObj.divsclass,
-                block : true,
                 margins : "0 0 0 0",
                 cssClass : this._context.getCSSClassNames(true) + " " + this._cfg.cssClass,
                 height : this._cfg.height,


### PR DESCRIPTION
This fixes #10 keeping the internal span as inline-block instead of giving
it a block display
