### PR TITLE
Fixing the tplcontext when no macrolibs are there

### DIFF
--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -633,7 +633,7 @@
              */
             _setOut : function (out) {
                 this._out = out;
-                var macrolibs = this._macrolibs;
+                var macrolibs = this._macrolibs || [];
                 for (var i = 0, l = macrolibs.length; i < l; i++) {
                     macrolibs[i]._setOut(out);
                 }


### PR DESCRIPTION
Trying to play around with creating our own widgets and instantiating templates, we stumbled upon an issue whereby `this._macrolibs` was `null` and therefore failing in the `_setOut` function.

This fix simply prevents this from happening.
