### PR TITLE
resIndex and apply on JsObject and utils.Callback

### DIFF
--- a/src/aria/core/CfgBeans.js
+++ b/src/aria/core/CfgBeans.js
@@ -388,6 +388,16 @@ Aria.beanDefinitions({
                 "args" : {
                     $type : "json:MultiTypes",
                     $description : "Optional argument passed to the function."
+                },
+                "resIndex" : {
+                    $type : "json:Integer",
+                    $description : "Optional param to specify the index of the result or event object in the arguments passed to the callback function.",
+                    $default : 0
+                },
+                "apply" : {
+                    $type : "json:Boolean",
+                    $description : "Whether we should use Function.call or Function.apply for args. Used only if args is an array",
+                    $default : false
                 }
             }
         }

--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -326,7 +326,7 @@
 
             /**
              * Generic method allowing to call-back a caller in asynchronous processes
-             * @param {aria.core.JsObject.Callback} cb callback description
+             * @param {aria.core.CfgBeans.Callback} cb callback description
              * @param {MultiTypes} res first result argument to pass to cb.fn (second argument will be cb.args)
              * @param {String} errorId error raised if an exception occurs in the callback
              * @return the value returned by the callback, or undefined if the callback could not be called.
@@ -354,8 +354,15 @@
                     callback = scope[callback];
                 }
 
+                var args = (cb.apply === true && cb.args && Object.prototype.toString.apply(cb.args) === "[object Array]") ? cb.args : [cb.args];
+                var resIndex = (cb.resIndex === undefined) ? 0 : cb.resIndex;
+
+                if (resIndex > -1) {
+                    args.splice(resIndex, 0, res);
+                }
+
                 try {
-                    return callback.call(scope, res, cb.args);
+                    return callback.apply(scope, args);
                 } catch (ex) {
                     this.$logError(errorId, [this.$classpath, scope.$classpath], ex);
                 }
@@ -381,26 +388,11 @@
                 return {
                     fn : callback,
                     scope : scope,
-                    args : cb.args
+                    args : cb.args,
+                    resIndex : cb.resIndex,
+                    apply : cb.apply
                 };
             },
-
-            /*
-             * if (cb == null) return; // callback is sometimes not used
-             * if (errorId == null) errorId = "20007_CALLBACK_ERROR";
-             * try { if (typeof(cb) == 'string') { // shortcut :
-             * scope=this and no arg return this[cb].call(this, res); }
-             * else if (typeof(cb) == 'function') { // shortcut :
-             * scope=this and no arg return cb.call(this, res); } else {
-             * var scope = cb.scope ? cb.scope : this; // use this as
-             * default scope (useful for templates, for // example) if
-             * (typeof(cb.fn) == 'string') { return
-             * scope[cb.fn].call(scope, res, cb.args); } else { return
-             * cb.fn.call(scope, res, cb.args); } } } catch (ex) { var
-             * scope = cb.scope; if (!scope) { scope = this; }
-             * this.$logError(errorId, [this.$classpath,
-             * scope.$classpath], ex); }
-             */
 
             /**
              * Display all internal values in a message box (debug and test purpose - usefull on low-end browsers)

--- a/src/aria/utils/Callback.js
+++ b/src/aria/utils/Callback.js
@@ -14,24 +14,94 @@
  */
 
 /**
- * Object representing a callback. Does normalization on creation, and expose a simple call method
- * @class aria.utils.Callback
+ * Object representing a callback. Does normalization on creation, and expose a simple call method.<br />
+ * The callback must at least contain a function, it can optionally specify the scope and arguments for the called
+ * method.<br />
+ * The following example creates a simple callback and calls it passing a result object
+ *
+ * <pre><code>
+ * // create the callback
+ * var callback = new aria.utils.Callback({
+ *     fn : function (result) {}
+ * });
+ *
+ * // later in the code, call the callback
+ * callback.call('my result here');
+ * </code></pre>
+ *
+ * The callback definition can also specify scope and arguments
+ *
+ * <pre><code>
+ * // create the callback
+ * var callback = new aria.utils.Callback({
+ *     fn : function (result, anotherObject) {
+ *         // here 'this' corresponds to myObject
+ *         // and 'anotherObject' is whatever object was passed to args
+ *     },
+ *     scope : myObject,
+ *     args : anotherObject
+ * });
+ *
+ * // later in the code, call the callback
+ * callback.call('my result here');
+ * </code></pre>
+ *
+ * The position in which 'result' is passed to the callback can be configured using 'resIndex'
+ *
+ * <pre><code>
+ * // create the callback
+ * var callback = new aria.utils.Callback({
+ *     fn : function (anotherObject) {
+ *         // 'anotherObject' is whatever object was passed to args
+ *         // with a negative resIndex we don't receive the result object
+ *     },
+ *     scope : myObject,
+ *     args : anotherObject,
+ *     resIndex : -1
+ * });
+ *
+ * // later in the code, call the callback
+ * callback.call('my result here');
+ * </code></pre>
+ *
+ * By default the callback passes 'args' as it was orginally defined, but if 'args' is an array and 'apply' is set to
+ * true, the 'args' are exploded
+ *
+ * <pre><code>
+ * // create the callback
+ * var callback = new aria.utils.Callback({
+ *     fn : function (one, two, three) {
+ *         // 'one' is 'first argument'
+ *         // 'two' is 'second argument'
+ *         // 'three' is 'my result here'
+ *     },
+ *     scope : myObject,
+ *     args : ['first argument', 'second argument'],
+ *     resIndex : 2
+ * });
+ *
+ * // later in the code, call the callback
+ * callback.call('my result here');
+ * </code></pre>
  */
 Aria.classDefinition({
-    $classpath : 'aria.utils.Callback',
+    $classpath : "aria.utils.Callback",
+    $dependencies : ["aria.utils.Type"],
     $statics : {
-        INVALID_CALLBACK : "The call method was called after $dispose."
+        INVALID_CALLBACK : "The callback function is invalid or missing or it was called after $dispose."
     },
     /**
      * Creates a callback instance
-     * @param {Object} callbackDefinition, an object or directly a function reference.
+     * @param {aria.core.CfgBeans.Callback|Function} callbackDefinition, an object or directly a function reference.
      *
      * <pre>
-     *     {
-     *         fn : ..., // a function reference
-     *      scope : ..., // Object to use as a scope, optional
-     *      args : ... // callback second argument, optional
-     *     }
+     * {
+     *      fn : ...,       // a function reference
+     *      scope : ...,    // Object to use as a scope, optional
+     *      args : ...,     // callback second argument, optional
+     *      resIndex : ..., // index of the result object
+     *      apply : ...     // whether args is passed as in Function.call or Function.apply
+     * }
      * </pre>
      */
     $constructor : function (callbackDefinition) {
@@ -39,26 +109,42 @@ Aria.classDefinition({
         // normalise definition
         callbackDefinition = this.$normCallback(callbackDefinition);
 
+        var valid = aria.utils.Type.isFunction(callbackDefinition.fn);
+
         /**
          * Scope for callback execution
          * @type Object
          */
-        this._scope = callbackDefinition.scope;
+        this._scope = valid ? callbackDefinition.scope : this;
 
         /**
          * Function to execute
          * @type Function
          */
-        this._function = callbackDefinition.fn;
+        this._function = valid ? callbackDefinition.fn : this._warnDisposed;
 
         /**
          * Arguments given when creating the callback
+         * @type Object
          */
         this._args = callbackDefinition.args;
 
+        /**
+         * Index of the result or event object in the arguments passed to the callback function
+         * @type Integer
+         */
+        this._resIndex = callbackDefinition.resIndex;
+
+        /**
+         * Whether we should use Function.call or Function.apply for args. Used only if args is an array
+         * @type Boolean
+         */
+        this._apply = callbackDefinition.apply;
+
     },
     $destructor : function () {
-        this._scope = null;
+        // scope : this, ensure that we can still log in case we re-use the callback
+        this._scope = this;
         this._function = this._warnDisposed;
         this._args = null;
     },
@@ -69,9 +155,20 @@ Aria.classDefinition({
          * @param {Object} event
          */
         call : function (evt) {
-            return this._function.call(this._scope, evt, this._args);
+            var args = (this._apply === true && aria.utils.Type.isArray(this._args)) ? this._args : [this._args];
+            var resIndex = (this._resIndex === undefined) ? 0 : this._resIndex;
+
+            if (resIndex > -1) {
+                args.splice(resIndex, 0, evt);
+            }
+
+            return this._function.apply(this._scope, args);
         },
 
+        /**
+         * Log an error in case the callback function is invalid
+         * @protected
+         */
         _warnDisposed : function () {
             this.$logError(this.INVALID_CALLBACK);
         }


### PR DESCRIPTION
Define a way to optionally specify the position of the callback arguments in the callback function or whether the event should be passed or not.

It also allows to specify whether we should use `Function.call` or `Function.apply` in case the arguments object is an array.

The changes are done in `aria.core.CfgBeans.Callback` (`JsObject.$callback()`) and in `aria.utils.Callback`

No changes are done on other callbacks like `aria.core.IO`, `Aria.load`, `Aria.loadTemplate`

Documentation is available in `aria.utils.Callback`'s JsDoc
