### PR TITLE
Enhancing widget extending mechanism

### DIFF
--- a/src/aria/widgets/Icon.js
+++ b/src/aria/widgets/Icon.js
@@ -22,7 +22,7 @@ Aria.classDefinition({
     $dependencies : ["aria.utils.Dom"],
     $css : ["aria.widgets.IconStyle"],
     $constructor : function (cfg, ctxt) {
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.IconCfg";
         this.$Widget.constructor.apply(this, arguments);
 
         /**

--- a/src/aria/widgets/Template.js
+++ b/src/aria/widgets/Template.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         }
     },
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TemplateCfg";
         aria.widgets.Template.superclass.constructor.apply(this, arguments);
 
         if (cfg.width != -1) {

--- a/src/aria/widgets/Text.js
+++ b/src/aria/widgets/Text.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TextCfg";
         this.$Widget.constructor.apply(this, arguments);
 
         if (aria.utils.Type.isString(cfg.ellipsis)) {

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -133,7 +133,7 @@
             try {
                 this._cfgOk = aria.core.JsonValidator.normalize({
                     json : cfg,
-                    beanName : this._cfgPackage + "." + this.$class + "Cfg"
+                    beanName : this._cfgBean || this._cfgPackage + "." + this.$class + "Cfg"
                 }, true);
             } catch (e) {
                 // PTR 05038013: aria.core.Log may not be available
@@ -234,6 +234,12 @@
              * @type String
              */
             _cfgPackage : "aria.widgets.CfgBeans",
+
+            /**
+             * Widget Cfg Bean Classpath to use when validating the configuration for the widget.
+             * @type String
+             */
+            _cfgBean : null,
 
             /**
              * Flag for widget that get initialized right after being displayed (typically, templates)

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.ButtonCfg";
         this.$ActionWidget.constructor.apply(this, arguments);
 
         /**

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.LinkCfg";
         this.$ActionWidget.constructor.apply(this, arguments);
         this._pressed = false;
         this._customTabIndexProvided = true;

--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -31,6 +31,7 @@ Aria.classDefinition({
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */
     $constructor : function (cfg, ctxt, lineNumber) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.SortIndicatorCfg";
         this.$ActionWidget.constructor.apply(this, arguments);
 
         this._setSkinObj("SortIndicator");

--- a/src/aria/widgets/calendar/Calendar.js
+++ b/src/aria/widgets/calendar/Calendar.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
     // TODO: find a better way, to also improve performances for custom templates
     $templates : ["aria.widgets.calendar.CalendarTemplate"],
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.CalendarCfg";
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
         var sclass = this._cfg.sclass;
         var skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Calendar", sclass);

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -31,6 +31,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.DialogCfg";
         this.$Container.constructor.apply(this, arguments);
         this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Dialog", cfg.sclass);
 

--- a/src/aria/widgets/container/Div.js
+++ b/src/aria/widgets/container/Div.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.DivCfg";
         this.$Container.constructor.apply(this, arguments);
         // make a call to the AriaSkinInterface to get access to the skin object applicable here
         if (!this._frame) {

--- a/src/aria/widgets/container/Fieldset.js
+++ b/src/aria/widgets/container/Fieldset.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.FieldsetCfg";
         this.$Container.constructor.apply(this, arguments);
         if (!this._frame) {
             /* this._frame could be overriden in sub-classes */

--- a/src/aria/widgets/container/Splitter.js
+++ b/src/aria/widgets/container/Splitter.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.SplitterCfg";
         this.$Container.constructor.apply(this, arguments);
 
         this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Splitter", cfg.sclass);

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -29,7 +29,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TabCfg";
         this.$Container.constructor.apply(this, arguments);
         this._setSkinObj("Tab");
         this._mouseOver = false;

--- a/src/aria/widgets/container/Tooltip.js
+++ b/src/aria/widgets/container/Tooltip.js
@@ -43,6 +43,7 @@
             timer = null;
         },
         $constructor : function (cfg, ctxt) {
+            this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TooltipCfg";
             this.$Container.constructor.apply(this, arguments);
             this._associatedWidget = null;
             this._showTimeout = null;

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -33,6 +33,7 @@ Aria.classDefinition({
         });
     },
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.ErrorListCfg";
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
         var skinObj = aria.widgets.AriaSkinInterface.getSkinObject("ErrorList", this._cfg.sclass);
         var divCfg = aria.utils.Json.copy(cfg, true, ['width', 'minWidth', 'maxWidth', 'height', 'minHeight', 'block',

--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -21,8 +21,7 @@ Aria.classDefinition({
     $extends : "aria.widgets.form.DropDownTextInput",
     $dependencies : ["aria.widgets.form.DropDownListTrait", "aria.widgets.controllers.AutoCompleteController",
             "aria.utils.Event"],
-    $css : ["aria.widgets.form.AutoCompleteStyle",
-            "aria.widgets.form.list.ListStyle",
+    $css : ["aria.widgets.form.AutoCompleteStyle", "aria.widgets.form.list.ListStyle",
             "aria.widgets.container.DivStyle"],
     /**
      * AutoComplete constructor
@@ -40,7 +39,7 @@ Aria.classDefinition({
              */
             this._skinnableClass = "AutoComplete";
         }
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.AutoCompleteCfg";
         var controller = new aria.widgets.controllers.AutoCompleteController();
 
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);

--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */
     $constructor : function (cfg, ctxt, lineNumber) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.CheckBoxCfg";
         this.$Input.constructor.apply(this, arguments);
 
         if (!this._skinnableClass) {

--- a/src/aria/widgets/form/DateField.js
+++ b/src/aria/widgets/form/DateField.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt, lineNumber) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.DateFieldCfg";
         var controller = new aria.widgets.controllers.DateController();
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         controller.setPattern(cfg.pattern);

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         if (!this._skinnableClass) {
             this._skinnableClass = "DatePicker";
         }
+        this._cfgBean = this._cfgBeam || "aria.widgets.CfgBeans.DatePickerCfg";
         var controller = new aria.widgets.controllers.DatePickerController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         controller.setPattern(cfg.pattern);

--- a/src/aria/widgets/form/Gauge.js
+++ b/src/aria/widgets/form/Gauge.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.GaugeCfg";
         this.$Widget.constructor.apply(this, arguments);
         this._cfg = cfg;
         this.__setSkinObj("Gauge");

--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -14,14 +14,13 @@
  */
 
 /**
- * Base class for all input widgets. Manage input data structure and properties, as well
- * as the label support
+ * Base class for all input widgets. Manage input data structure and properties, as well as the label support
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.form.Input",
     $extends : "aria.widgets.Widget",
     $dependencies : ["aria.utils.Dom", "aria.widgets.form.InputValidationHandler", "aria.utils.Data",
-            "aria.utils.String", "aria.widgets.environment.WidgetSettings","aria.core.Browser"],
+            "aria.utils.String", "aria.widgets.environment.WidgetSettings", "aria.core.Browser"],
     /**
      * Input constructor
      * @param {aria.widgets.CfgBeans.InputCfg} cfg the widget configuration
@@ -29,6 +28,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt) {
         this._setAutomaticBindings(cfg);
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.InputCfg";
         this.$Widget.constructor.apply(this, arguments);
         /**
          * 1 Minimum width in px that must be kept for the input markup To be overridden by sub-classes
@@ -245,12 +245,12 @@ Aria.classDefinition({
             // PTR04951216 skinnable labels
             var cssClass = 'class="x' + this._skinnableClass + '_' + cfg.sclass + '_' + this._state + '_label"';
             var IE7Align;
-            (aria.core.Browser.isIE7)?(IE7Align="-25%"):(IE7Align="middle");
+            (aria.core.Browser.isIE7) ? (IE7Align = "-25%") : (IE7Align = "middle");
             out.write('<label ' + cssClass + ' style="');
             if (!aria.widgets.environment.WidgetSettings.getWidgetSettings().middleAlignment) {
                 out.write('vertical-align:-1px;');
             } else {
-                out.write('vertical-align:'+IE7Align+';');
+                out.write('vertical-align:' + IE7Align + ';');
             }
             out.write('display:' + cssDisplay);
             if (margin) {

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
         if (!this._skinnableClass) {
             this._skinnableClass = "MultiSelect";
         }
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.MultiSelectCfg";
         var controller = new aria.widgets.controllers.MultiSelectController();
 
         // The following line was added for PTR 04557432: if the value in cfg is not set to [] as a default, then the

--- a/src/aria/widgets/form/NumberField.js
+++ b/src/aria/widgets/form/NumberField.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt, lineNumber) {
         var controller = new aria.widgets.controllers.NumberController();
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.NumberFieldCfg";
         if (cfg.pattern) {
             controller.setPattern(cfg.pattern);
         }

--- a/src/aria/widgets/form/RadioButton.js
+++ b/src/aria/widgets/form/RadioButton.js
@@ -40,6 +40,7 @@
                 // allow the skinnable class to be defined in the child class, before calling this constructor
                 this._skinnableClass = "RadioButton";
             }
+            this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.RadioButtonCfg";
             this.$CheckBox.constructor.apply(this, arguments);
             if (this._skinObj.simpleHTML) {
                 if (!idManager) {

--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         if (!this._skinnableClass) {
             this._skinnableClass = "Select";
         }
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.SelectCfg";
         this.$DropDownInput.constructor.call(this, cfg, ctxt, lineNumber);
 
         var skinObj = this._skinObj;

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -30,7 +30,7 @@ Aria.classDefinition({
         if (!this._skinnableClass) {
             this._skinnableClass = "SelectBox";
         }
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.SelectBoxCfg";
         var controller = new aria.widgets.controllers.SelectBoxController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         this.controller.setListOptions(this._cfg.options);

--- a/src/aria/widgets/form/TextField.js
+++ b/src/aria/widgets/form/TextField.js
@@ -28,7 +28,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt, lineNumber) {
         var controller = new aria.widgets.controllers.TextDataController();
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TextFieldCfg";
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
 
         // The following change was creating non regressions and has been removed
@@ -37,8 +37,8 @@ Aria.classDefinition({
     },
     $prototype : {
         /**
-         * Compare newValue with the one stored in _cfg[propertyName]
-         * For a Textfield, undefined, null and an empty string are considered as equal.
+         * Compare newValue with the one stored in _cfg[propertyName] For a Textfield, undefined, null and an empty
+         * string are considered as equal.
          * @param {String} propertyName
          * @param {Multitype} newValue If transformation is used, this should be the widget value and not the data model
          * value

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -40,7 +40,7 @@ Aria.classDefinition({
              */
             this._skinnableClass = "TextInput";
         }
-
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TextInputCfg";
         this.$InputWithFrame.constructor.apply(this, arguments);
 
         /**
@@ -259,8 +259,8 @@ Aria.classDefinition({
                 out.write(['<textarea', Aria.testMode ? ' id="' + this._domId + '_textarea"' : '',
                         cfg.disabled ? ' disabled="disabled"' : cfg.readOnly ? ' readonly="readonly"' : '', ' type="',
                         type, '" style="', inlineStyle.join(''), 'color:', color,
-                        ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth, 'px;"',
-                        'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
+                        ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth,
+                        'px;"', 'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
                         (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck,
                         '>', stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text),
                         '</textarea>'

--- a/src/aria/widgets/form/TimeField.js
+++ b/src/aria/widgets/form/TimeField.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
     $constructor : function (cfg, ctxt, lineNumber) {
         var controller = new aria.widgets.controllers.TimeController(cfg);
         controller.setPattern(cfg.pattern);
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.TimeFieldCfg";
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
     },
     $prototype : {}

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         if (!cfg) {
             cfg = {};
         }
+        this._cfgBean = this._cfgBean || "aria.widgets.CfgBeans.ListCfg";
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
         var realSkinObj = aria.widgets.AriaSkinInterface.getSkinObject("List", cfg.sclass);
         var skinObj = aria.utils.Json.copy(realSkinObj, false);


### PR DESCRIPTION
This provides a way to extend a widget from the AriaLib without creating a new config bean even if the developer don't change the configuration accepted by the widget. We are storing a variable viz., this._cfgBean on each widget specifying the bean to use.
