### PR TITLE
now using packman 0.2.6 which fixes the js-yaml install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "wrench": "",
-    "packman": "0.2.5",
+    "packman": "0.2.6",
     "jshint": "0.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Recently, npm package js-yaml was updated to 1.0.0 and (at least for me) it can no longer be installed without any error with `npm install js-yaml`.
Therefore, packman, which made use of the latest js-yaml was failing to install too.
Therefore, running `npm install` on ariatemplates was failing too.

Now using 0.2.6 of packman which freezes the version of js-yaml to 0.3.7 which is the latest that installs correctly.

Build works again now for me.

What is strange is that the build has never failed on travis (e.g. http://travis-ci.org/#!/captainbrosset/ariatemplates/builds/1788660)
But anyway, it's a better practice to fix the version of dependencies, to avoid unexpected issues.

Issue https://github.com/nodeca/js-yaml/issues/45 opened
