### PR TITLE
getComputedStyle in FF3.6

### DIFF
--- a/src/aria/jsunit/LayoutTester.js
+++ b/src/aria/jsunit/LayoutTester.js
@@ -172,9 +172,8 @@ Aria.classDefinition({
          * @private
          */
         _hasStyleThatMakesItVisible : function (el) {
-            // var getComputedStyle = document.defaultView.getComputedStyle;
-
-            var computedStyle = el.currentStyle || el.ownerDocument.defaultView.getComputedStyle(el);
+            // getComputedStyle takes two parameters in FF<4
+            var computedStyle = el.currentStyle || el.ownerDocument.defaultView.getComputedStyle(el, null);
 
             return (computedStyle.border !== "" || computedStyle.borderWidth !== ""
                     || computedStyle.borderTopWidth !== "" || computedStyle.borderLeftWidth !== ""


### PR DESCRIPTION
getComputedStyle takes two mandatory parameters in FF<4
