### PR TITLE
Skip Robot tests

### DIFF
--- a/src/aria/jsunit/RobotTestCase.js
+++ b/src/aria/jsunit/RobotTestCase.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Class to be extended to create a template test case using the Robot applet. The applet allows to execute user actions
+ * (click, type, move, drag, ...) as if they were done by the user instead of simultating browser events.<br />
+ * This test makes sure that the robot is loaded and initialized before starting the template test case
+ */
+Aria.classDefinition({
+    $classpath : "aria.jsunit.RobotTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.jsunit.SynEvents", "aria.jsunit.Robot"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        /**
+         * Events utility to simulate user actions
+         * @type aria.jsunit.SynEvents
+         */
+        this.synEvent = aria.jsunit.SynEvents;
+    },
+    $destructor : function () {
+        this.synEvent = null;
+        this.$TemplateTestCase.$destructor.call(this);
+    },
+    $prototype : {
+        run : function () {
+            if (this.skipTest) {
+                this.$TemplateTestCase.run.call(this);
+            } else {
+                aria.jsunit.Robot.initRobot({
+                    fn : this.$TemplateTestCase.run,
+                    scope : this
+                });
+            }
+        }
+    }
+});

--- a/src/aria/jsunit/TestEngine.js
+++ b/src/aria/jsunit/TestEngine.js
@@ -14,21 +14,18 @@
  */
 
 /**
- * @class aria.jsunit.TestEngine This class drives the test execution by looping on all Tests it is associated to It
- * also acts as test listener and maintain global informations on the test executions (e.g. what test have been run, how
- * many failures found, etc...). Some UI listeners can be associated to it to display real-time information to the user.
+ * This class drives the test execution by looping on all Tests it is associated to.<br />
+ * It also acts as test listener and maintains global informations on the test executions (e.g. what test have been run,
+ * how many failures found, etc...). Some UI listeners can be associated to it to display real-time information to the
+ * user.<br />
  * Note: Tests are run in an asynchronous way in order to give HTML UIs the possibility to refresh information
- * (otherwise the refresh would only occur at the end of the Thread execution) Note2: This class doesn't display any
- * information - see TestRunner to get a runner with an HTML UI
- * @extends aria.core.JsObject
+ * (otherwise the refresh would only occur at the end of the Thread execution) <br />
+ * Note: This class doesn't display any information - see TestRunner to get a runner with an HTML UI
  */
 Aria.classDefinition({
-    $classpath : 'aria.jsunit.TestEngine',
-    $dependencies : ['aria.utils.Type'],
+    $classpath : "aria.jsunit.TestEngine",
+    $dependencies : ["aria.utils.Type"],
     $events : {
-        /**
-         * @event change
-         */
         "change" : {
             description : "raised when some data have changed in the test report",
             properties : {
@@ -40,23 +37,42 @@ Aria.classDefinition({
     $constructor : function () {
         /**
          * Data model representing the test report in real time This data model is a tree where each node as the
-         * following structure: [Test]: { testClass:{String) test classpath totalNbrOfFailures: {Integer}: total number
-         * of failures (including sub tests) totalNbrOfErrors: {Integer}: total number of errors (including sub tests)
-         * totalNbrOfAsserts: {Integer}: total number of assertions (including sub tests) state: {String} "loaded",
-         * "processing" or "done" processingState: {String} description of the internal state when processing
-         * subTests:[{Test}] Array of sub-tests - null if none failures: [{TestFailure}] Array of failures discovered in
-         * this test (doesn't include sub-tests) [TestFailure] : { testState: {String} name of the test method in which
-         * the failure was found, description: {String} Failure description } errors:[{TestError}] Array of the errors
-         * caught in this test [TestError] : { testState: {String} name of the test method in which the error was
-         * caught, description: {String} Error description, exception: {Error} The error object caught in the catch
-         * statement } }
+         * following structure:
+         *
+         * <pre>
+         * [Test]
+         * : {
+         *      testClass : {String) test classpath
+         *      totalNbrOfFailures : {Integer} total number of failures (including sub tests)
+         *      totalNbrOfErrors : {Integer} total number of errors (including sub tests)
+         *      totalNbrOfAsserts : {Integer} total number of assertions (including sub tests)
+         *      state : {String} &quot;loaded&quot;, &quot;processing&quot; or &quot;done&quot;
+         *      processingState : {String} description of the internal state when processing
+         *      subTests : [{Test}] Array of sub-tests - null if none
+         *      failures: [{TestFailure}] Array of failures discovered in this test (doesn't include sub-tests)
+         *      errors:[{TestError}] Array of the errors caught in this test
+         * }
+         *
+         * [TestFailure] : {
+         *      testState: {String} name of the test method in which the failure was found,
+         *      description: {String} Failure description
+         * }
+         *
+         * [TestError] : {
+         *      testState: {String} name of the test method in which the error was caught,
+         *      description: {String} Error description,
+         *      exception: {Error} The error object caught in the catchstatement
+         * }
+         * </pre>
          */
         this.testReport = null;
+
         /**
          * Internal stack used to retrieve a test parent
          * @private
          */
         this._testStack = [];
+
         /**
          * Last test in the test stack
          * @private
@@ -139,12 +155,20 @@ Aria.classDefinition({
          * @private
          */
         _onTestLoad : function (evt) {
-            var testObject = evt.testObject;
+            var testObject = evt.testObject, classpath = testObject.$classpath;
 
             // verify if the test is supposed to be skipped and store the value
             if (this.skipTests != null && aria.utils.Array.contains(this.skipTests, testObject.$classpath)) {
                 testObject.skipTest = true;
             }
+            // verify also that it doesn't extend from a skipped test
+            do {
+                var definition = Aria.nspace(classpath).classDefinition;
+                if (aria.utils.Array.contains(this.skipTests, definition.$extends)) {
+                    testObject.skipTest = true;
+                }
+                classpath = definition.$extends;
+            } while (classpath)
             this._registerAsListener(testObject);
         },
 
@@ -192,7 +216,6 @@ Aria.classDefinition({
          * @private
          */
         _onTestEnd : function (evt) {
-
             // unregister from the test object
             evt.testObject.$unregisterListeners(this);
 

--- a/src/aria/jsunit/TestSuite.js
+++ b/src/aria/jsunit/TestSuite.js
@@ -265,7 +265,7 @@ Aria.classDefinition({
             }
 
             this._sequencer.$on({
-                "end" : this._onSequenceEnd,
+                "end" : this._onSequencerEnd,
                 scope : this
             });
 
@@ -572,7 +572,7 @@ Aria.classDefinition({
          * @param {Object} evt the sequencer event
          * @private
          */
-        _onSequenceEnd : function (evt) {
+        _onSequencerEnd : function (evt) {
             if (this._sequencer) {
                 this._sequencer.$dispose(); // will also remove listeners
                 this._sequencer = null;


### PR DESCRIPTION
Give the possibility to skip a test if it extends from a specific classpath.

It also introduces `aria.jsunit.RobotTestCase` that is the test case class to be extended by tests using the robot applet.
If the test should be skipped, the applet is not initialized.

Tests extending from `aria.jsunit.RobotTestCase` don't have to call `initRobot` anymore
