### PR TITLE
Fixes #64: IE10 extra pseudoelements for text inputs

### DIFF
--- a/src/aria/widgets/GlobalStyle.tpl.css
+++ b/src/aria/widgets/GlobalStyle.tpl.css
@@ -174,6 +174,15 @@ a:focus {
   vertical-align:top;
 }
 {/if}
+
+{if aria.core.Browser.isIE10 }
+.xTextInputInput::-ms-clear {
+	display: none;
+}
+.xTextInputInput::-ms-reveal {
+	display: none;
+}
+{/if}
 {/macro}
 
 {macro writeAnchorState(state)}

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -267,7 +267,7 @@ Aria.classDefinition({
 
                 ].join(''));
             } else {
-                out.write(['<input', Aria.testMode ? ' id="' + this._domId + '_input"' : '',
+                out.write(['<input class="xTextInputInput" ', Aria.testMode ? ' id="' + this._domId + '_input"' : '',
                         cfg.disabled ? ' disabled="disabled"' : cfg.readOnly ? ' readonly="readonly"' : '', ' type="',
                         type, '" style="', inlineStyle.join(''), 'color:', color, ';width:', inputWidth, 'px;"',
                         'value="', stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text),


### PR DESCRIPTION
Fixes #64: IE10 extra pseudoelements for text inputs
