### PR TITLE
Fixes #58: scrollbars in textareas in IE (all versions)

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -259,7 +259,7 @@ Aria.classDefinition({
                 out.write(['<textarea', Aria.testMode ? ' id="' + this._domId + '_textarea"' : '',
                         cfg.disabled ? ' disabled="disabled"' : cfg.readOnly ? ' readonly="readonly"' : '', ' type="',
                         type, '" style="', inlineStyle.join(''), 'color:', color,
-                        ';resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth, 'px;"',
+                        ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth, 'px;"',
                         'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
                         (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck,
                         '>', stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text),


### PR DESCRIPTION
Fixes #58: scrollbars in textareas in IE (all versions)

Now scrollbars appear only when necessary, in all browsers.
