### PR TITLE
Dropdown width computation issues in IE6: popupWidth

### DIFF
--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -181,6 +181,10 @@ Aria.classDefinition({
          */
         _renderDropdownContent : function (out) {
             var cfg = this._cfg, skinObj = this._skinObj;
+            var wrapperDiv = cfg.popupWidth && cfg.popupWidth > -1 && aria.core.Browser.isIE6;
+            if (wrapperDiv) {
+                out.write('<div style="width: ' + cfg.popupWidth + 'px;">');
+            }
 
             var dm = this.controller.getDataModel();
 
@@ -221,6 +225,9 @@ Aria.classDefinition({
             this.controller.setCalendar(calendar);
             out.registerBehavior(calendar);
             calendar.writeMarkup(out);
+            if (wrapperDiv) {
+                out.write('</div>');
+            }
         },
 
         _closeDropdown : function () {

--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -207,6 +207,9 @@ Aria.classDefinition({
                 // No width specified, let the widget decide
                 return null;
             }
+            if (aria.core.Browser.isIE6) {
+                return popupWidth;
+            }
 
             return (popupWidth > inputMarkupWidth) ? popupWidth : inputMarkupWidth;
         }


### PR DESCRIPTION
Setting a popupWidth in the autocomplete or datepicker configuration allows to see the dropdown correctly positioned. Useful for degraded version of an application in IE6.
