### PR TITLE
URLService proposed improvements

### DIFF
--- a/src/aria/modules/RequestBeans.js
+++ b/src/aria/modules/RequestBeans.js
@@ -37,7 +37,12 @@ Aria.beanDefinitions({
                 "actionName" : {
                     $type : "json:String",
                     $description : "The name of the target action, including an optional HTTP Query String",
-                    $mandatory : true
+                    $mandatory : false
+                },
+                "serviceSpec" : {
+                    $type : "json:ObjectRef",
+                    $description : "specification of target service; structure depends on particular UrlService implementation",
+                    $mandatory : false
                 },
                 "session" : {
                     $type : "json:ObjectRef",
@@ -65,6 +70,22 @@ Aria.beanDefinitions({
                 }
             }
         },
+        "RequestDetails" : {
+            $type : "json:Object",
+            $description : "Request details, as returned by URLService implementations",
+            $restricted : false,
+            $properties : {
+                "url" : {
+                    $type : "json:String",
+                    $description : "Final url for the call",
+                    $mandatory : true
+                },
+                "method" : {
+                    $type : "json:String",
+                    $description : "HTTP Method in use for the call"
+                }
+            }
+        },        
         "SuccessResponse" : {
             $type : "json:Object",
             $description : "Describe the response from the server if no communication error happened.",

--- a/src/aria/modules/urlService/IUrlService.js
+++ b/src/aria/modules/urlService/IUrlService.js
@@ -26,9 +26,18 @@ Aria.interfaceDefinition({
          * @param {String} moduleName Name of the module that is making the request
          * @param {String} actionName Action to be called on the server
          * @param {Number} sessionId Value of the session id
-         * @return {String} Full URL
+         * @return {aria.modules.RequestBeans.RequestDetails|String} URL details
          */
         createActionUrl : function (moduleName, actionName, sessionId) {},
+
+        /**
+         * Generate a service URL.
+         * @param {String} moduleName Name of the module that is making the request
+         * @param {Object} serviceSpec Specification for target service
+         * @param {Number} sessionId Value of the session id
+         * @return {aria.modules.RequestBeans.RequestDetails|String} URL details
+         */
+        createServiceUrl : function (moduleName, serviceSpec, sessionId) {},
 
         /**
          * Generate an i18n URL.

--- a/src/aria/modules/urlService/PatternURLCreationImpl.js
+++ b/src/aria/modules/urlService/PatternURLCreationImpl.js
@@ -46,6 +46,20 @@ Aria.classDefinition({
         },
 
         /**
+         * Generate a 'service' URL This implementation understands a serviceSpec in the form {actionName: string}
+         * @param {String} moduleName Name of the module that is making the request
+         * @param {Object} serviceSpec Specification for target service
+         * @param {Number} sessionId Value of the session id
+         * @return {String} full URL
+         */
+        createServiceUrl : function (moduleName, serviceSpec, sessionId) {
+            if (!serviceSpec || !serviceSpec.actionName) {
+                return this.createActionUrl(moduleName, null, sessionId);
+            }
+            return this.createActionUrl(moduleName, serviceSpec.actionName, sessionId);
+        },
+
+        /**
          * Generate an i18n URL. The pattern recognized are
          *
          * <pre>

--- a/src/aria/templates/ModuleCtrl.js
+++ b/src/aria/templates/ModuleCtrl.js
@@ -188,12 +188,14 @@ Aria.classDefinition({
         /**
          * Submit a JSON Request
          * @see aria.modules.RequestMgr.
-         * @param {String} action the action path - e.g. 'search' or 'search?x=y'. This path will be automatically
+         * @param {String|Object} targetService, either :
+         * - the action path - e.g. 'search' or 'search?x=y'. This path will be automatically
          * concatenated to the module path determined from the class package
+         * - a 'service specification' structure, understood by the UrlService implementation
          * @param {Object} jsonData - the data to post to the server
          * @param {aria.core.JsObject.Callback} cb the callback
          */
-        submitJsonRequest : function (action, jsonData, cb) {
+        submitJsonRequest : function (targetService, jsonData, cb) {
             var typeUtils = aria.utils.Type;
             // change cb as an object if a string or a function is passed as a
             // callback
@@ -217,13 +219,19 @@ Aria.classDefinition({
             // Request object constructed with all necessary properties
             var requestObject = {
                 moduleName : this.$package,
-                actionName : action,
                 session : this._session,
                 actionQueuing : null,
                 requestHandler : this.$requestHandler,
                 urlService : this.$urlService,
                 requestJsonSerializer : this.$requestJsonSerializer
             };
+            
+            if (typeUtils.isString(targetService)) {
+                requestObject.actionName = targetService;
+            } else {
+                requestObject.serviceSpec = targetService;
+            }
+            
             aria.modules.RequestMgr.submitJsonRequest(requestObject, jsonData, wrapCB);
         },
 

--- a/test/aria/modules/RequestMgrTest.js
+++ b/test/aria/modules/RequestMgrTest.js
@@ -140,14 +140,14 @@ Aria.classDefinition({
             // Undefined text
             requestMgr.addParam("text");
 
-            url = requestMgr.createRequestUrl({
+            url = requestMgr.createRequestDetails({
                 moduleName : "tpls",
                 actionName : "doTest1"
             }, {
                 id : "x"
             });
 
-            this.assertEquals(url, "http://test/tpls/doTest1;jsessionid=x?number=12", "got " + url);
+            this.assertEquals(url.url, "http://test/tpls/doTest1;jsessionid=x?number=12", "got " + url.url);
 
             // Try overriding a parameter
             requestMgr.addParam("text", "twelve");
@@ -155,38 +155,39 @@ Aria.classDefinition({
 
             requestMgr.addParam("number", null);
 
-            url = requestMgr.createRequestUrl({
+            url = requestMgr.createRequestDetails({
                 moduleName : "tpls",
                 actionName : "doTest2"
             }, {
                 id : "x"
             });
 
-            this.assertEquals(url, "http://test/tpls/doTest2;jsessionid=x?text=twelve", "wrong url. got " + url);
+            this.assertEquals(url.url, "http://test/tpls/doTest2;jsessionid=x?text=twelve", "wrong url. got " + url.url);
 
             // However false should be left as false
             requestMgr.addParam("text", null);
             requestMgr.addParam("number", null);
             requestMgr.addParam("boolean", false);
 
-            url = requestMgr.createRequestUrl({
+            url = requestMgr.createRequestDetails({
                 moduleName : "tpls",
                 actionName : "doTest3"
             }, {
                 id : "x"
             });
-            this.assertEquals(url, "http://test/tpls/doTest3;jsessionid=x?boolean=false", "boolean missing. got " + url);
+            this.assertEquals(url.url, "http://test/tpls/doTest3;jsessionid=x?boolean=false", "boolean missing. got "
+                    + url.url);
 
             // try removing the last param
             requestMgr.removeParam("boolean");
 
-            url = requestMgr.createRequestUrl({
+            url = requestMgr.createRequestDetails({
                 moduleName : "tpls",
                 actionName : "doTest3"
             }, {
                 id : "x"
             });
-            this.assertEquals(url, "http://test/tpls/doTest3;jsessionid=x", "boolean not remove. got " + url);
+            this.assertEquals(url.url, "http://test/tpls/doTest3;jsessionid=x", "boolean not remove. got " + url.url);
         },
 
         /**
@@ -537,6 +538,32 @@ Aria.classDefinition({
                 args : "testAsyncRemoveMetadata",
                 delay : 100
             });
+        },
+
+        /**
+         * Tests that calling createRequestDetails passing in a service give the same result as calling it passing an
+         * action as argument.
+         */
+        testCreateRequestDetailsForService : function () {
+            var requestMgr = aria.modules.RequestMgr, url;
+
+            urlAction = requestMgr.createRequestDetails({
+                moduleName : "tpls",
+                actionName : "doTest1"
+            }, {
+                id : "x"
+            });
+
+            urlService = requestMgr.createRequestDetails({
+                moduleName : "tpls",
+                serviceSpec : {
+                    actionName : "doTest1"
+                }
+            }, {
+                id : "x"
+            });
+
+            this.assertEquals(urlAction.url, urlService.url);
         }
 
     }

--- a/test/aria/modules/test/CustomImplementation.js
+++ b/test/aria/modules/test/CustomImplementation.js
@@ -29,6 +29,17 @@ Aria.classDefinition({
 			return "Custom";
 		},
 
+        /**
+         * Generate a service URL.
+         * @param {String} moduleName Name of the module that is making the request
+         * @param {Object} serviceSpec Specification for target service
+         * @param {Number} sessionId Value of the session id
+         * @return {aria.modules.RequestBeans.RequestDetails|String} URL details
+         */
+        createServiceUrl : function (moduleName, serviceSpec, sessionId) {
+        	return "Custom";
+        },
+
 		/**
 		 * Generate an i18n URL.
 		 * @param {moduleName} Name of the module that is making the request

--- a/test/aria/modules/urlService/ModuleURLCreationImpl.js
+++ b/test/aria/modules/urlService/ModuleURLCreationImpl.js
@@ -14,55 +14,69 @@
  */
 
 Aria.classDefinition({
-	$classpath : 'test.aria.modules.urlService.ModuleURLCreationImpl',
-	$implements : ['aria.modules.urlService.IUrlService'],
-	$constructor : function (actionUrlPattern, i18nUrlPattern) {
-		this.actionUrlPattern = actionUrlPattern || "";
-		this.i18nUrlPattern = i18nUrlPattern || "";
-	},
-	$prototype : {
-		/**
-		 * Generate an action URL. The pattern recognized are
-		 *
-		 * <pre>
-		 *  ${moduleName}, ${actionName} and ${sessionId}
-		 * </pre>
-		 *
-		 * @param {String} Name of the module that is making the request. ${moduleName}
-		 * @param {String} Action to be called on the server. ${actionName}
-		 * @param {String} Value of the session id. ${sessionId}
-		 * @return {String} Full URL
-		 */
-		createActionUrl : function (moduleName, actionName, sessionId) {
-			var url = this.actionUrlPattern;
-			url = url.replace(/\$\{moduleName\}/g, moduleName || "");
-			// Additional parameter is passed specific for this module
-			// url = url.concat("&myCustMod=true");
-			url = url.replace(/\$\{actionName\}/g, actionName || "");
-			url = url.replace(/\$\{sessionId\}/g, sessionId || "");
-			return url;
-		},
+    $classpath : 'test.aria.modules.urlService.ModuleURLCreationImpl',
+    $implements : ['aria.modules.urlService.IUrlService'],
+    $constructor : function (actionUrlPattern, i18nUrlPattern) {
+        this.actionUrlPattern = actionUrlPattern || "";
+        this.i18nUrlPattern = i18nUrlPattern || "";
+    },
+    $prototype : {
+        /**
+         * Generate an action URL. The pattern recognized are
+         *
+         * <pre>
+         *  ${moduleName}, ${actionName} and ${sessionId}
+         * </pre>
+         *
+         * @param {String} Name of the module that is making the request. ${moduleName}
+         * @param {String} Action to be called on the server. ${actionName}
+         * @param {String} Value of the session id. ${sessionId}
+         * @return {String} Full URL
+         */
+        createActionUrl : function (moduleName, actionName, sessionId) {
+            var url = this.actionUrlPattern;
+            url = url.replace(/\$\{moduleName\}/g, moduleName || "");
+            // Additional parameter is passed specific for this module
+            // url = url.concat("&myCustMod=true");
+            url = url.replace(/\$\{actionName\}/g, actionName || "");
+            url = url.replace(/\$\{sessionId\}/g, sessionId || "");
+            return url;
+        },
 
-		/**
-		 * Generate an i18n URL. The pattern recognized are
-		 *
-		 * <pre>
-		 *  ${moduleName}, ${sessionId} amd ${locale}
-		 * </pre>
-		 *
-		 * @param {String} Name of the module that is making the request. ${moduleName}
-		 * @param {String} Value of the session id. ${sessionId}
-		 * @param {String} Locale for i18n, if not present defaults to currentLocale. ${locale}
-		 * @return {String} Full URL
-		 */
-		createI18nUrl : function (moduleName, sessionId, locale) {
-			var url = this.i18nUrlPattern;
-			url = url.replace(/\$\{moduleName\}/g, moduleName || "");
-			// Additional parameter is passed specific for this module resources
-			url = url.concat("&myCustRes=true");
-			url = url.replace(/\$\{sessionId\}/g, sessionId || "");
-			url = url.replace(/\$\{locale\}/g, locale || "");
-			return url;
-		}
-	}
+        /**
+         * Generate a 'service' URL This implementation understands a serviceSpec in the form {actionName: string}
+         * @param {String} moduleName Name of the module that is making the request
+         * @param {Object} serviceSpec Specification for target service
+         * @param {Number} sessionId Value of the session id
+         * @return {String} full URL
+         */
+        createServiceUrl : function (moduleName, serviceSpec, sessionId) {
+            if (!serviceSpec || !serviceSpec.actionName) {
+                return this.createActionUrl(moduleName, null, sessionId);
+            }
+            return this.createActionUrl(moduleName, serviceSpec.actionName, sessionId);
+        },
+
+        /**
+         * Generate an i18n URL. The pattern recognized are
+         *
+         * <pre>
+         *  ${moduleName}, ${sessionId} amd ${locale}
+         * </pre>
+         *
+         * @param {String} Name of the module that is making the request. ${moduleName}
+         * @param {String} Value of the session id. ${sessionId}
+         * @param {String} Locale for i18n, if not present defaults to currentLocale. ${locale}
+         * @return {String} Full URL
+         */
+        createI18nUrl : function (moduleName, sessionId, locale) {
+            var url = this.i18nUrlPattern;
+            url = url.replace(/\$\{moduleName\}/g, moduleName || "");
+            // Additional parameter is passed specific for this module resources
+            url = url.concat("&myCustRes=true");
+            url = url.replace(/\$\{sessionId\}/g, sessionId || "");
+            url = url.replace(/\$\{locale\}/g, locale || "");
+            return url;
+        }
+    }
 });

--- a/test/aria/modules/urlService/PatternURLCreationImplTest.js
+++ b/test/aria/modules/urlService/PatternURLCreationImplTest.js
@@ -17,143 +17,160 @@
  * Test case for the default url pattern creation implementation
  */
 Aria.classDefinition({
-	$classpath : 'test.aria.modules.urlService.PatternURLCreationImplTest',
-	$dependencies : ["aria.modules.urlService.PatternURLCreationImpl",'aria.modules.RequestMgr'],
-	$extends : 'aria.jsunit.TestCase',
-	$prototype : {
-		/**
-		 * Test creation of url with wrong parameters
-		 */
-		testUrlCreationEmpty : function () {
-			//Get an instance
-			var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))();
+    $classpath : 'test.aria.modules.urlService.PatternURLCreationImplTest',
+    $dependencies : ["aria.modules.urlService.PatternURLCreationImpl", 'aria.modules.RequestMgr'],
+    $extends : 'aria.jsunit.TestCase',
+    $prototype : {
+        /**
+         * Test creation of url with wrong parameters
+         */
+        testUrlCreationEmpty : function () {
+            // Get an instance
+            var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))();
 
-			this.assertFalse(!!instance.actionUrlPattern);
-			this.assertFalse(!!instance.i18nUrlPattern);
+            this.assertFalse(!!instance.actionUrlPattern);
+            this.assertFalse(!!instance.i18nUrlPattern);
 
-			//Get the url
-			this.assertFalse(!!instance.createActionUrl());
-			this.assertFalse(!!instance.createI18nUrl());
+            // Get the url
+            this.assertFalse(!!instance.createActionUrl());
+            this.assertFalse(!!instance.createI18nUrl());
+            this.assertFalse(!!instance.createServiceUrl());
 
-			this.assertFalse(!!instance.createActionUrl("a", "b", "c"));
-			this.assertFalse(!!instance.createI18nUrl("a", "b", "c"));
+            this.assertFalse(!!instance.createActionUrl("a", "b", "c"));
+            this.assertFalse(!!instance.createI18nUrl("a", "b", "c"));
+            this.assertFalse(!!instance.createServiceUrl("a", "b", "c"));
 
-			instance.$dispose();
-		},
+            instance.$dispose();
+        },
 
-		/**
-		 * Test creation of url with no placeholder
-		 */
-		testUrlCreationNoPlaceHolder : function () {
-			//Get an instance
-			var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))(
-				"a", "b"
-			);
+        /**
+         * Test creation of url with no placeholder
+         */
+        testUrlCreationNoPlaceHolder : function () {
+            // Get an instance
+            var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))("a", "b");
 
-			this.assertEquals(instance.actionUrlPattern, "a");
-			this.assertEquals(instance.i18nUrlPattern, "b");
+            this.assertEquals(instance.actionUrlPattern, "a");
+            this.assertEquals(instance.i18nUrlPattern, "b");
 
-			//Get the url
-			this.assertEquals(instance.createActionUrl(), "a");
-			this.assertEquals(instance.createI18nUrl(), "b");
+            // Get the url
+            this.assertEquals(instance.createActionUrl(), "a");
+            this.assertEquals(instance.createI18nUrl(), "b");
+            this.assertEquals(instance.createServiceUrl(), "a");
 
-			this.assertEquals(instance.createActionUrl("a", "b", "c"), "a");
-			this.assertEquals(instance.createI18nUrl("a", "b", "c"), "b");
+            this.assertEquals(instance.createActionUrl("a", "b", "c"), "a");
+            this.assertEquals(instance.createI18nUrl("a", "b", "c"), "b");
+            this.assertEquals(instance.createServiceUrl("a", {
+                actionName : "b"
+            }, "c"), "a");
 
-			instance.$dispose();
-		},
+            instance.$dispose();
+        },
 
-		/**
-		 * Test creation of url with one placeholder
-		 */
-		testUrlCreationModuleName : function () {
-			//Get an instance
-			var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))(
-				"a${moduleName}", "b${moduleName}"
-			);
+        /**
+         * Test creation of url with one placeholder
+         */
+        testUrlCreationModuleName : function () {
+            // Get an instance
+            var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))("a${moduleName}", "b${moduleName}");
 
-			this.assertEquals(instance.actionUrlPattern, "a${moduleName}");
-			this.assertEquals(instance.i18nUrlPattern, "b${moduleName}");
+            this.assertEquals(instance.actionUrlPattern, "a${moduleName}");
+            this.assertEquals(instance.i18nUrlPattern, "b${moduleName}");
 
-			//Get the url
-			this.assertEquals(instance.createActionUrl(), "a");
-			this.assertEquals(instance.createI18nUrl(), "b");
+            // Get the url
+            this.assertEquals(instance.createActionUrl(), "a");
+            this.assertEquals(instance.createI18nUrl(), "b");
+            this.assertEquals(instance.createServiceUrl(), "a");
 
-			this.assertEquals(instance.createActionUrl("a", "b", "c"), "aa");
-			this.assertEquals(instance.createI18nUrl("a", "b", "c"), "ba");
+            this.assertEquals(instance.createActionUrl("a", "b", "c"), "aa");
+            this.assertEquals(instance.createI18nUrl("a", "b", "c"), "ba");
+            this.assertEquals(instance.createServiceUrl("a", {
+                actionName : "b"
+            }, "c"), "aa");
 
-			instance.$dispose();
-		},
+            instance.$dispose();
+        },
 
-		/**
-		 * Test creation of url with correct parameters
-		 */
-		testUrlCreation : function () {
-			//Get an instance
-			var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))(
-				"a${moduleName}/${actionName}?${sessionId}",
-				"b${moduleName}/${actionName}?${sessionId}"
-			);
+        /**
+         * Test creation of url with correct parameters
+         */
+        testUrlCreation : function () {
+            // Get an instance
+            var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))("a${moduleName}/${actionName}?${sessionId}", "b${moduleName}/${actionName}?${sessionId}");
 
-			this.assertEquals(instance.actionUrlPattern, "a${moduleName}/${actionName}?${sessionId}");
-			this.assertEquals(instance.i18nUrlPattern, "b${moduleName}/${actionName}?${sessionId}");
+            this.assertEquals(instance.actionUrlPattern, "a${moduleName}/${actionName}?${sessionId}");
+            this.assertEquals(instance.i18nUrlPattern, "b${moduleName}/${actionName}?${sessionId}");
 
-			//Get the url
-			this.assertEquals(instance.createActionUrl(), "a/?");
-			this.assertEquals(instance.createI18nUrl(), "b/${actionName}?");
+            // Get the url
+            this.assertEquals(instance.createActionUrl(), "a/?");
+            this.assertEquals(instance.createI18nUrl(), "b/${actionName}?");
+            this.assertEquals(instance.createServiceUrl(), "a/?");
 
-			this.assertEquals(instance.createActionUrl("a", "b", "c"), "aa/b?c");
-			this.assertEquals(instance.createI18nUrl("a", "b", "c"), "ba/${actionName}?b");
+            this.assertEquals(instance.createActionUrl("a", "b", "c"), "aa/b?c");
+            this.assertEquals(instance.createI18nUrl("a", "b", "c"), "ba/${actionName}?b");
+            this.assertEquals(instance.createServiceUrl("a", {
+                actionName : "b"
+            }, "c"), "aa/b?c");
 
-			instance.$dispose();
-		},
+            instance.$dispose();
+        },
 
-		/**
-		 * This function does the same tests previously done by RequestMgrTest
-		 */
-		testOriginalCreation : function () {
-			//Get an instance
-			var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))(
-				"http://www.amadeus.com:8080/xyz/${moduleName}/${actionName};jsessionid=${sessionId}",
-				""
-			);
+        /**
+         * This function does the same tests previously done by RequestMgrTest
+         */
+        testOriginalCreation : function () {
+            // Get an instance
+            var instance = new (Aria.getClassRef("aria.modules.urlService.PatternURLCreationImpl"))("http://www.amadeus.com:8080/xyz/${moduleName}/${actionName};jsessionid=${sessionId}", "");
 
-			var url = instance.createActionUrl("m1", "doTest", '');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=");
+            this.__originalCreationImp(instance.createActionUrl, instance);
+            this.__originalCreationImp(function (moduleName, actionName, sessionId) {
+                return instance.createServiceUrl(moduleName, {
+                    actionName : actionName
+                }, sessionId)
+            }, instance);
 
-			url = instance.createActionUrl("m1", "doTest", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
+        },
 
-			url = instance.createActionUrl("m1", "doTest", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
+        /**
+         * Helper function for testOriginalCreation
+         */
+        __originalCreationImp : function (functToTest, instance) {
+            var url = functToTest.call(instance, "m1", "doTest", '');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=");
 
-			url = instance.createActionUrl("m1", "doTest", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
+            url = functToTest.call(instance, "m1", "doTest", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
 
-			url = instance.createActionUrl("m1", "doTest?param1=value1", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
+            url = functToTest.call(instance, "m1", "doTest", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
 
-			var rm = aria.modules.RequestMgr;
-			rm.addParam("key1", "v1");
-			url = instance.createActionUrl("m1", "doTest?param1=value1", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
+            url = functToTest.call(instance, "m1", "doTest", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest;jsessionid=1234567890");
 
-			rm.addParam("key2", "v2");
-			url = instance.createActionUrl("m1", "doTest?param1=value1", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
+            url = functToTest.call(instance, "m1", "doTest?param1=value1", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
 
-			url = instance.createActionUrl("m2", "xyz", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m2/xyz;jsessionid=1234567890");
+            var rm = aria.modules.RequestMgr;
+            rm.addParam("key1", "v1");
+            url = functToTest.call(instance, "m1", "doTest?param1=value1", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
 
-			rm.removeParam("key2");
-			url = instance.createActionUrl("m1", "doTest?param1=value1", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
+            rm.addParam("key2", "v2");
+            url = functToTest.call(instance, "m1", "doTest?param1=value1", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
 
-			rm.removeParam();
-			url = instance.createActionUrl("m2", "xyz", '1234567890');
-			this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m2/xyz;jsessionid=1234567890");
+            url = functToTest.call(instance, "m2", "xyz", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m2/xyz;jsessionid=1234567890");
 
-			instance.$dispose();
-		}
-	}
+            rm.removeParam("key2");
+            url = functToTest.call(instance, "m1", "doTest?param1=value1", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m1/doTest?param1=value1;jsessionid=1234567890");
+
+            rm.removeParam();
+            url = functToTest.call(instance, "m2", "xyz", '1234567890');
+            this.assertTrue(url == "http://www.amadeus.com:8080/xyz/m2/xyz;jsessionid=1234567890");
+
+            instance.$dispose();
+        }
+    }
 });

--- a/test/aria/modules/urlService/SearchURLCreationImpl.js
+++ b/test/aria/modules/urlService/SearchURLCreationImpl.js
@@ -14,56 +14,70 @@
  */
 
 Aria.classDefinition({
-	$classpath : 'test.aria.modules.urlService.SearchURLCreationImpl',
-	$implements : ['aria.modules.urlService.IUrlService'],
-	$constructor : function (actionUrlPattern, i18nUrlPattern) {
-		this.actionUrlPattern = actionUrlPattern || "";
-		this.i18nUrlPattern = i18nUrlPattern || "";
-	},
-	$destructor : function () {},
-	$prototype : {
-		/**
-		 * Generate an action URL. The pattern recognized are
-		 *
-		 * <pre>
-		 *  ${moduleName}, ${actionName} and ${sessionId}
-		 * </pre>
-		 *
-		 * @param {String} Name of the module that is making the request. ${moduleName}
-		 * @param {String} Action to be called on the server. ${actionName}
-		 * @param {String} Value of the session id. ${sessionId}
-		 * @return {String} Full URL
-		 */
-		createActionUrl : function (moduleName, actionName, sessionId) {
-			var url = this.actionUrlPattern;
-			url = url.replace(/\$\{moduleName\}/g, moduleName || "");
-			// Additional parameter is passed specific for this module
-			// url = url.concat("&myCustMod=true");
-			url = url.replace(/\$\{actionName\}/g, actionName || "");
-			url = url.replace(/\$\{sessionId\}/g, sessionId || "");
-			return url;
-		},
+    $classpath : 'test.aria.modules.urlService.SearchURLCreationImpl',
+    $implements : ['aria.modules.urlService.IUrlService'],
+    $constructor : function (actionUrlPattern, i18nUrlPattern) {
+        this.actionUrlPattern = actionUrlPattern || "";
+        this.i18nUrlPattern = i18nUrlPattern || "";
+    },
+    $destructor : function () {},
+    $prototype : {
+        /**
+         * Generate an action URL. The pattern recognized are
+         *
+         * <pre>
+         *  ${moduleName}, ${actionName} and ${sessionId}
+         * </pre>
+         *
+         * @param {String} Name of the module that is making the request. ${moduleName}
+         * @param {String} Action to be called on the server. ${actionName}
+         * @param {String} Value of the session id. ${sessionId}
+         * @return {String} Full URL
+         */
+        createActionUrl : function (moduleName, actionName, sessionId) {
+            var url = this.actionUrlPattern;
+            url = url.replace(/\$\{moduleName\}/g, moduleName || "");
+            // Additional parameter is passed specific for this module
+            // url = url.concat("&myCustMod=true");
+            url = url.replace(/\$\{actionName\}/g, actionName || "");
+            url = url.replace(/\$\{sessionId\}/g, sessionId || "");
+            return url;
+        },
 
-		/**
-		 * Generate an i18n URL. The pattern recognized are
-		 *
-		 * <pre>
-		 *  ${moduleName}, ${sessionId} amd ${locale}
-		 * </pre>
-		 *
-		 * @param {String} Name of the module that is making the request. ${moduleName}
-		 * @param {String} Value of the session id. ${sessionId}
-		 * @param {String} Locale for i18n, if not present defaults to currentLocale. ${locale}
-		 * @return {String} Full URL
-		 */
-		createI18nUrl : function (moduleName, sessionId, locale) {
-			var url = this.i18nUrlPattern;
-			url = url.replace(/\$\{moduleName\}/g, moduleName || "");
-			// Additional parameter is passed specific for this module resources
-			url = url.concat("&myCustRes=true");
-			url = url.replace(/\$\{sessionId\}/g, sessionId || "");
-			url = url.replace(/\$\{locale\}/g, locale || "");
-			return url;
-		}
-	}
+        /**
+         * Generate a 'service' URL This implementation understands a serviceSpec in the form {actionName: string}
+         * @param {String} moduleName Name of the module that is making the request
+         * @param {Object} serviceSpec Specification for target service
+         * @param {Number} sessionId Value of the session id
+         * @return {String} full URL
+         */
+        createServiceUrl : function (moduleName, serviceSpec, sessionId) {
+            if (!serviceSpec || !serviceSpec.actionName) {
+                return this.createActionUrl(moduleName, null, sessionId);
+            }
+            return this.createActionUrl(moduleName, serviceSpec.actionName, sessionId);
+        },
+
+        /**
+         * Generate an i18n URL. The pattern recognized are
+         *
+         * <pre>
+         *  ${moduleName}, ${sessionId} amd ${locale}
+         * </pre>
+         *
+         * @param {String} Name of the module that is making the request. ${moduleName}
+         * @param {String} Value of the session id. ${sessionId}
+         * @param {String} Locale for i18n, if not present defaults to currentLocale. ${locale}
+         * @return {String} Full URL
+         */
+        createI18nUrl : function (moduleName, sessionId, locale) {
+            var url = this.i18nUrlPattern;
+            url = url.replace(/\$\{moduleName\}/g, moduleName || "");
+            // Additional parameter is passed specific for this module resources
+            url = url.concat("&myCustRes=true");
+            url = url.replace(/\$\{sessionId\}/g, sessionId || "");
+            url = url.replace(/\$\{locale\}/g, locale || "");
+            return url;
+        }
+    }
 });


### PR DESCRIPTION
## Change

Two changes to the `URLService` framework, needed for interaction with RESTFul services :
- now modules can pass a full `service specification` structure, instead of a raw `actionName` string, to be used by the `URLService` to determine the target request
- an `URLService` can now return a structured `request details` instead of a raw URL, which can for now contain URL and HTTP method; this mechanism could later be used for `URLService` to define needed HTTP headers as well (`Range:`, `Accept:`, ...)
## Example use
### New way to call sendJsonRequest from a module :

``` javascript
this.submitJsonRequest(
  {name:"fm.flightleg.get",
   params:{flight:"AF226",departurePort:"CDG"}},
   null,
   {
     fn : this._onRequest,
     scope : this,
     args:{}
  });
},
```
### Usage in an URLService implementation :

``` javascript
    $actionMap: {
        "fm.flightleg.get" : {
            method : "GET", url: "/flight/{flight}/leg/{departurePort}"
        },
        "fm.flightleg.update" : {
            method : "POST", url: "/flight/{flight}/leg/{departurePort}"
        }
    },

    createServiceUrl : function (moduleName, serviceSpec, sessionId) {
        var actionName = serviceSpec.name;
        var actionParams = serviceSpec.params;
        var actionDef = this.$actionMap[actionName];
        if (!actionDef) {
            return '';
        }
        //TODO : do a generic URL template engine
        var url = actionDef.url;
        url = url.replace(/\{flight\}/,actionParams.flight);
        url = url.replace(/\{departurePort\}/,actionParams.departurePort);

        if (sessionId) {
            url = aria.modules.RequestMgr.__appendActionParameters(url,"SITK="+sessionId);
        }

        return {
            url: this.baseUrl+url,
            method: actionDef.method
        };
       }
```
