### PR TITLE
displayReady called too early

### DIFF
--- a/src/aria/html/Template.js
+++ b/src/aria/html/Template.js
@@ -15,15 +15,13 @@
 
 /**
  * A HTML Template include simple widget
- * @class aria.html.Template
- * @extends aria.widgetLibs.BaseWidget
  */
 Aria.classDefinition({
-    $classpath : 'aria.html.Template',
+    $classpath : "aria.html.Template",
     $extends : "aria.widgetLibs.BaseWidget",
-    $dependencies : ['aria.html.beans.TemplateCfg', 'aria.templates.TemplateTrait', 'aria.utils.Html',
-            'aria.templates.TemplateCtxt', 'aria.utils.Dom', 'aria.templates.ModuleCtrlFactory',
-            'aria.core.environment.Customizations'],
+    $dependencies : ["aria.html.beans.TemplateCfg", "aria.templates.TemplateTrait", "aria.utils.Html",
+            "aria.templates.TemplateCtxt", "aria.utils.Dom", "aria.templates.ModuleCtrlFactory",
+            "aria.core.environment.Customizations"],
     $events : {
         "ElementReady" : {
             description : "Raised when the template content is fully displayed."
@@ -85,8 +83,24 @@ Aria.classDefinition({
 
         var tplCtxt = new aria.templates.TemplateCtxt();
         this.subTplCtxt = tplCtxt;
+
+        /**
+         * Whether the context was already initialized or not.<br />
+         * Not-initialized context means the the widget is still waiting for some dependencies to load, thus it's a
+         * differed content
+         * @type Boolean
+         * @protected
+         */
         this._initCtxDone = false;
 
+        /**
+         * Whether or not the widget is differed in its main section.<br />
+         * If the context is not initialized when the markup is created this widget should be considered as differed to
+         * avoid triggering $displayReady on the containg template
+         * @type Boolean
+         * @override
+         */
+        this.isDiffered = false;
     },
     $destructor : function () {
         this._subTplDiv = null;
@@ -241,8 +255,6 @@ Aria.classDefinition({
                     }
                 });
                 if (this._tplcfg) {
-                    // the template is not yet loaded, show the loading indicator
-
                     var tagName = this._cfg.type;
                     var markup = ['<', tagName, ' id="', this._domId, '"'];
                     if (this._cfg.attributes) {
@@ -257,6 +269,8 @@ Aria.classDefinition({
                         } else {
                             markup.push(this.ERROR_SUBTEMPLATE);
                         }
+                    } else {
+                        this.isDiffered = true;
                     }
                     markup.push('</' + tagName + '>');
                     out.write(markup.join(''));
@@ -265,11 +279,16 @@ Aria.classDefinition({
                 }
             }
         },
+
+        /**
+         * Return the id of the widget, if it should be referenced from the template scripts or other widgets.<br />
+         * In this case do not return dynamic ids, as they don't need to be checked for unicity and they are not known
+         * outside the widget
+         * @return {String} id of the widget, as specified in the config
+         * @override
+         */
         getId : function () {
-            // do not return dynamic ids, as they don't need to be checked for unicity
-            // and they are not known outside the widget
             return this._cfg.id;
         }
-
     }
 });

--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -18,8 +18,6 @@
     // shortcuts
     var layout;
     var jsonValidator;
-    var functionUtils;
-    var typeUtils;
     var __getModulePrivateInfo;
 
     // list of methods to map between the template and the template context
@@ -54,29 +52,23 @@
      * different ways: - either you already have a div object, and you want to put a template inside it - or you don't
      * have it yet, but want to include the markup of this template inside another markup and link the template with its
      * markup later
-     * @class aria.templates.TemplateCtxt
-     * @extends aria.core.JsObject
      */
     Aria.classDefinition({
-        $classpath : 'aria.templates.TemplateCtxt',
-        $dependencies : ['aria.templates.Layout', 'aria.templates.CfgBeans', 'aria.utils.Array', 'aria.utils.Function',
-                'aria.utils.Type', 'aria.templates.TemplateCtxtManager', 'aria.templates.RefreshManager',
-                'aria.templates.CSSMgr', 'aria.utils.Path', 'aria.utils.Delegate', 'aria.templates.NavigationManager',
-                'aria.templates.SectionWrapper', 'aria.core.environment.Customizations',
-                'aria.templates.DomElementWrapper', 'aria.templates.MarkupWriter', 'aria.utils.DomOverlay'],
-        $implements : ['aria.templates.ITemplate', 'aria.templates.ITemplateCtxt'],
+        $classpath : "aria.templates.TemplateCtxt",
+        $dependencies : ["aria.templates.Layout", "aria.templates.CfgBeans", "aria.utils.Array", "aria.utils.Function",
+                "aria.utils.Type", "aria.templates.TemplateCtxtManager", "aria.templates.RefreshManager",
+                "aria.templates.CSSMgr", "aria.utils.Path", "aria.utils.Delegate", "aria.templates.NavigationManager",
+                "aria.templates.SectionWrapper", "aria.core.environment.Customizations",
+                "aria.templates.DomElementWrapper", "aria.templates.MarkupWriter", "aria.utils.DomOverlay"],
+        $implements : ["aria.templates.ITemplate", "aria.templates.ITemplateCtxt"],
         $extends : "aria.templates.BaseCtxt",
         $onload : function () {
             layout = aria.templates.Layout;
             jsonValidator = aria.core.JsonValidator;
-            functionUtils = aria.utils.Function;
-            typeUtils = aria.utils.Type;
         },
         $onunload : function () {
             layout = null;
             jsonValidator = null;
-            functionUtils = null;
-            typeUtils = null;
         },
         $events : {
             "Ready" : {
@@ -253,7 +245,8 @@
                     cfg.tplDiv = null;
                 }
                 if (cfg.div) {
-                    if (typeUtils.isObject(cfg.width) || typeUtils.isObject(cfg.height)) {
+                    var isObject = aria.utils.Type.isObject;
+                    if (isObject(cfg.width) || isObject(cfg.height)) {
                         layout.unregisterAutoresize(cfg.div);
                     }
                     aria.utils.Dom.replaceHTML(cfg.div, "");
@@ -398,8 +391,6 @@
                         fn : this.$refresh,
                         args : args,
                         scope : this
-                        // TODO : write explicite TODO ...
-                        // TODO check this
                     }, this);
                 } else {
                     if (!this._cfg.tplDiv) {
@@ -769,7 +760,7 @@
             },
 
             /**
-             * Insert the sction's markup in the DOM
+             * Insert the section's markup in the DOM
              */
             insertSection : function (section, skipInsertHTML) {
                 // PROFILING // var profilingId = this.$startMeasure("Inserting section in DOM from " +
@@ -969,9 +960,7 @@
                     idCount++;
                 }
 
-                // if the template has been customized, get the actual (customized) classpath
-                // this is already done in the widget
-                // this.tplClasspath = aria.core.environment.Customizations.getTemplateCP(cfg.classpath);
+                // if the template has been customized, the widget returns already the actual (customized) classpath
                 this.tplClasspath = cfg.classpath;
 
                 // TODO: check if cfg.classpath corresponds to a template is a template
@@ -1085,6 +1074,7 @@
                     tpl[name] = this[name];
                 }
 
+                var functionUtils = aria.utils.Function;
                 for (index = 0; name = methodMapping[index]; index++) {
                     tpl[name] = functionUtils.bind(this[name], this);
                 }


### PR DESCRIPTION
When using html templates or when a child template is preloaded,
displayReady of a parent template might get called when the DOM is not yet ready.

The initial fix introduced a performance problem as all preloaded context were considered as differed.
This commit moves the differed logic in the template's init where the information about context ready is more reliable

This fixes #52
