### PR TITLE
SELC82P100 - RAT R javascript error on search page

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -930,7 +930,7 @@ Aria.classDefinition({
         isAncestor : function (child, parent) {
             if (!( child && child.ownerDocument)) {
                 return false;
-            } 
+            }
             var document = child.ownerDocument;
             var body = document.body;
             var element = child;


### PR DESCRIPTION
The isAncestor method utils class fails when plain objects are passed.

eg: 
var child = {};
aria.utils.Dom.isAncestor(child , null);
