### PR TITLE
Closes #80 - bindable width and height for Containers

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -104,6 +104,17 @@ Aria.beanDefinitions({
             $type : "WidgetCfg",
             $description : "Base config for any widget that can be resized in width and height (by default widgets only support width)",
             $properties : {
+                "bind" : {
+                    $type : "WidgetCfg.bind",
+                    $properties : {
+                        "width" : {
+                            $type : "common:BindingRef"
+                        },
+                        "height" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
                 "height" : {
                     $type : "json:Integer",
                     $description : "Widget height in pixel - note: some widgets may ignore this property. If negative, the height will be considered as unset and the widget will use the most appropriate height when possible",
@@ -1124,7 +1135,7 @@ Aria.beanDefinitions({
             $description : "Configuration for the ErrorList widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "messages" : {
                             $type : "common:BindingRef"
@@ -1173,7 +1184,7 @@ Aria.beanDefinitions({
             $description : "Configuration for the Calendar widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "value" : {
                             $type : "common:BindingRef"
@@ -1378,7 +1389,7 @@ Aria.beanDefinitions({
                     $description : "Function to be called when the user moves the mouse over an item in the list."
                 },
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "selectedValues" : {
                             $type : "common:BindingRef"
@@ -1424,7 +1435,7 @@ Aria.beanDefinitions({
             $description : "The base configuration for the Dialog widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "DivCfg.bind",
                     $properties : {
                         "visible" : {
                             $type : "common:BindingRef"
@@ -1552,7 +1563,7 @@ Aria.beanDefinitions({
             $description : "The base configuration for the Tab widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "selectedTab" : {
                             $type : "common:BindingRef"
@@ -1580,7 +1591,7 @@ Aria.beanDefinitions({
             $description : "The base configuration for the Tab widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "selectedTab" : {
                             $type : "common:BindingRef"
@@ -1706,7 +1717,7 @@ Aria.beanDefinitions({
                     $default : true
                 },
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ResizableWidgetCfg.bind",
                     $properties : {
                         "size1" : {
                             $type : "common:BindingRef"

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -332,6 +332,14 @@ Aria.classDefinition({
             } else if (propertyName === "center") {
                 this._cfg.center = newValue;
                 this.updatePosition();
+            } else if (propertyName === "height") {
+                // Resize ourself and then the contained div
+                this.$Container._onBoundPropertyChange.apply(this, arguments);
+                this._div.updateSize(this._cfg);
+            } else if (propertyName === "width") {
+                // Resize ourself and then the contained div
+                this.$Container._onBoundPropertyChange.apply(this, arguments);
+                this._div.updateSize(this._cfg);
             } else {
                 // delegate to parent class
                 this.$Container._onBoundPropertyChange.apply(this, arguments);

--- a/src/aria/widgets/container/Div.js
+++ b/src/aria/widgets/container/Div.js
@@ -118,14 +118,8 @@ Aria.classDefinition({
                 hasChanged = true;
             }
             if (hasChanged) {
-                /*
-                 * // Change width and height if it's too large compared to the viewport var viewport =
-                 * aria.utils.Dom._getViewportSize(); if (viewport.width < this._cfg.width) { this._cfg.width =
-                 * viewport.width; } if (viewport.height < this._cfg.height) { this._cfg.height = viewport.height; }
-                 */
-                this.$Container._updateContainerSize.call(this);
+                this.$Container._updateSize.call(this);
             }
-
         }
     }
 });


### PR DESCRIPTION
Updated the Beans in order to take in account that "ResizableWidgetCfg" now declares bindings.
Updated dialog in order to react to resize correctly when bound.
Fixed div in order to have a proper call to container resizing method.
