### PR TITLE
Allowing to use Aria Templates as a node npm dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "author": "ariatemplates <contact@ariatemplates.com> (http://github.com/ariatemplates)",
-  "name": "ariatemplates",
-  "description": "Aria Templates (aka AT) is an application framework written in JavaScript for building rich and large-scaled enterprise web applications.",
-  "version": "1.2.4",
-  "homepage": "http://github.com/ariatemplates/ariatemplates",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/ariatemplates/ariatemplates.git"
-  },
-  "private": true,
-  "dependencies": {},
-  "devDependencies": {
-    "wrench": "",
-    "packman": "0.2.x",
-    "jshint": "0.7.x"
-  },
-  "scripts": {
-    "install": "node build/build.js"
-  }
+    "author" : "ariatemplates <contact@ariatemplates.com> (http://github.com/ariatemplates)",
+    "name" : "ariatemplates",
+    "description" : "Aria Templates (aka AT) is an application framework written in JavaScript for building rich and large-scaled enterprise web applications.",
+    "version" : "1.2.4",
+    "homepage" : "http://github.com/ariatemplates/ariatemplates",
+    "repository" : {
+        "type" : "git",
+        "url" : "git://github.com/ariatemplates/ariatemplates.git"
+    },
+    "private" : true,
+    "main" : "src/aria/node.js",
+    "dependencies" : {
+        "wrench" : "1.3.x",
+        "packman" : "0.2.x",
+        "jshint" : "0.7.x"
+    },
+    "scripts" : {
+        "install" : "node build/build.js"
+    }
 }


### PR DESCRIPTION
Currently there is an error when trying to use Aria Templates as a node npm dependency, because the install script uses dependencies declared in devDependencies.
This pull request fixes this issue.
