### PR TITLE
Expected JSON response in RequestMgr

### DIFF
--- a/src/aria/modules/RequestBeans.js
+++ b/src/aria/modules/RequestBeans.js
@@ -116,6 +116,18 @@ Aria.beanDefinitions({
                 "error" : {
                     $type : "json:String",
                     $description : "Error message from the framework"
+                },
+                "responseText" : {
+                    $type : "json:String",
+                    $description : "Response from the server as a string."
+                },
+                "responseXML" : {
+                    $type : "json:ObjectRef",
+                    $description : "If available, response as an XML tree."
+                },
+                "responseJSON" : {
+                    $type : "json:ObjectRef",
+                    $description : "If available, response as a javascript object."
                 }
             }
         },

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -353,11 +353,13 @@ Aria.classDefinition({
          */
         _callAsyncRequest : function (args) {
             var req = args.req;
-            if (args.requestHandler == null) {
-                args.requestHandler = this.__getRequestHandler();
+            var handler = args.requestHandler;
+            if (handler == null) {
+                handler = this.__getRequestHandler();
             }
+
             req.data = (req.data == null && req.method == "POST")
-                    ? args.requestHandler.prepareRequestBody(req.jsonData, req.requestObject)
+                    ? handler.prepareRequestBody(req.jsonData, req.requestObject)
                     : req.data;
 
             // call the server
@@ -388,12 +390,15 @@ Aria.classDefinition({
                         id : args.id,
                         session : args.session,
                         actionQueuing : args.actionQueuing,
-                        requestHandler : args.requestHandler
+                        requestHandler : handler
                     }
                 }
             };
             if (req.postHeader) {
                 requestObject.postHeader = req.postHeader;
+            }
+            if (handler.expectedResponseType) {
+                requestObject.expectedResponseType = handler.expectedResponseType;
             }
             aria.core.IO.asyncRequest(requestObject);
         },
@@ -420,7 +425,7 @@ Aria.classDefinition({
                 requestObject : requestObject,
                 responseXML : res.responseXML,
                 responseText : res.responseText,
-                responseJSON : res.responseJson,
+                responseJSON : res.responseJSON,
                 status : res.status, // http status (e.g.: 404)
                 error : res.error, // contains error message
 
@@ -451,7 +456,10 @@ Aria.classDefinition({
             if (res.error) {
                 handler.processFailure({
                     error : res.error,
-                    status : res.status
+                    status : res.status,
+                    responseXML : res.responseXML,
+                    responseText : res.responseText,
+                    responseJSON : res.responseJSON
                 }, {
                     url : args.res.url,
                     session : args.session,
@@ -465,7 +473,7 @@ Aria.classDefinition({
                 handler.processSuccess({
                     responseXML : res.responseXML,
                     responseText : res.responseText,
-                    responseJSON : res.responseJson
+                    responseJSON : res.responseJSON
                 }, {
                     url : res.url,
                     session : args.session,

--- a/src/aria/modules/requestHandler/IRequestHandler.js
+++ b/src/aria/modules/requestHandler/IRequestHandler.js
@@ -16,10 +16,9 @@
 /**
  * Interface exposed from the Request Manager to the application. It is used by the request manager handler the response
  * of the request
- * @class aria.modules.requestHandler.IRequestHandler
  */
 Aria.interfaceDefinition({
-    $classpath : 'aria.modules.requestHandler.IRequestHandler',
+    $classpath : "aria.modules.requestHandler.IRequestHandler",
     $interface : {
         /**
          * Handles the response from the server, and call the associated callback
@@ -52,6 +51,14 @@ Aria.interfaceDefinition({
          * @param {aria.modules.RequestBeans.RequestObject} requestObject
          * @return {String} Stringified representation of the input data
          */
-        serializeRequestData : function (jsonData, requestObject) {}
+        serializeRequestData : function (jsonData, requestObject) {},
+
+        /**
+         * Expected response type. This parameter, if specified, is added on every request handled by this handler
+         * @type String
+         */
+        expectedResponseType : {
+            $type : "Object"
+        }
     }
 });

--- a/src/aria/modules/requestHandler/JSONRequestHandler.js
+++ b/src/aria/modules/requestHandler/JSONRequestHandler.js
@@ -15,7 +15,6 @@
 
 /**
  * Json handler, that handles JSON as weel as a javascript object retrieved in responseJSON
- * @class aria.modules.test.JSONRequestHandler
  */
 Aria.classDefinition({
     $classpath : "aria.modules.requestHandler.JSONRequestHandler",
@@ -25,6 +24,12 @@ Aria.classDefinition({
         PARSING_ERROR : "Response text could not be evaluated as JSON."
     },
     $prototype : {
+        /**
+         * Expect JSON as response type
+         * @type String
+         */
+        expectedResponseType : "json",
+
         /**
          * Handles the response from the server, and call the associated callback
          * @param {aria.modules.RequestBeans.SuccessResponse} successResponse

--- a/src/aria/modules/requestHandler/RequestHandler.js
+++ b/src/aria/modules/requestHandler/RequestHandler.js
@@ -15,7 +15,6 @@
 
 /**
  * Base class for request handler, that handles HTTP errors
- * @class aria.modules.test.RequestHandler
  */
 Aria.classDefinition({
     $classpath : "aria.modules.requestHandler.RequestHandler",
@@ -75,7 +74,11 @@ Aria.classDefinition({
 
             // resource forwarded to the callback
             var res = {
-                response : null,
+                response : {
+                    responseText : failureResponse.responseText,
+                    responseJSON : failureResponse.responseJSON,
+                    responseXML :  failureResponse.responseXML
+                },
                 error : true
             };
 


### PR DESCRIPTION
All request handler wipe out the failure response from the server. This prevents REST applications.
Moreover, using JSON the expected response should contain JSON also in case of errors.

This commit fixes #304

In case of error the Request Manager returns now a `response` object just like the success use case.
