### PR TITLE
Node.js module for Aria Templates

### DIFF
--- a/src/aria/bootstrap.js
+++ b/src/aria/bootstrap.js
@@ -90,6 +90,7 @@
 
             // mandatory utils
             'aria/utils/Array.js',
+            'aria/utils/String.js',
             'aria/utils/QueryString.js',
             'aria/utils/Type.js',
             'aria/utils/json/JsonSerializer.js',

--- a/src/aria/node.js
+++ b/src/aria/node.js
@@ -1,0 +1,58 @@
+var vm = require("vm"), fs = require("fs"), path = require("path");
+
+/* aria and Aria are going to be global */
+aria = {};
+
+Aria = {
+    rootFolderPath : __dirname + "/../"
+};
+
+/* This is the global load method used by the framework, it's common to Rhino */
+load = function (filePath) {
+    filePath = path.normalize(filePath);
+
+    var fileContent = fs.readFileSync(filePath, "utf-8");
+    vm.runInThisContext(fileContent);
+};
+
+try {
+    load(__dirname + "/bootstrap.js");
+
+    // For all the other classes we use IO, define our node transport
+    Aria.classDefinition({
+        $classpath : "aria.node.Transport",
+        $implements : ["aria.core.transport.ITransports"],
+        $singleton : true,
+        $prototype : {
+            isReady : true,
+            init : function () {},
+            request : function (reqId, method, uri, callback, postData) {
+                fs.readFile(uri, "utf-8", function (err, data) {
+                    if (err) {
+                        console.log("ERROR", err);
+                    } else {
+                        var responseObject = {
+                            reqId : reqId,
+                            status : 200,
+                            responseText : data
+                        };
+                        if (callback && callback.success) {
+                            if (!callback.scope) {
+                                callback.success(responseObject);
+                            } else {
+                                callback.success.call(callback.scope, responseObject);
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    });
+
+    aria.core.IO.updateTransports({
+        "sameDomain" : "aria.node.Transport"
+    });
+} catch (ex) {
+    console.error('\n[Error] Aria Templates framework not loaded.', ex);
+    process.exit(0);
+}


### PR DESCRIPTION
Add a node.js module to include the framework with a single instruction

``` Javascript
require("./path/to/aria/node.js");
```

The module create the two global variables `aria` and `Aria` that can be used to load classes, parse templates and so on.
