### PR TITLE
Fix for issue 24: wrong parameter order in logError

### DIFF
--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -703,7 +703,7 @@ Aria.classDefinition({
                 // call the error callback
                 if (cb.onerror == null) {
                     // Generic IO error mgt
-                    this.$logError(this.IO_REQUEST_FAILED, [res.error, res.url]);
+                    this.$logError(this.IO_REQUEST_FAILED, [res.url, res.error]);
                 } else {
                     var scope = cb.onerrorScope;
                     if (!scope) {


### PR DESCRIPTION
This commit fixes issue 24: wrong parameter order in logError in IO.js.
