### PR TITLE
Compute the path to skin images with aria.core.DownloadMgr.resolveURL

### DIFF
--- a/src/aria/widgets/AriaSkinInterface.js
+++ b/src/aria/widgets/AriaSkinInterface.js
@@ -14,15 +14,13 @@
  */
 
 /**
- * @class aria.widgets.AriaSkinInterface A class that provides an interface to the AriaSkin object that comes from the
- * skinning system.
- * @extends aria.core.JsObject
- * @singleton
+ * A class that provides an interface to the AriaSkin object that comes from the skinning system.
  */
 Aria.classDefinition({
     $classpath : 'aria.widgets.AriaSkinInterface',
     $singleton : true,
-    $dependencies : ['aria.core.JsonValidator', 'aria.widgets.AriaSkinBeans', 'aria.widgets.AriaSkinNormalization'],
+    $dependencies : ['aria.core.JsonValidator', 'aria.widgets.AriaSkinBeans', 'aria.widgets.AriaSkinNormalization',
+            'aria.core.DownloadMgr'],
     $statics : {
         // ERROR MESSAGES:
         WIDGET_SKIN_CLASS_OBJECT_NOT_FOUND : "There is no skin configuration for skin class %1 of widget %2. Skin class std will be used instead. The widget will probably not be displayed correctly."
@@ -236,15 +234,7 @@ Aria.classDefinition({
          * @return {String} full URL (taking into account Aria.rootFolderPath and the general.imagesRoot skin property)
          */
         getSkinImageFullUrl : function (imageUrl) {
-            var baseUrl = Aria.rootFolderPath;
-            if (!baseUrl) {
-                // Relative path, make it looks like an absolute
-                baseUrl = "./";
-            } else if (baseUrl.charAt(baseUrl.length - 1) !== "/") {
-                // Ensure an ending slash
-                baseUrl += "/";
-            }
-            return baseUrl + this.getGeneral().imagesRoot + imageUrl;
+            return aria.core.DownloadMgr.resolveURL(this.getGeneral().imagesRoot + imageUrl, true);
         },
 
         /**


### PR DESCRIPTION
With this pull request, the path to skin images is computed according to the root map instead of only taking into account `Aria.rootFolderPath`.

With this change, it's possible to just change `Aria.rootFolderPath` from its default value (and the root map so that `aria` points to the right directory) and paths to skin images will be correctly computed.
