### PR TITLE
fix #312 Hard-coded dropdown skin class for several widgets

### DIFF
--- a/src/aria/widgets/AriaSkinBeans.js
+++ b/src/aria/widgets/AriaSkinBeans.js
@@ -713,6 +713,11 @@ Aria.beanDefinitions({
                             $type : "json:Integer",
                             $description : "",
                             $default : 3
+                        },
+                        sclass : {
+                            $type : "json:String",
+                            $description : "sclass of the calendar to use inside the DatePicker. It must be defined in the skin.",
+                            $default : "dropdown"
                         }
                     }
                 }
@@ -720,7 +725,14 @@ Aria.beanDefinitions({
         },
         "SelectBoxCfg" : {
             $type : "DropDownTextInputCfg",
-            $description : ""
+            $description : "",
+            $properties: {
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the List to use inside the widget. It must be defined in the skin.",
+                    $default : "dropdown"
+                }
+            }
         },
         "TextareaCfg" : {
             $type : "TextInputCfg",
@@ -804,7 +816,14 @@ Aria.beanDefinitions({
         },
         "MultiSelectCfg" : {
             $type : "DropDownTextInputCfg",
-            $description : ""
+            $description : "",
+            $properties : {
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the List to use inside the widget. It must be defined in the skin.",
+                    $default : "dropdown"
+                }
+            }
         },
         "SelectCfg" : {
             $type : "Object",
@@ -861,6 +880,11 @@ Aria.beanDefinitions({
                 },
                 "offsetTop" : {
                     $type : "Pixels"
+                },
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the List to use inside the widget. It must be defined in the skin.",
+                    $default : "dropdown"
                 }
             }
         },
