### PR TITLE
Possibility to call $focus on HTML Text Input

### DIFF
--- a/src/aria/html/Element.js
+++ b/src/aria/html/Element.js
@@ -68,6 +68,10 @@
              */
             this._id = this._createDynamicId();
 
+            if (cfg.id) {
+                this._id = this._id + "_" + cfg.id;
+            }
+
             /**
              * Reference of the DOM element with id this._id.
              * @type HTMLElement

--- a/src/aria/html/TextInput.js
+++ b/src/aria/html/TextInput.js
@@ -96,11 +96,18 @@
             /**
              * Wheter or not this widget has a 'on type' callback
              * @protected
-             * @param {Boolean}
+             * @type Boolean
              */
             this._reactOnType = this._registerType(cfg.on, context);
 
             this._registerBlur(cfg.on, context);
+
+            /**
+             * Element containing input field
+             * @protected
+             * @type HTMLElement
+             */
+            this._inputText = null;
 
             this.$Element.constructor.call(this, cfg, context, line);
         },
@@ -108,7 +115,7 @@
             if (this._typeCallback) {
                 aria.core.Timer.cancelCallback(this._typeCallback);
             }
-
+            this._inputText = null;
             this.$Element.$destructor.call(this);
         },
         $prototype : {
@@ -140,6 +147,7 @@
                         this._domElt.value = newValue;
                     }
                 }
+                this._inputText = aria.utils.Dom.getElementById(this._id);
             },
 
             /**
@@ -152,6 +160,21 @@
                 if (name === "value") {
                     this._domElt.value = value;
                 }
+            },
+
+            /**
+             * Function to return the id
+             * @return {String} Element id.
+             */
+            getId : function () {
+                return this._cfg.id;
+            },
+
+            /**
+             * Function to assign the focus to input field.
+             */
+            focus : function () {
+                this._inputText.focus();
             },
 
             /**

--- a/src/aria/html/beans/ElementCfg.js
+++ b/src/aria/html/beans/ElementCfg.js
@@ -25,6 +25,10 @@ Aria.beanDefinitions({
             $type : "json:Object",
             $description : "All properties that can be used in Element widget.",
             $properties : {
+                "id" : {
+                    $type : "json:String",
+                    $description : "Element id"
+                },
                 "tagName" : {
                     $type : "json:String",
                     $description : "Qualified name of the Element node",

--- a/test/aria/html/ElementTest.js
+++ b/test/aria/html/ElementTest.js
@@ -68,6 +68,25 @@ Aria.classDefinition({
             var widget = new aria.html.Element(cfg, {
                 tplClasspath : "Element"
             });
+
+            this.assertEquals(widget._id, "w0", "The id is not the id expected");
+            widget.$dispose();
+
+            cfg.id = 'x';
+
+            widget = new aria.html.Element(cfg, {
+                tplClasspath : "Element"
+            });
+
+            this.assertEquals(widget._id, "w0_x", "The id is not the id expected");
+            widget.$dispose();
+
+            delete cfg.id;
+
+            widget = new aria.html.Element(cfg, {
+                tplClasspath : "Element"
+            });
+
             widget._id = "x";
 
             // These two functions are called if the widget is used as a container


### PR DESCRIPTION
It is possible to provide an id to text input widget of the HTML library and to use it with the $focus method.
