### PR TITLE
Close on click feature added on dialog widget

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -36,6 +36,12 @@ Aria.classDefinition({
                 cancelClose : "{Boolean} Cancel the closing of the popup"
             }
         },
+        onMouseClickClose : {
+            description : "Event triggered when the popup is close with a mouse click outside the popup",
+            properties : {
+                domEvent : "{aria.DomEvent} The event that triggered the closing of the popup"
+            }
+        },
         onAfterClose : "",
         onBeforeOpen : "",
         onAfterOpen : "",
@@ -701,6 +707,12 @@ Aria.classDefinition({
          */
         closeOnMouseClick : function (domEvent) {
             if (this.conf.closeOnMouseClick) {
+                var event = {
+                    name : "onMouseClickClose",
+                    cancelClose : false,
+                    domEvent : domEvent
+                };
+                this.$raiseEvent(event);
                 this.close(domEvent);
                 return true;
             }

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1445,6 +1445,11 @@ Aria.beanDefinitions({
                     $description : "Whether the dialog has a close button in its title bar.",
                     $default : true
                 },
+                "closeOnMouseClick" : {
+                    $type : "json:Boolean",
+                    $description : "Close the dialog when the user clicks outside of it",
+                    $default : false
+                },
                 "center" : {
                     $type : "json:Boolean",
                     $description : "If true, the dialog is always centered in the browser window. Takes priority over xpos and ypos. However, if the dialog box is movable and the user manually moves it, the centered behavior will be switched off.",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -379,6 +379,12 @@ Aria.classDefinition({
                 "onAfterOpen" : this._onAfterPopupOpen,
                 scope : this
             });
+            if (cfg.closeOnMouseClick) {
+                popup.$on({
+                    "onMouseClickClose" : this._onMouseClickClose,
+                    scope : this
+                });
+            }
 
             // global navigation is disable is the case of a modal dialog
             if (this._cfg.modal) {
@@ -405,7 +411,7 @@ Aria.classDefinition({
                 center : cfg.center,
                 modal : cfg.modal,
                 maskCssClass : "xDialogMask",
-                closeOnMouseClick : false,
+                closeOnMouseClick : cfg.closeOnMouseClick,
                 closeOnMouseScroll : false,
                 parentDialog : this
             });
@@ -451,6 +457,13 @@ Aria.classDefinition({
                     }
                 });
             }
+        },
+
+        /**
+         * Is called right after the popup is close.
+         */
+        _onMouseClickClose : function () {
+            this.actionClose();
         },
 
         /**


### PR DESCRIPTION
The closeOnMouseClick property has been added to the dialog widget property list.

When this option is activated, the user can close the dialog by simply clicking outside of it.
The default is false.