@@ -1124,7 +1148,14 @@ Aria.beanDefinitions({
         },
         "AutoCompleteCfg" : {
             $type : "DropDownTextInputCfg",
-            $description : ""
+            $description : "",
+            $properties: {
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the List to use inside the widget. It must be defined in the skin.",
+                    $default : "dropdown"
+                }
+            }
         },
         "TabPanelCfg" : {
             $type : "Object",

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -613,6 +613,10 @@ Aria.beanDefinitions({
                     $description : "Template to use to display the list.",
                     $default : "aria.widgets.form.templates.TemplateMultiSelect"
                 },
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
+                },
                 "items" : {
                     $type : "ListCfg.items",
                     $description : "List of options on a MultiSelect"
@@ -709,8 +713,7 @@ Aria.beanDefinitions({
                 },
                 "calendarSclass" : {
                     $type : "json:String",
-                    $description : "sclass to be used for the calendar the calendar.",
-                    $default : "dropdown"
+                    $description : "sclass of the calendar used in the dropdown. The default value for this property is taken from the skin."
                 },
                 "iconTooltip" : {
                     $type : "json:String",
@@ -735,6 +738,10 @@ Aria.beanDefinitions({
                 "listTemplate" : {
                     $type : "json:PackageName",
                     $description : "Template to use to display the list."
+                },
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
                 },
                 "options" : {
                     $type : "json:Array",
@@ -766,6 +773,10 @@ Aria.beanDefinitions({
                 "listTemplate" : {
                     $type : "json:PackageName",
                     $description : "Template used for displaying the list."
+                },
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
                 },
                 "options" : {
                     $type : "json:Array",
@@ -834,6 +845,10 @@ Aria.beanDefinitions({
                 "popupMaxHeight" : {
                     $type : "json:Integer",
                     $description : "Maximum height of the dropdown."
+                },
+                "listSclass" : {
+                    $type : "json:String",
+                    $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
                 }
             }
         },

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -192,7 +192,6 @@ Aria.classDefinition({
                 block : true,
                 startDate : dm.jsDate,
                 tabIndex : -1,
-                sclass : cfg.calendarSclass,
                 label : cfg.calendarLabel,
                 defaultTemplate : cfg.calendarTemplate,
                 minValue : cfg.minValue,
@@ -212,7 +211,7 @@ Aria.classDefinition({
             // maps property from datepicker configuration
             var propMapped = ['displayUnit', 'numberOfUnits', 'firstDayOfWeek', 'monthLabelFormat',
                     'dayOfWeekLabelFormat', 'dateLabelFormat', 'completeDateLabelFormat', 'showWeekNumbers',
-                    'showShortcuts', 'restrainedNavigation'];
+                    'showShortcuts', 'restrainedNavigation', 'sclass'];
             for (var i = 0, property; property = propMapped[i]; i++) {
                 this._applyCalendarCfg(property, calendarConf);
             }

--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -144,7 +144,7 @@ Aria.classDefinition({
                 id : cfg.id,
                 defaultTemplate : "defaultTemplate" in options ? options.defaultTemplate : cfg.listTemplate,
                 block : true,
-                sclass : "dropdown",
+                sclass : cfg.listSclass || this._skinObj.listSclass,
                 onclick : {
                     fn : this._clickOnItem,
                     scope : this

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -157,7 +157,7 @@ Aria.classDefinition({
             var list = new aria.widgets.form.list.List({
                 defaultTemplate : cfg.listTemplate,
                 block : true,
-                sclass : "dropdown",
+                sclass : cfg.listSclass || this._skinObj.listSclass,
                 onchange : {
                     fn : this._clickOnItem,
                     scope : this

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -41,6 +41,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.TextareaTest");
         this.addTests("test.aria.widgets.form.TextInputTest");
         this.addTests("test.aria.widgets.form.multiselect.issue223.MultiSelect");
+        this.addTests("test.aria.widgets.form.multiselect.issue312.Issue312TestSuite");
         this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
     }
 });

--- a/test/aria/widgets/form/multiselect/issue312/AutoComplete.js
+++ b/test/aria/widgets/form/multiselect/issue312/AutoComplete.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.AutoComplete",
+    $extends : "test.aria.widgets.form.multiselect.issue312.Common",
+    $dependencies : ["aria.widgets.form.list.List", "aria.utils.Json"],
+    $prototype : {
+        innerWidgetClasspath : "aria.widgets.form.list.List",
+        innerWidgetName : "List",
+        outerWidgetName : "AutoComplete",
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            skin.listSclass = innerWidgetSkinClass;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/AutoCompleteTpl.tpl
+++ b/test/aria/widgets/form/multiselect/issue312/AutoCompleteTpl.tpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.issue312.AutoCompleteTpl',
+    $hasScript:true
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        sclass: ${data.outerSclass} <br />
+        listSclass: ${data.innerSclass} <br />
+        {@aria:AutoComplete {
+            id:"widget",
+            label:"Select",
+            labelWidth:150,
+            sclass:data.outerSclass,
+            listSclass:data.innerSclass,
+            resourcesHandler:getResourcesHandler(),
+            width:400,
+            expandButton:true,
+            bind:{
+                value : {
+                    to : 'value',
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiselect/issue312/AutoCompleteTplScript.js
+++ b/test/aria/widgets/form/multiselect/issue312/AutoCompleteTplScript.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.multiselect.issue312.AutoCompleteTplScript',
+    $dependencies : ['aria.resources.handlers.LCResourcesHandler'],
+    $destructor : function () {
+        if (this.resourcesHandler) {
+            this.resourcesHandler.$dispose();
+            this.resourcesHandler = null;
+        }
+    },
+    $prototype : {
+        getResourcesHandler : function () {
+            var res = this.resourcesHandler;
+            if (!res) {
+                res = this.resourcesHandler = new aria.resources.handlers.LCResourcesHandler();
+                res.setSuggestions([{
+                            code : 'AF',
+                            label : 'AF'
+                        }, {
+                            code : 'AC',
+                            label : 'AC'
+                        }, {
+                            code : 'NZ',
+                            label : 'NZ'
+                        }, {
+                            code : 'DL',
+                            label : 'DL'
+                        }, {
+                            code : 'AY',
+                            label : 'AY'
+                        }, {
+                            code : 'IB',
+                            label : 'IB'
+                        }, {
+                            code : 'LH',
+                            label : 'LH'
+                        }, {
+                            code : 'MX',
+                            label : 'MX'
+                        }, {
+                            code : 'QF',
+                            label : 'QF'
+                        }]);
+            }
+            return res;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/Common.js
+++ b/test/aria/widgets/form/multiselect/issue312/Common.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.Common",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $prototype : {
+
+        // Those properties are defined in sub-classes:
+        innerWidgetClasspath : "",
+        innerWidgetName : "",
+        outerWidgetName : "",
+
+        testAsyncStartTemplateTest : function () {
+            var self = this;
+            var OriginalInnerWidget = Aria.getClassRef(this.innerWidgetClasspath);
+            var MockInnerWidget = function (cfg, context, lineNbr) {
+                var innerSclasses = self.innerSclasses;
+                if (innerSclasses) {
+                    if (innerSclasses.length === 0 || innerSclasses[innerSclasses.length - 1] !== cfg.sclass) {
+                        // Only keep an sclass if it's different from the previous one.
+                        // This makes it possible for the popup to be refreshed (with the same sclass) in some cases.
+                        // (this happens in PhantomJS which triggers a viewport resized event)
+                        innerSclasses.push(cfg.sclass);
+                    }
+                }
+                var callback = self.callback;
+                if (callback) {
+                    self.callback = null;
+                    aria.core.Timer.addCallback(callback);
+                }
+                return new OriginalInnerWidget(cfg, context, lineNbr);
+            }
+            this.overrideClass(this.innerWidgetClasspath, MockInnerWidget);
+            this.$TemplateTestCase.testAsyncStartTemplateTest.call(this);
+        },
+
+        runTemplateTest : function () {
+            this.checkInnerSclass("dropdown", this._step1);
+        },
+
+        _step1 : function () {
+            this.setWidgetProperties(undefined, "std");
+            this.checkInnerSclass("std", this._step2);
+        },
+
+        _step2 : function () {
+            // creates the testIssue312I skin class for the inner widget:
+            aria.widgets.AriaSkin.skinObject[this.innerWidgetName].testIssue312I = aria.widgets.AriaSkin.skinObject[this.innerWidgetName].std;
+            // creates the testIssue312O skin class for the outer widget:
+            var newOuterWidgetSkin = aria.utils.Json.copy(aria.widgets.AriaSkin.skinObject[this.outerWidgetName].std, false, null, true);
+            this._setOuterWidgetSkinProperty(newOuterWidgetSkin, "testIssue312I");
+            aria.widgets.AriaSkin.skinObject[this.outerWidgetName].testIssue312O = newOuterWidgetSkin;
+            // Note that those new skin classes were not present when the CSS for the corresponding widgets were
+            // generated so the display will not be correct, but this is not what we are checking here.
+
+            this.setWidgetProperties("testIssue312O", undefined);
+            this.checkInnerSclass("testIssue312I", this._step3);
+        },
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            // to be overridden in sub-classes
+        },
+
+        _step3 : function () {
+            // Removes the new skin classes:
+            delete aria.widgets.AriaSkin.skinObject[this.innerWidgetName].testIssue312I;
+            delete aria.widgets.AriaSkin.skinObject[this.outerWidgetName].testIssue312O;
+
+            this.end();
+        },
+
+        setWidgetProperties : function (outerSclass, innerSclass) {
+            var tplCtxt = this.templateCtxt;
+            var data = tplCtxt.data;
+            data.outerSclass = outerSclass;
+            data.innerSclass = innerSclass;
+            tplCtxt.$refresh();
+        },
+
+        checkInnerSclass : function (expected, cb) {
+            this.innerSclasses = [];
+            this.callback = {
+                delay : 100,
+                fn : this._checkInnerSclassCb,
+                scope : this,
+                args : {
+                    expected : expected,
+                    cb : cb
+                }
+            };
+            var outerWidget = this.getWidgetInstance("widget");
+            outerWidget.focus();
+            outerWidget._toggleDropdown();
+        },
+
+        _checkInnerSclassCb : function (args) {
+            this.assertJsonEquals([args.expected], this.innerSclasses, "Expected sclass '" + args.expected +
+                    "' but got '" + this.innerSclasses + "'.");
+            this.$callback(args.cb);
+        }
+
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/DatePicker.js
+++ b/test/aria/widgets/form/multiselect/issue312/DatePicker.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.DatePicker",
+    $extends : "test.aria.widgets.form.multiselect.issue312.Common",
+    $dependencies : ["aria.widgets.calendar.Calendar", "aria.utils.Json"],
+    $prototype : {
+        innerWidgetClasspath : "aria.widgets.calendar.Calendar",
+        innerWidgetName : "Calendar",
+        outerWidgetName : "DatePicker",
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            skin.calendar = aria.utils.Json.copy(skin.calendar, false, null, true);
+            skin.calendar.sclass = innerWidgetSkinClass;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/DatePickerTpl.tpl
+++ b/test/aria/widgets/form/multiselect/issue312/DatePickerTpl.tpl
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.issue312.DatePickerTpl'
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {@aria:DatePicker {
+            id:"widget",
+            label:"DatePicker",
+            labelWidth:150,
+            sclass:data.outerSclass,
+            calendarSclass:data.innerSclass,
+            width:400,
+            bind:{
+                value : {
+                    to : 'value',
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiselect/issue312/Issue312TestSuite.js
+++ b/test/aria/widgets/form/multiselect/issue312/Issue312TestSuite.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.Issue312TestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+        var packageName = this.$package;
+        this.addTests(packageName + ".AutoComplete");
+        this.addTests(packageName + ".DatePicker");
+        this.addTests(packageName + ".MultiSelect");
+        this.addTests(packageName + ".Select");
+        this.addTests(packageName + ".SelectBox");
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/issue312/MultiSelect.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.MultiSelect",
+    $extends : "test.aria.widgets.form.multiselect.issue312.Common",
+    $dependencies : ["aria.widgets.form.list.List"],
+    $prototype : {
+        innerWidgetClasspath : "aria.widgets.form.list.List",
+        innerWidgetName : "List",
+        outerWidgetName : "MultiSelect",
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            skin.listSclass = innerWidgetSkinClass;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/issue312/MultiSelectTpl.tpl
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.issue312.MultiSelectTpl'
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {var testItems = [
+            {value:'AF', label:'AF'},
+            {value:'AC', label:'AC'},
+            {value:'NZ', label:'NZ'},
+            {value:'DL', label:'DL'},
+            {value:'AY', label:'AY'},
+            {value:'IB', label:'IB'},
+            {value:'LH', label:'LH'},
+            {value:'MX', label:'MX'},
+            {value:'QF', label:'QF'}
+        ]/}
+
+        {@aria:MultiSelect {
+            id:"widget",
+            label:"Multiselect",
+            labelWidth:150,
+            sclass:data.outerSclass,
+            listSclass:data.innerSclass,
+            width:400,
+            items:testItems,
+            bind:{
+                value : {
+                    to : 'value',
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiselect/issue312/Select.js
+++ b/test/aria/widgets/form/multiselect/issue312/Select.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.Select",
+    $extends : "test.aria.widgets.form.multiselect.issue312.Common",
+    $dependencies : ["aria.widgets.form.list.List"],
+    $prototype : {
+        innerWidgetClasspath : "aria.widgets.form.list.List",
+        innerWidgetName : "List",
+        outerWidgetName : "Select",
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            skin.listSclass = innerWidgetSkinClass;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/SelectBox.js
+++ b/test/aria/widgets/form/multiselect/issue312/SelectBox.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.issue312.SelectBox",
+    $extends : "test.aria.widgets.form.multiselect.issue312.Common",
+    $dependencies : ["aria.widgets.form.list.List"],
+    $prototype : {
+        innerWidgetClasspath : "aria.widgets.form.list.List",
+        innerWidgetName : "List",
+        outerWidgetName : "SelectBox",
+
+        _setOuterWidgetSkinProperty : function (skin, innerWidgetSkinClass) {
+            skin.listSclass = innerWidgetSkinClass;
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/issue312/SelectBoxTpl.tpl
+++ b/test/aria/widgets/form/multiselect/issue312/SelectBoxTpl.tpl
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.issue312.SelectBoxTpl'
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {var testItems = [
+            {value:'AF', label:'AF'},
+            {value:'AC', label:'AC'},
+            {value:'NZ', label:'NZ'},
+            {value:'DL', label:'DL'},
+            {value:'AY', label:'AY'},
+            {value:'IB', label:'IB'},
+            {value:'LH', label:'LH'},
+            {value:'MX', label:'MX'},
+            {value:'QF', label:'QF'}
+        ]/}
+
+        {@aria:SelectBox {
+            id:"widget",
+            label:"Select",
+            labelWidth:150,
+            sclass:data.outerSclass,
+            listSclass:data.innerSclass,
+            width:400,
+            options:testItems,
+            bind:{
+                value : {
+                    to : 'value',
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiselect/issue312/SelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/issue312/SelectTpl.tpl
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.issue312.SelectTpl'
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {var testItems = [
+            {value:'AF', label:'AF'},
+            {value:'AC', label:'AC'},
+            {value:'NZ', label:'NZ'},
+            {value:'DL', label:'DL'},
+            {value:'AY', label:'AY'},
+            {value:'IB', label:'IB'},
+            {value:'LH', label:'LH'},
+            {value:'MX', label:'MX'},
+            {value:'QF', label:'QF'}
+        ]/}
+
+        {@aria:Select {
+            id:"widget",
+            label:"Select",
+            labelWidth:150,
+            sclass:data.outerSclass,
+            listSclass:data.innerSclass,
+            width:400,
+            options:testItems,
+            bind:{
+                value : {
+                    to : 'value',
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This is a fix for #312.

For consistency, the same fix is applied to the following widgets:
- AutoComplete
- DatePicker
- MultiSelect
- Select
- SelectBox

The skin class of the inner widget can be specified either from the widget configuration or from the skin class of the container widget.
