### PR TITLE
Global unprefixed css template

### DIFF
--- a/src/aria/templates/CSSClassGenerator.js
+++ b/src/aria/templates/CSSClassGenerator.js
@@ -50,6 +50,7 @@ Aria.classDefinition({
             var tplParam = out.templateParam;
             out.enterBlock("classInit");
             this._writeMapInheritance(out, "__$csslibs", out.templateParam.$csslibs, "{}");
+            this._writeValueInheritance(out, "__$prefix", out.templateParam.$prefix, "true");
             out.leaveBlock();
             this.$ClassGenerator._writeClassInit.call(this, out);
         }

--- a/src/aria/templates/CSSCtxt.js
+++ b/src/aria/templates/CSSCtxt.js
@@ -142,7 +142,7 @@ Aria.classDefinition({
          */
         doPrefixing : function () {
             // Widget don't need prefixing
-            if (this._tpl.disablePrefix) {
+            if (!this._tpl.__$prefix) {
                 return;
             }
             return !this._cfg.isWidget;
@@ -274,10 +274,10 @@ Aria.classDefinition({
          * @return {String} CSS text
          */
         getText : function () {
-            if (this._cfg.isWidget || this._tpl.disablePrefix) {
-                return this._getOutput();
-            } else {
+            if (this.doPrefixing()) {
                 return this.__prefixedText;
+            } else {
+                return this._getOutput();
             }
         },
 

--- a/src/aria/templates/CfgBeans.js
+++ b/src/aria/templates/CfgBeans.js
@@ -190,7 +190,7 @@ Aria.beanDefinitions({
                 },
                 "$prefix" : {
                     $type : "json:Boolean",
-                    $description : "Turns of the css prefix and expose the css globally."
+                    $description : "Defaulted to true. Use it only when required to use features like ( @font-face and @keyframes), avoid otherwise, to limit  CSS class name collisions."
                 }
             }
         },

--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -373,9 +373,6 @@ Aria.classDefinition({
          */
         _writeConstructor : function (out) {
             out.writeln("$constructor: function() { ");
-            if (out.templateParam.$prefix != undefined && out.templateParam.$prefix == false) {
-                out.writeln("this.disablePrefix = true;");
-            }
             out.increaseIndent();
             var parentClassName = out.parentClassName;
             if (parentClassName) {
@@ -489,11 +486,11 @@ Aria.classDefinition({
         _writeValueInheritance : function (out, name, value, defaultValue) {
             if (out.parentClassType == this._classType) {
                 // override value at class loading time, as there is a parent template:
-                if (value) {
+                if (value != null) {
                     out.writeln("proto.", name, " = ", aria.utils.Json.convertToJsonString(value), ";");
                 }
             } else {
-                var valueStr = value ? aria.utils.Json.convertToJsonString(value) : defaultValue;
+                var valueStr = value != null ? aria.utils.Json.convertToJsonString(value) : defaultValue;
                 out.writeln("proto.", name, " = ", valueStr, ";");
             }
         },


### PR DESCRIPTION
Helps to enable the media types and Globalize the css. Use it only when required to use features like ( @font-face and @keyframes), avoid otherwise, to limit  CSS class name collisions.
