### PR TITLE
feat #305 remove useless code

### DIFF
--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -252,19 +252,6 @@
             _directInit : false,
 
             /**
-             * Prototype init method called at prototype creation time Allows to store class-level objects that are
-             * shared by all instances
-             * @param {Object} p the prototype object being built
-             * @param {Object} def the class definition
-             * @param {Object} sdef the superclass class definition
-             */
-            $init : function (p, def, sdef) {
-                // prototype initialization function
-                // we add the bindable properties to the Widget prototype
-                p.bindableProperties = ["tooltip"];
-            },
-
-            /**
              * Main widget entry-point called by the template objects to get the markup associated to a widget for
              * non-container widgets
              * @param {aria.templates.MarkupWriter} out

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -111,18 +111,6 @@ Aria.classDefinition({
         this.$ActionWidget.$destructor.call(this);
     },
     $prototype : {
-        /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["disabled"]);
-        },
 
         /**
          * Internal method to update the state of the widget

--- a/src/aria/widgets/calendar/Calendar.js
+++ b/src/aria/widgets/calendar/Calendar.js
@@ -23,8 +23,6 @@ Aria.classDefinition({
     $extends : "aria.widgets.TemplateBasedWidget",
     $dependencies : ["aria.widgets.Template", "aria.widgets.calendar.CalendarController", "aria.DomEvent"],
     $css : ["aria.widgets.calendar.CalendarStyle"],
-    // Preload the default template here, to improve performances, especially for the DatePicker
-    // TODO: find a better way, to also improve performances for custom templates
     $templates : ["aria.widgets.calendar.CalendarTemplate"],
     $constructor : function (cfg, ctxt) {
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
@@ -65,18 +63,6 @@ Aria.classDefinition({
     },
 
     $prototype : {
-        /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["value", "startDate"]);
-        },
 
         /**
          * React to the events coming from the module controller.

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -83,19 +83,6 @@ Aria.classDefinition({
     $prototype : {
 
         /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["contentMacro", "visible"]);
-        },
-
-        /**
          * Manage the viewport resize event
          * @param {aria.DomEvent} event
          * @protected

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -79,18 +79,6 @@ Aria.classDefinition({
         this.$Container.$destructor.call(this);
     },
     $prototype : {
-        /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["selectedTab"]);
-        },
 
         /**
          * Called when a new instance is initialized

--- a/src/aria/widgets/container/TabPanel.js
+++ b/src/aria/widgets/container/TabPanel.js
@@ -63,18 +63,6 @@ Aria.classDefinition({
         TABPANEL_INVALID_CONFIG_ID : "%1Invalid tab panel configuration, you must pass an ID if your panel is a container"
     },
     $prototype : {
-        /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["selectedTab"]);
-        },
 
         /**
          * Called when a new instance is initialized

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -58,19 +58,6 @@ Aria.classDefinition({
         this.$TemplateBasedWidget.$destructor.call(this);
     },
     $prototype : {
-        /**
-         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
-         * by all instances
-         * @param {Object} p the prototype object being built
-         * @param {Object} def the class definition
-         * @param {Object} sdef the superclass class definition
-         */
-        $init : function (p, def, sdef) {
-            // prototype initialization function
-            // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["messages"]);
-        },
-
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             this._inOnBoundPropertyChange = true;
             try {

--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -106,10 +106,7 @@ Aria.classDefinition({
          * @param {Object} sdef the superclass class definition
          */
         $init : function (p, def, sdef) {
-            // prototype initialization function
             // we add the bindable properties to the Widget prototype
-            p.bindableProperties = p.bindableProperties.concat(["label", "value", "mandatory", "readOnly", "disabled",
-                    "error"]);
             p.automaticallyBindedProperties = ["formatError", "formatErrorMessages", "error", "errorMessages",
                     "requireFocus"];
         },

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -176,9 +176,6 @@ Aria.classDefinition({
          * @param {Object} sdef the superclass class definition
          */
         $init : function (p, def, sdef) {
-            // we add the "prefill" and "prefillError" properties to the
-            // bindable properties
-            p.bindableProperties = p.bindableProperties.concat("prefill");
             p.automaticallyBindedProperties = p.automaticallyBindedProperties.concat("prefillError");
         },
 


### PR DESCRIPTION
Ages ago we removed .bindableProperties from widgets. Unfortunately we forgot to remove it from all classes.
This does some cleaning of dead code.
