### PR TITLE
Allow classes and templates to be unloaded together with their parents

### DIFF
--- a/src/aria/templates/TemplateManager.js
+++ b/src/aria/templates/TemplateManager.js
@@ -29,20 +29,50 @@ Aria.classDefinition({
          * be bypassed by adding a timestamp to the url.
          */
         unloadTemplate : function (classpath, timestampNextTime) {
+            this._unloadTemplate(classpath, timestampNextTime, false, function() { return true; });
+        },
+        
+        /**
+         * Unload a template (cache/files/urls/scripts/CSS associated) and its parents
+         * @param {String} classpath the classpath of the class to be removed
+         * @param {Boolean} timestampNextTime if true, the next time the class is loaded, browser and server cache will
+         * be bypassed by adding a timestamp to the url.
+         * @param {Function} a closure that is called with the resource classpath to be unloaded and informs if it
+         * should actually be unloaded tests whether a given classpath is to be unloaded, must return <code>true</code>
+         * only for classpaths owned by the caller.
+         */
+        unloadTemplateRecursive : function (classpath, timestampNextTime, tester) {
+            this._unloadTemplate(classpath, timestampNextTime, true, tester);
+        },
+        
+        /**
+         * Unload a template (cache/files/urls/scripts/CSS associated) and its parents
+         * @private
+         * @param {String} classpath the classpath of the class to be removed
+         * @param {Boolean} timestampNextTime if true, the next time the class is loaded, browser and server cache will
+         * be bypassed by adding a timestamp to the url.
+         * @param {Boolean} recursive if true, the parent is investigated for unloading.
+         * @param {Function} a closure that is called with the resource classpath to be unloaded and informs if it
+         * should actually be unloaded, must return <code>true</code> only for classpaths owned by the caller.
+         */
+        _unloadTemplate : function (classpath, timestampNextTime, recursive, tester) {
             var classMgr = aria.core.ClassMgr;
+            var classCaller = function (cp) {
+                if (recursive) {
+                    classMgr.unloadClass(cp, timestampNextTime);
+                } else {
+                    classMgr.unloadClassRecursive(cp, timestampNextTime, tester);
+                }
+            }
+            // Clean template script
             var scriptClasspath = classpath + "Script";
-            // do some cleaning in cache
-            if (Aria.nspace(scriptClasspath, false) || aria.core.Cache.getItem("classes", scriptClasspath)) {
-                classMgr.unloadClass(scriptClasspath, timestampNextTime);
+            if (tester(scriptClasspath)) {
+                if (Aria.nspace(scriptClasspath, false) || aria.core.Cache.getItem("classes", scriptClasspath)) {
+                    classCaller(scriptClasspath);
+                }
             }
-            var itm = Aria.$classDefinitions[classpath];
-            if (!Aria.nspace(classpath, false) && itm) {// when there is an error in the script, the class reference for
-                // the template is not created, so the css would not be
-                // unregistered in the unloadClass method
-                aria.templates.CSSMgr.unregisterDependencies(classpath, itm.$css, true, timestampNextTime);
-            }
-            classMgr.unloadClass(classpath, timestampNextTime);
-            // every thing is done : CSS are unhandled at classMgr level directly
+            // every thing is done : CSS are handled at classMgr level directly
+            classCaller(classpath);
             this.$raiseEvent("unloadTemplate");
         }
     }


### PR DESCRIPTION
When unloading a template, a class or a CSS, it would be useful to be able to unload also its parents.

In order not to unload core AT stuff, users have to provide a closure that restricts unloading to their code base, based on the classpath of the related entity. The closure takes the classpath in argument (maybe file type could be useful too like js/css/tpl) and returns a boolean, the resource is actually unloaded only if it returns true. For example to unload code that is inside a given package:

``` js
function (classpath) {
  return (classpath.indexOf("my.root.classpath") === 0)
}
```

Attached commit is mostly scratching, the same mecanism should be applied to CSS and resources unloading too, and code cleaned (like the true callback, and no tests). I removed the CSS unloading part in TemplateManager because despite the comment, it seems it is handled in ClassMgr.

If the callback approach is too broad and considered too dangerous, a more constrained way of doing so would be to require the package name in which to unload entities.
