### PR TITLE
Predictable ID on Template Based widgets

### DIFF
--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -14,7 +14,7 @@
  */
 
 /**
- * @class aria.popups.Beans Configuration Beans for aria.popups.Popup
+ * Configuration Beans for aria.popups.Popup
  */
 Aria.beanDefinitions({
     $package : "aria.popups.Beans",

--- a/src/aria/widgets/TemplateBasedWidget.js
+++ b/src/aria/widgets/TemplateBasedWidget.js
@@ -15,15 +15,11 @@
 
 /**
  * Abstract widget which enables an easy implementation of any template-based widget.
- * @class aria.widgets.TemplateBasedWidget
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.TemplateBasedWidget",
     $extends : "aria.widgets.container.Container",
     $dependencies : ["aria.widgets.Template"],
-    $constructor : function (cfg, ctxt) {
-        aria.widgets.TemplateBasedWidget.superclass.constructor.call(this, cfg, ctxt);
-    },
     $events : {
         "widgetContentReady" : {
             description : "Raised when the template content is displayed."
@@ -44,6 +40,12 @@ Aria.classDefinition({
     },
     $prototype : {
         /**
+         * List of configuration options that are inherited from the Widget's configuration to the sub-template
+         * @type Array
+         */
+        __inherithCfg : ["tooltip", "tooltipId", "tabIndex", "margins", "block", "printOptions"],
+
+        /**
          * Initialize the template associated to this template based widget. It will create a new instance of the
          * Template.
          * @param {aria.templates.CfgBeans.LoadTemplateCfg} tplCfg Template configuration object
@@ -52,31 +54,20 @@ Aria.classDefinition({
         _initTemplate : function (tplCfg) {
             if (this._cfgOk) {
                 var cfg = this._cfg;
-                /*
-                 * if (!tplCfg.hasOwnProperty("width")) { tplCfg.width = cfg.width; } if
-                 * (!tplCfg.hasOwnProperty("height")) { tplCfg.height = cfg.height; }
-                 */
-                if (!tplCfg.hasOwnProperty("tooltip")) {
-                    tplCfg.tooltip = cfg.tooltip;
+
+                for (var i =0, len = this.__inherithCfg; i < len; i += 1) {
+                    var property = this.__inherithCfg[i];
+                    if (!tplCfg.hasOwnProperty(property)) {
+                        tplCfg[property] = cfg[property];
+                    }
                 }
-                if (!tplCfg.hasOwnProperty("tooltipId")) {
-                    tplCfg.tooltipId = cfg.tooltipId;
-                }
-                if (!tplCfg.hasOwnProperty("tabIndex")) {
-                    tplCfg.tabIndex = cfg.tabIndex;
-                }
-                if (!tplCfg.hasOwnProperty("margins")) {
-                    tplCfg.margins = cfg.margins;
-                }
-                if (!tplCfg.hasOwnProperty("block")) {
-                    tplCfg.block = cfg.block;
-                }
-                if (!tplCfg.hasOwnProperty("printOptions")) {
-                    tplCfg.printOptions = cfg.printOptions;
-                }
+
                 if (cfg.defaultTemplate) {
                     // allow the customization of the template:
                     tplCfg.defaultTemplate = cfg.defaultTemplate;
+                }
+                if (cfg.id) {
+                    tplCfg.id = cfg.id + "_t_";
                 }
                 this._tplWidget = new aria.widgets.Template(tplCfg, this._context, this._lineNumber);
                 this._tplWidget.tplLoadCallback = {
@@ -87,7 +78,8 @@ Aria.classDefinition({
         },
 
         /**
-         * FIXME: doc
+         * Abstract. This function is called any time the sub-template's module controller raises an event.<br />
+         * This function must be overridden.
          * @param {Event} evt
          */
         _onModuleEvent : function (evt) {

--- a/src/aria/widgets/form/DropDownInput.js
+++ b/src/aria/widgets/form/DropDownInput.js
@@ -14,14 +14,12 @@
  */
 
 /**
- * @class aria.widgets.form.DropDownInput Base class for input widgets that use a drop-down popup without being a text
- * input
- * @extends aria.widgets.form.Input
+ * Base class for input widgets that use a drop-down popup without being a text input
  */
 Aria.classDefinition({
-    $classpath : 'aria.widgets.form.DropDownInput',
-    $extends : 'aria.widgets.form.InputWithFrame',
-    $dependencies : ['aria.widgets.form.DropDownTrait'],
+    $classpath : "aria.widgets.form.DropDownInput",
+    $extends : "aria.widgets.form.InputWithFrame",
+    $dependencies : ["aria.widgets.form.DropDownTrait"],
     /**
      * DropDownInput constructor
      * @param {aria.widgets.CfgBeans.DropDownInputCfg} cfg the widget configuration
@@ -29,8 +27,13 @@ Aria.classDefinition({
      */
     $constructor : function () {
         this.$InputWithFrame.constructor.apply(this, arguments);
-        // controller is a property managed at the level of the DropDownInput (as it is accessed from method in this
-        // class), even if specific controller instances can be created in sub-classes
+
+        /**
+         * Controller is a property managed at the level of the DropDownInput (as it is accessed from method in this
+         * class), even if specific controller instances can be created in sub-classes
+         * @type {Object}
+         * @override
+         */
         this.controller = null;
     },
     $destructor : function () {

--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -16,28 +16,35 @@
 /**
  * DropDownListTrait is a class to share code between dropdown widgets containing a list in their popup. The purpose of
  * this class is not to be created directly, but to allow its prototype to be imported.
- * @class aria.widgets.form.DropDownListTrait
  */
 Aria.classDefinition({
-    $classpath : 'aria.widgets.form.DropDownListTrait',
-    $dependencies : ['aria.widgets.form.list.List'],
+    $classpath : "aria.widgets.form.DropDownListTrait",
+    $dependencies : ["aria.widgets.form.list.List"],
     $constructor : function () {
         // The purpose of this class is to provide a prototype to be imported, not to be created directly.
         this.$assert(11, false);
     },
     $statics : {
+        /**
+         * Maximum List widget's height
+         * @type Number
+         */
         MAX_HEIGHT : 210,
+        /**
+         * Minimum List widget's height
+         * @type Number
+         */
         MIN_HEIGHT : 50
     },
     $prototype : {
 
         /**
-         * Callback called when the user clicks on a date in the list.
+         * Callback called when the user clicks on a date in the list. <br />
+         * When clicking on an item in the dropdown list, close the dropdown and save the selected item
          * @param {Object} evt object containing information about the clicked item in the list (value and index).
          * @protected
          */
         _clickOnItem : function (evt) {
-            // when clicking on an item in the dropdown list, close the dropdown and save the selected item
             this._closeDropdown();
             var report = this.controller.checkValue(evt.value);
             this._reactToControllerReport(report);
@@ -89,21 +96,21 @@ Aria.classDefinition({
         },
 
         /**
+         * Callback for the keyevent on List widget. <br />
+         * restore the focus on the right item if it does not have the focus, and propagate the key
          * @param {Object} evt object containing keyboard event information (charCode and keyCode). This is not an
          * aria.DomEvent object.
-         * @return {Boolean}
+         * @return {Boolean} Whether the default action should be stopped or not
          * @protected
          */
         _keyPressed : function (evt) {
-            // restore the focus on the right item if it does not have the focus,
-            // and propagate the key
             if (!this._hasFocus) {
                 this.focus();
                 this._handleKey({
                     charCode : evt.charCode,
                     keyCode : evt.keyCode
                 });
-                return true; // stop default action
+                return true;
             }
             return false;
         },
@@ -133,6 +140,7 @@ Aria.classDefinition({
             maxHeight = (maxHeight < this.MIN_HEIGHT) ? this.MIN_HEIGHT : maxHeight;
             maxHeight = (maxHeight > this.MAX_HEIGHT) ? this.MAX_HEIGHT : maxHeight - 2;
             var list = new aria.widgets.form.list.List({
+                id : cfg.id,
                 defaultTemplate : "defaultTemplate" in options ? options.defaultTemplate : cfg.listTemplate,
                 block : true,
                 sclass : "dropdown",

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -14,8 +14,7 @@
  */
 
 /**
- * @class aria.widgets.form.DropDownTrait Class whose prototype is intended to be imported for all widgets that use a
- * drop-down popup
+ * Class whose prototype is intended to be imported for all widgets that use a drop-down popup
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.form.DropDownTrait",

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -15,7 +15,6 @@
 
 /**
  * A simple list of selectable items
- * @class aria.widgets.form.list.List
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.form.list.List",
@@ -68,9 +67,6 @@ Aria.classDefinition({
                 }
             }
         });
-    },
-    $destructor : function () {
-        this.$TemplateBasedWidget.$destructor.call(this);
     },
     $prototype : {
         /**
@@ -191,9 +187,9 @@ Aria.classDefinition({
         /**
          * Called when json data that we have properties bound to are externally changed. In general we need to update
          * our internal data model and refresh the sub template if needed.
-         * @param {} key The property changed
-         * @param {} newValue
-         * @param {} oldValue
+         * @param {String} key The property changed
+         * @param {Object} newValue
+         * @param {Object} oldValue
          */
         _onBoundPropertyChange : function (key, newValue, oldValue) {
             // If the template needs a refresh, refreshNeeded has to be set to true


### PR DESCRIPTION
On widgets it's already possible to specify an id, this is only used for the widget's markup.

With this commit, the id is propagated to the sub template in case of template based id.

This allows for instance to have predictable ids in dropdown widget of Select / SelectBox / AutoComplete
