### PR TITLE
Splitting aria.widgets.GlobalStyle.

### DIFF
--- a/src/aria/core/TplClassLoader.js
+++ b/src/aria/core/TplClassLoader.js
@@ -228,7 +228,7 @@
             classes.push("aria.templates.ModuleCtrlFactory", moduleCtrl.classpath);
         }
 
-        var cssToReload = ['aria.widgets.GlobalStyle'];
+        var cssToReload = ['aria.templates.GlobalStyle','aria.widgets.GlobalStyle'];
         if (cfg.reload) {
             aria.templates.TemplateManager.unloadTemplate(cfg.classpath, cfg.reloadByPassCache);
             if (aria.templates.CSSMgr) {
@@ -488,7 +488,8 @@
         $prototype : {
             /**
              * Load the class definition file.
-             * @param {String} classDef File content, can be either the generated class definition or the source template itself
+             * @param {String} classDef File content, can be either the generated class definition or the source
+             * template itself
              * @param {String} logicalPath template's logical classpath
              * @override
              */

--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -43,6 +43,10 @@ Aria.beanDefinitions({
                     $description : "If true, a mask is shown behind the popup so that mouse and keyboard interraction with elements behind the popup is not possible.",
                     $default : false
                 },
+                "maskCssClass" : {
+                    $type : "json:String",
+                    $description : "CSS classes to be applied on the mask. Only used if modal is true. If not specified, a default style is applied."
+                },
                 "domReference" : {
                     $type : "json:ObjectRef",
                     $description : "{HTMLElement} The DOM reference which will be used as the reference position for the tooltip",

--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -213,7 +213,7 @@ Aria.classDefinition({
                 this.modalMaskDomElement = null;
             }
             if (conf.modal) {
-                this.modalMaskDomElement = this._createMaskDomElement();
+                this.modalMaskDomElement = this._createMaskDomElement(conf.maskCssClass);
             }
             if (this.domElement != null) {
                 aria.utils.Dom.removeElement(this.domElement);
@@ -281,12 +281,13 @@ Aria.classDefinition({
         /**
          * Create the DOM element of the mask, for modal popups.
          * @protected
+         * @param {String} className CSS classes for the dialog mask.
          * @return {HTMLElement}
          */
-        _createMaskDomElement : function () {
+        _createMaskDomElement : function (className) {
             var document = this._document;
             var div = document.createElement("div");
-            div.className = "xDialogMask";
+            div.className = className || "xModalMask-default";
             div.style.cssText = "position:absolute;top:-15000px;left:-15000px;visibility:hidden;display:block;";
             return document.body.appendChild(div);
         },
@@ -746,7 +747,7 @@ Aria.classDefinition({
          * popup and blurs the dom reference.
          * @param {Object} event scroll event that triggered the handler.
          */
-        _isScrolling : function() {
+        _isScrolling : function () {
             var domReference = this.reference;
             if (domReference) {
                 var geometry = aria.utils.Dom.getGeometry(domReference);

--- a/src/aria/templates/CSSMgr.js
+++ b/src/aria/templates/CSSMgr.js
@@ -376,6 +376,10 @@ Aria.classDefinition({
             delete this.__invalidClasspaths[cssClasspath];
 
             var cssCtxt = aria.templates.CSSCtxtManager.getContext(cssClasspath, contextArgs);
+            if (cssClasspath == "aria.templates.GlobalStyle") {
+                // Give a prefix to the Global file in order to have higher priority
+                this.__getPrefix(cssClasspath);
+            }
             if (cssClasspath == "aria.widgets.GlobalStyle") {
                 // Give a prefix to the Global file in order to have higher priority
                 this.__getPrefix(cssClasspath);

--- a/src/aria/templates/GlobalStyle.tpl.css
+++ b/src/aria/templates/GlobalStyle.tpl.css
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath : "aria.templates.GlobalStyle"
+}}
+
+{macro main()}
+
+.xLDI-text {
+    position: relative;
+    top: 50%;
+    display:block;
+    text-align:center;
+    padding-top: 20px;
+}
+
+.xLDI {
+	/* These default values can be overridden in the skin */
+    background-color: #fff;
+    {call opacity(80)/}
+}
+
+.xOverlay {
+	/* These default values can be overridden in the skin */
+    background-color: #ddd;
+    border: 1px solid black;
+    {call opacity(40)/}
+}
+
+.xModalMask-default {
+    width:100%;
+    height:100%;
+    background-color: black;
+    {call opacity(40)/}
+}
+
+.xOverflowAuto {
+    overflow: auto;
+}
+
+.xOverflowHidden {
+    overflow: hidden;
+}
+
+.xOverflowXAuto {
+    overflow-x: auto;
+}
+
+.xOverflowYAuto {
+    overflow-y: auto;
+}
+
+.xOverflowXHidden {
+    overflow-x: hidden;
+}
+
+.xOverflowYHidden {
+    overflow-y: hidden;
+}
+
+/* template div container style */
+.xTplContent {
+}
+
+{/macro}
+
+{macro opacity(percent)}
+    filter: alpha(opacity=${percent});
+    -moz-opacity: ${percent/100};
+    opacity: ${percent/100};
+{/macro}
+
+{/CSSTemplate}

--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -60,11 +60,10 @@
     Aria.classDefinition({
         $classpath : 'aria.templates.TemplateCtxt',
         $dependencies : ['aria.templates.Layout', 'aria.templates.CfgBeans', 'aria.utils.Array', 'aria.utils.Function',
-                'aria.utils.Type', 'aria.templates.TemplateCtxtManager',
-                'aria.templates.RefreshManager', 'aria.templates.CSSMgr', 'aria.utils.Path', 'aria.utils.Delegate',
-                'aria.templates.NavigationManager', 'aria.templates.SectionWrapper',
-                'aria.core.environment.Customizations', 'aria.templates.DomElementWrapper',
-                'aria.templates.MarkupWriter'],
+                'aria.utils.Type', 'aria.templates.TemplateCtxtManager', 'aria.templates.RefreshManager',
+                'aria.templates.CSSMgr', 'aria.utils.Path', 'aria.utils.Delegate', 'aria.templates.NavigationManager',
+                'aria.templates.SectionWrapper', 'aria.core.environment.Customizations',
+                'aria.templates.DomElementWrapper', 'aria.templates.MarkupWriter'],
         $implements : ['aria.templates.ITemplate', 'aria.templates.ITemplateCtxt'],
         $extends : "aria.templates.BaseCtxt",
         $onload : function () {
@@ -170,8 +169,9 @@
                 // Warn the CSS Manager that we are removing a template (it won't change the style)
                 aria.templates.CSSMgr.unloadDependencies(this);
                 if (this._globalCssDepsLoaded) {
-                    // PTR 05086835: only unload the global widgets CSS if it was loaded by this instance
-                    aria.templates.CSSMgr.unloadWidgetDependencies('aria.templates.Template', ['aria.widgets.GlobalStyle']);
+                    // PTR 05086835: only unload the global CSS if it was loaded by this instance
+                    aria.templates.CSSMgr.unloadWidgetDependencies('aria.templates.Template', [
+                            'aria.templates.GlobalStyle', /* BACKWARD-COMPATIBILITY-BEGIN */'aria.widgets.GlobalStyle' /* BACKWARD-COMPATIBILITY-END */]);
                     this._globalCssDepsLoaded = false;
                 }
                 this._cssClasses = null;
@@ -949,12 +949,13 @@
                 if (moduleCtrl) {
                     // When a moduleCtrl is used, the ModuleCtrlFactory should be loaded.
                     // However, the ModuleCtrlFactory is not a static dependency cause sometimes we don't need it.
-                    // TODO: today, we just fail if it's not here, replace this with a silent dynamic loading (Aria.load)
-                    if(!aria.templates.ModuleCtrlFactory) {
+                    // TODO: today, we just fail if it's not here, replace this with a silent dynamic loading
+                    // (Aria.load)
+                    if (!aria.templates.ModuleCtrlFactory) {
                         this.$logError(this.MISSING_MODULE_CTRL_FACTORY, [cfg.classpath]);
                     } else {
 
-                        if(!__getModulePrivateInfo) {
+                        if (!__getModulePrivateInfo) {
                             __getModulePrivateInfo = aria.templates.ModuleCtrlFactory.__getModulePrivateInfoMethod();
                         }
                         privateInfo = __getModulePrivateInfo.call(this, moduleCtrl);
@@ -980,10 +981,8 @@
                                     privateInfo = __getModulePrivateInfo.call(this, moduleCtrl);
                                     if (!privateInfo) {
                                         // if privateInfo is null, it means either the module controller was not created
-                                        // through
-                                        // aria.templates.ModuleCtrlFactory or it was already disposed (error was already
-                                        // logged in
-                                        // __getModulePrivateInfo)
+                                        // through aria.templates.ModuleCtrlFactory or it was already disposed (error
+                                        // was already logged in __getModulePrivateInfo)
                                         return false;
                                     }
                                     moduleCtrlPrivate = privateInfo.moduleCtrlPrivate;
@@ -1601,8 +1600,10 @@
                 var classes = this._cssClasses;
                 if (!classes) {
                     if (this._cfg.isRootTemplate) {
-                        // PTR 05086835: load the global widgets CSS here, and remember that it was loaded
-                        aria.templates.CSSMgr.loadWidgetDependencies('aria.templates.Template', ['aria.widgets.GlobalStyle']);
+                        // PTR 05086835: load the global CSS here, and remember that it was loaded
+                        aria.templates.CSSMgr.loadWidgetDependencies('aria.templates.Template', [
+                                'aria.templates.GlobalStyle', /* BACKWARD-COMPATIBILITY-BEGIN */
+                                'aria.widgets.GlobalStyle' /* BACKWARD-COMPATIBILITY-END */]);
                         this._globalCssDepsLoaded = true;
                     }
                     // Load the CSS dependencies, the style should be added before the html

--- a/src/aria/tools/contextual/ContextualMenu.js
+++ b/src/aria/tools/contextual/ContextualMenu.js
@@ -349,6 +349,7 @@
                         left : xpos
                     },
                     modal : true,
+                    maskCssClass : "xDialogMask" /* uses the css class from the AriaSkin */,
                     preferredPositions : [{
                                 reference : "bottom left",
                                 popup : "top left"

--- a/src/aria/widgets/AriaSkinBeans.js
+++ b/src/aria/widgets/AriaSkinBeans.js
@@ -57,11 +57,11 @@ Aria.beanDefinitions({
                     $properties : {
                         "size" : {
                             $type : "Pixels",
-                            $description : "General font size for the application (in pixels)."
+                            $description : "[Deprecated, please use a CSS file directly] General font size for the application (in pixels)."
                         },
                         "family" : {
                             $type : "json:String",
-                            $description : "General font family for the application."
+                            $description : "[Deprecated, please use a CSS file directly] General font family for the application."
                         }
                     }
                 },
@@ -71,7 +71,7 @@ Aria.beanDefinitions({
                     $properties : {
                         "bkg" : {
                             $type : "Color",
-                            $description : "General background color of the application."
+                            $description : "[Deprecated, please use a CSS file directly] General background color of the application."
                         },
                         "disabled" : {
                             $type : "Color",
@@ -107,7 +107,8 @@ Aria.beanDefinitions({
                         },
                         "opacity" : {
                             $type : "Opacity",
-                            $description : ""
+                            $description : "",
+                            $default : 100
                         },
                         "border" : {
                             $type : "json:String",
@@ -133,7 +134,7 @@ Aria.beanDefinitions({
                 },
                 "anchor" : {
                     $type : "Object",
-                    $description : "General settings for anchors.",
+                    $description : "[Deprecated, please use a CSS file directly] General settings for anchors.",
                     $properties : {
                         "states" : {
                             $type : "StatesSet",
@@ -172,7 +173,7 @@ Aria.beanDefinitions({
                                     $properties : {
                                         "style" : {
                                             $type : "json:Boolean",
-                                            $description : ""
+                                            $description : "[Deprecated, please use a CSS file directly]"
                                         }
                                     }
                                 }
@@ -184,23 +185,24 @@ Aria.beanDefinitions({
         },
         "AnchorState" : {
             $type : "Object",
-            $description : "Settings for anchors.",
+            $description : "[Deprecated, please use a CSS file directly] Settings for anchors.",
             $properties : {
                 "color" : {
-                    $type : "Color"
+                    $type : "Color",
+                    $description : "[Deprecated, please use a CSS file directly]"
                 },
                 "text" : {
                     $type : "Object",
                     $properties : {
                         "decoration" : {
                             $type : "json:String",
-                            $description : ""
+                            $description : "[Deprecated, please use a CSS file directly]"
                         }
                     }
                 },
                 "outline" : {
                     $type : "json:String",
-                    $description : ""
+                    $description : "[Deprecated, please use a CSS file directly]"
                 }
             }
         },

--- a/src/aria/widgets/GlobalStyle.tpl.css
+++ b/src/aria/widgets/GlobalStyle.tpl.css
@@ -21,47 +21,27 @@
 
 {macro main()}
     {var general = aria.widgets.AriaSkinInterface.getGeneral()/}
-/* Skin: ${skin.name} */
 /* Note: all private classes start with 'x' - these classes must not be used in application pages as they can change when new features are implemented */
+
+/* BACKWARD-COMPATIBILITY-BEGIN */
+/* CSS rules added by Aria Templates itself should not impact the whole page */
 
 /* Global classes */
 body, textarea, select, input, button, table {
 {if general.font.size}
-  font-size: ${general.font.size}px;
+    font-size: ${general.font.size}px;
 {/if}
 {if general.font.family}
-  font-family: ${general.font.family};
+    font-family: ${general.font.family};
 {/if}
 }
 body {
-  padding: 0;
-  margin: 0;
-  cursor:default;
+    padding: 0;
+    margin: 0;
+    cursor:default;
 {if general.colors.bkg}
-  background-color: ${general.colors.bkg};
+    background-color: ${general.colors.bkg};
 {/if}
-}
-
-.xLDI-text {
-  position: relative;
-  top: 50%;
-  display:block;
-  text-align:center;
-  padding-top:
-  20px;
-}
-
-.xLDI {
-  {call background(general.loadingOverlay.backgroundColor, general.loadingOverlay.spriteURL,"no-repeat center center")/}
-  {call opacity(general.loadingOverlay.opacity)/}
-}
-
-.xOverlay {
-  background-color: ${general.overlay.backgroundColor};
-  {if general.overlay.opacity}
-      {call opacity(general.overlay.opacity)/}
-  {/if}
-  border: ${general.overlay.border};
 }
 
 a {
@@ -71,20 +51,20 @@ a:link {
 {call writeAnchorState(general.anchor.states.link)/}
 }
 a:visited {
-{call writeAnchorState(general.anchor.states.visited)/}    
+{call writeAnchorState(general.anchor.states.visited)/}
 }
 a:hover {
 {call writeAnchorState(general.anchor.states.hover)/}
 }
 
 {if ! general.disable.ul.list.style}
-  ul, li {list-style-type:none;}
+ul, li {list-style-type:none;}
 {/if}
 
 /* Hide input focus on safari*/
 {if aria.core.Browser.isSafari || aria.core.Browser.isChrome}
 *:focus {
-  outline: 0;
+    outline: 0;
 }
 {/if}
 
@@ -92,53 +72,38 @@ a:focus {
 {call writeAnchorState(general.anchor.states.focus)/}
 }
 
+/* BACKWARD-COMPATIBILITY-END */
+
+.xLDI {
+    {call background(general.loadingOverlay.backgroundColor, general.loadingOverlay.spriteURL,"no-repeat center center")/}
+    {call opacity(general.loadingOverlay.opacity)/}
+}
+
+.xOverlay {
+    background-color: ${general.overlay.backgroundColor};
+    {call opacity(general.overlay.opacity)/}
+    border: ${general.overlay.border};
+}
+
 /*AT Widget wrapper DOMElm */
 {var widgetSettings = aria.widgets.environment.WidgetSettings.getWidgetSettings() /}
 .xWidget {
-  position: relative;
-  display: inline-block;
-  {if widgetSettings.middleAlignment}vertical-align: middle;{/if}
+    position: relative;
+    display: inline-block;
+    {if widgetSettings.middleAlignment}vertical-align: middle;{/if}
 }
 
 .xWidget.xBlock, .xBlock {
-  display: block;
-}
-
-.xOverflowAuto {
-  overflow: auto;
-}
-
-.xOverflowHidden {
-  overflow: hidden;
-}
-
-.xOverflowXAuto {
-  overflow-x: auto;
-}
-
-.xOverflowYAuto {
-  overflow-y: auto;
-}
-
-.xOverflowXHidden {
-  overflow-x: hidden;
-}
-
-.xOverflowYHidden {
-  overflow-y: hidden;
-}
-
-/* template div container style */
-.xTplContent {
+    display: block;
 }
 
 /* Mask for modal dialogs */
 .xDialogMask {
-  /* width and height are required for IE6 to work correctly */
-  width:100%;
-  height:100%;
-  background-color: ${general.dialogMask.backgroundColor};
-  {call opacity(general.dialogMask.opacity || 40) /}
+    /* width and height are required for IE6 to work correctly */
+    width:100%;
+    height:100%;
+    background-color: ${general.dialogMask.backgroundColor};
+    {call opacity(general.dialogMask.opacity || 40) /}
 }
 
 .xFrameContent {
@@ -155,8 +120,8 @@ a:focus {
     vertical-align: {if widgetSettings.middleAlignment}middle{else/}top{/if};
 }
 .xFixedHeightFrame_bme {
-    display: inline-block; 
-    vertical-align: {if widgetSettings.middleAlignment}middle{else/}top{/if}; 
+    display: inline-block;
+    vertical-align: {if widgetSettings.middleAlignment}middle{else/}top{/if};
 }
 .xSimpleFrame {
     display: inline-block;
@@ -165,36 +130,36 @@ a:focus {
 
 {if aria.core.Browser.isIE7 }
 .xFixedHeightFrame_w {
-  vertical-align:top;
+    vertical-align:top;
 }
-{/if}
 
-{if aria.core.Browser.isIE7 }
 .xFixedHeightFrame_bme {
-  vertical-align:top;
+    vertical-align:top;
 }
 {/if}
 
 {if aria.core.Browser.isIE10 }
 .xTextInputInput::-ms-clear {
-	display: none;
+    display: none;
 }
 .xTextInputInput::-ms-reveal {
-	display: none;
+    display: none;
 }
 {/if}
 {/macro}
 
+/* BACKWARD-COMPATIBILITY-BEGIN */
 {macro writeAnchorState(state)}
 {if state.color}
-  color: ${state.color};
+    color: ${state.color};
 {/if}
 {if state.text.decoration}
-  text-decoration: ${state.text.decoration};
+    text-decoration: ${state.text.decoration};
 {/if}
 {if state.outline}
-  outline: ${state.outline};
+    outline: ${state.outline};
 {/if}
 {/macro}
+/* BACKWARD-COMPATIBILITY-END */
 
 {/CSSTemplate}

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -28,6 +28,11 @@
         $dependencies : ["aria.widgets.CfgBeans", "aria.utils.Json", "aria.utils.Dom", "aria.DomEvent",
                 "aria.utils.Delegate", "aria.widgets.AriaSkinInterface", "aria.utils.Type",
                 "aria.templates.RefreshManager"],
+        // BACKWARD-COMPATIBILITY-BEGIN
+        // The following line should be uncommented when removing the automatic load of this CSS from
+        // aria.templates.TemplateCtxt and aria.core.TplClassLoader:
+        // $css : ["aria.widgets.GlobalStyle"],
+        // BACKWARD-COMPATIBILITY-END
         $onload : function () {
             delegateManager = aria.utils.Delegate;
             jsonUtils = aria.utils.Json;

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -404,6 +404,7 @@ Aria.classDefinition({
                 },
                 center : cfg.center,
                 modal : cfg.modal,
+                maskCssClass : "xDialogMask",
                 closeOnMouseClick : false,
                 closeOnMouseScroll : false,
                 parentDialog : this
@@ -630,7 +631,7 @@ Aria.classDefinition({
          * @protected
          */
         _onDragEnd : function () {
-            //this.updatePosition();
+            // this.updatePosition();
             if (this._popup) {
                 this._popup.refreshProcessingIndicators();
             }


### PR DESCRIPTION
This is the first part of a change to avoid depending on aria.widgets.GlobalStyle if no widget from the AriaLib is used. There is a need to separate from aria.widgets.GlobalStyle the classes used by loading indicator, overlay and mask because they are used outside of the AriaLib widgets library.
Someone doing an application with just Aria.loadTemplate, no aria widget, and simple html sub templates should not need any skin object.

Note that, for backward compatibility with existing applications, only part of the change is implemented. The remaining part will be done when removing backward compatibility.
