### PR TITLE
Performance improvements for TabPanel

### DIFF
--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -15,27 +15,42 @@
 
 /**
  * Tab widget
- * @class aria.widgets.container.Tab
- * @extends aria.widgets.container.Container
  */
 Aria.classDefinition({
-    $classpath : 'aria.widgets.container.Tab',
-    $extends : 'aria.widgets.container.Container',
-    $dependencies : ['aria.widgets.frames.FrameFactory', 'aria.utils.Function'],
-    $css : ['aria.widgets.container.TabStyle'],
+    $classpath : "aria.widgets.container.Tab",
+    $extends : "aria.widgets.container.Container",
+    $dependencies : ["aria.widgets.frames.FrameFactory", "aria.utils.Function"],
+    $css : ["aria.widgets.container.TabStyle"],
     /**
      * Tab constructor
      * @param {aria.widgets.CfgBeans.TabCfg} cfg the widget configuration
      * @param {aria.templates.TemplateCtxt} ctxt template context
      */
     $constructor : function (cfg, ctxt) {
-
         this.$Container.constructor.apply(this, arguments);
         this._setSkinObj("Tab");
+
+        /**
+         * Whether the mouse is over the Tab or not
+         * @type Boolean
+         * @protected
+         */
         this._mouseOver = false;
+
+        /**
+         * Whether the Tab is focused or not
+         * @type Boolean
+         * @protected
+         */
         this._hasFocus = false;
+
         this._updateState(true);
 
+        /**
+         * Frame instance. Actual instance depends on the skin
+         * @type aria.widgets.frames.Frame
+         * @protected
+         */
         this._frame = aria.widgets.frames.FrameFactory.createFrame({
             height : cfg.height,
             state : this._state,
@@ -46,14 +61,15 @@ Aria.classDefinition({
             id : Aria.testMode ? this._domId + "_" + cfg.tabId : undefined
         });
 
-        // override span style
+        /**
+         * Override default widget's span style
+         * @type String
+         * @protected
+         * @override
+         */
         this._spanStyle = "z-index:100;vertical-align:top;";
     },
-    /**
-     * Tab destructor
-     */
     $destructor : function () {
-        this._actingDom = null;
 
         if (this._frame) {
             this._frame.$dispose();
@@ -61,7 +77,6 @@ Aria.classDefinition({
         }
 
         this.$Container.$destructor.call(this);
-
     },
     $prototype : {
         /**
@@ -76,22 +91,16 @@ Aria.classDefinition({
             // we add the bindable properties to the Widget prototype
             p.bindableProperties = p.bindableProperties.concat(["selectedTab"]);
         },
+
         /**
          * Called when a new instance is initialized
          * @protected
          */
         _init : function () {
-
             var domElt = this.getDom();
             var actingDom = aria.utils.Dom.getDomElementChild(domElt, 0);
 
-            /*
-             * MOVED TO this._spanStyle domElt.style.position = "relative"; domElt.style.zIndex = "9999";
-             * domElt.style.verticalAlign = "top";
-             */
-
             if (actingDom) {
-                this._actingDom = actingDom;
                 this._frame.linkToDom(actingDom);
             }
 
@@ -99,18 +108,13 @@ Aria.classDefinition({
         },
 
         /**
-         * Gets the DOM element that handles the focus
+         * Give focus to the element representing the focus for this widget
          */
-        _getFocusableElement : function () {
-            return this._focusableElement;
-        },
-
-        // Focuses the element representing the focus for this widget
         _focus : function () {
             try {
                 this.getDom().focus();
             } catch (ex) {
-                // FIXME: fix for IE7, investigate why it may fail
+                // FIXME: fix for IE7, investigate why it may fail, actually, why should this work???
             }
         },
 
@@ -125,7 +129,9 @@ Aria.classDefinition({
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             var changedState = false;
             if (propertyName === "selectedTab") {
-                changedState = true;
+                if (newValue === this._cfg.tabId || oldValue === this._cfg.tabId) {
+                    changedState = true;
+                }
             } else {
                 this.$Container._onBoundPropertyChange.call(this, propertyName, newValue, oldValue);
             }
@@ -195,6 +201,10 @@ Aria.classDefinition({
             }
         },
 
+        /**
+         * Set the current tab as selected
+         * @protected
+         */
         _selectTab : function () {
             this.changeProperty("selectedTab", this._cfg.tabId);
         },
@@ -236,6 +246,7 @@ Aria.classDefinition({
         },
 
         /**
+         * Internal method to handle focus event
          * @protected
          * @param {aria.DomEvent} domEvt
          */
@@ -246,6 +257,7 @@ Aria.classDefinition({
         },
 
         /**
+         * Internal method to handle blur event
          * @protected
          * @param {aria.DomEvent} domEvt
          */
@@ -256,11 +268,11 @@ Aria.classDefinition({
         },
 
         /**
+         * Internal method to handle keyboard event
          * @protected
          * @param {aria.DomEvent} domEvt
          */
         _dom_onkeyup : function (domEvt) {
-            var cfg = this._cfg;
             return false;
         },
 
@@ -269,7 +281,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} domEvt
          */
         _dom_onkeydown : function (domEvt) {
-            var cfg = this._cfg;
             if (domEvt.keyCode == aria.DomEvent.KC_SPACE || domEvt.keyCode == aria.DomEvent.KC_ENTER) {
                 this._selectTab();
             }

--- a/src/aria/widgets/container/TabPanel.js
+++ b/src/aria/widgets/container/TabPanel.js
@@ -15,14 +15,12 @@
 
 /**
  * TabPanel widget
- * @class aria.widgets.container.TabPanel
- * @extends aria.widgets.container.Container
  */
 Aria.classDefinition({
-    $classpath : 'aria.widgets.container.TabPanel',
-    $extends : 'aria.widgets.container.Container',
-    $dependencies : ['aria.widgets.frames.FrameFactory', 'aria.utils.Function'],
-    $css : ['aria.widgets.container.TabPanelStyle'],
+    $classpath : "aria.widgets.container.TabPanel",
+    $extends : "aria.widgets.container.Container",
+    $dependencies : ["aria.widgets.frames.FrameFactory", "aria.utils.Function"],
+    $css : ["aria.widgets.container.TabPanelStyle"],
     /**
      * TabPanel constructor
      * @param {aria.widgets.CfgBeans.TabPanelCfg} cfg the widget configuration
@@ -77,6 +75,7 @@ Aria.classDefinition({
             // we add the bindable properties to the Widget prototype
             p.bindableProperties = p.bindableProperties.concat(["selectedTab"]);
         },
+
         /**
          * Called when a new instance is initialized
          * @private
@@ -88,6 +87,7 @@ Aria.classDefinition({
             }
             this.$Container._init.call(this);
         },
+
         /**
          * Internal method called when one of the model properties that the widget is bound to has changed Must be
          * overridden by sub-classes defining bindable properties
@@ -111,6 +111,7 @@ Aria.classDefinition({
                 this.$Container._onBoundPropertyChange.call(this, propertyName, newValue, oldValue);
             }
         },
+
         /**
          * Internal function to generate the internal widget markup
          * @param {aria.templates.MarkupWriter} out
@@ -146,6 +147,7 @@ Aria.classDefinition({
             });
 
         },
+
         /**
          * Internal function to generate the internal widget markup
          * @param {aria.templates.MarkupWriter} out
@@ -163,7 +165,6 @@ Aria.classDefinition({
          */
         _setSkinObj : function (widgetName) {
             this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject(widgetName, this._cfg.sclass);
-
         }
 
     }

--- a/test/performance/PerfTestSuite.js
+++ b/test/performance/PerfTestSuite.js
@@ -25,5 +25,6 @@ Aria.classDefinition({
         this.addTests("test.performance.interceptors.DisableMethodEventsPrefTestCase");
         this.addTests("test.performance.subTemplateLoop.PerfTestCase");
         this.addTests("test.performance.leakOnRefresh.TemplateRefreshTestCase");
+        this.addTests("test.performance.tabbar.ChangeState");
     }
 });

--- a/test/performance/tabbar/ChangeState.js
+++ b/test/performance/tabbar/ChangeState.js
@@ -1,0 +1,70 @@
+/**
+ * In this test I have a TabPanel with 4 tabs, one of them is selected. When I change tab I don't want to reapply the same
+ * style to the third tab that is not transitioning
+ */
+Aria.classDefinition({
+    $classpath : "test.performance.tabbar.ChangeState",
+    $extends : "aria.jsunit.WidgetTestCase",
+    $dependencies : ["aria.utils.Json", "aria.widgets.container.Tab", "aria.widgets.container.TabPanel"],
+    $prototype : {
+        testChangeState : function () {
+            var state = {
+                selected : "one",
+                changeState : 0
+            };
+
+            var folder1 = this._crateTab("one", state);
+            var folder2 = this._crateTab("two", state);
+            var folder3 = this._crateTab("three", state);
+            var folder4 = this._crateTab("four", state);
+
+            var instance = new aria.widgets.container.TabPanel({
+                bind : {
+                    selectedTab : {
+                        inside : state,
+                        to : "selected"
+                    }
+                }
+            }, this.outObj.tplCtxt);
+
+            aria.utils.Json.setValue(state, "selected", "two");
+
+            this.assertEquals(state.changeState, 2, "It's enough to update only two instances");
+
+            folder1.$dispose();
+            folder2.$dispose();
+            folder3.$dispose();
+            folder4.$dispose();
+            instance.$dispose();
+        },
+
+        /**
+         * Create a Tab widget with selectedTab bound to the container and refreshes on it
+         * @param {String} name tabId
+         * @param {Object} container Data model used for bindings
+         * @return {aria.widgets.container.Tab}
+         */
+        _crateTab : function (name, container) {
+            var instance = new aria.widgets.container.Tab({
+                tabId : name,
+                bind : {
+                    selectedTab : {
+                        inside : container,
+                        to : "selected"
+                    }
+                }
+            }, this.outObj.tplCtxt);
+
+            instance.writeMarkup(this.outObj);
+            this.outObj.putInDOM();
+            // init widget
+            instance.initWidget();
+
+            instance._updateState = function () {
+                container.changeState += 1;
+            }
+
+            return instance;
+        }
+    }
+})


### PR DESCRIPTION
With this commit Tab Widget will update the state only if either they were selected or they are selected.

This avoid useless DOM access (set class) for non-selected tabs that on bound property change are still non-selected
