### PR TITLE
Added support for <img:naturalWidth/Height> in getproperty

### DIFF
--- a/src/aria/utils/sandbox/DOMProperties.js
+++ b/src/aria/utils/sandbox/DOMProperties.js
@@ -186,6 +186,12 @@
             "TEXTAREA" : "rw"
         },
         "namespaceURI" : "r-",
+        "naturalWidth" : {
+            "IMG" : "r-"
+        },
+        "naturalHeight" : {
+            "IMG" : "r-"
+        },
         "nodeName" : "r-",
         "nodeType" : "r-",
         "nodeValue" : "r-",


### PR DESCRIPTION
Added "naturalWidth" and "naturalHeight" to whitelist of properties accessible via getproperty on dom element wrapper.
