### PR TITLE
Possibility to override html:TextInput cfg beans

### DIFF
--- a/src/aria/html/TextInput.js
+++ b/src/aria/html/TextInput.js
@@ -86,7 +86,7 @@
             INVALID_USAGE : "Widget %1 can only be used as a %2."
         },
         $constructor : function (cfg, context, line) {
-            this.$cfgBean = "aria.html.beans.TextInputCfg.Properties";
+            this.$cfgBean = this.$cfgBean || "aria.html.beans.TextInputCfg.Properties";
 
             cfg.tagName = "input";
             cfg.attributes = cfg.attributes || {};


### PR DESCRIPTION
The configuration bean for the html:TextInput is not set if it is already defined.
