### PR TITLE
Invalid aria.utils.Html test in Internet Explorer

### DIFF
--- a/test/aria/utils/Html.js
+++ b/test/aria/utils/Html.js
@@ -52,8 +52,16 @@ Aria.classDefinition({
                     } else if (aria.templates.DomElementWrapper.attributesWhiteList.test(key)) {
                         var value = stringUtil.encodeForQuotedHTMLAttribute(attribute);
                         var got = div.getAttribute(key);
-                        this.assertEquals(got, value, "The attribute " + key + " should be equals to " + value
-                                + " got " + got);
+
+                        if (key === "style") {
+                            // IE messes up pretty badly with style tags
+                            got = got.toLowerCase();
+                            // just add a semicolon if missing
+                            if (got.charAt(got.length - 1) !== ";") {
+                                got += ";"
+                            }
+                        }
+                        this.assertEquals(got, value, "The attribute " + key + " should be " + value + " got " + got);
                     }
                 }
             }
@@ -83,7 +91,7 @@ Aria.classDefinition({
                     data3 : "data3-value"
                 },
                 dir : "ltr",
-                disabled : "false",
+                disabled : "disabled",
                 height : "100px",
                 lang : "en-US",
                 maxlength : "10",
@@ -95,7 +103,7 @@ Aria.classDefinition({
                 rowspan : "2",
                 selected : "myValue",
                 size : "100px",
-                style : "border: 1px solid black;",
+                style : "color: black;",
                 title : "myElement",
                 type : "text",
                 valign : "middle",


### PR DESCRIPTION
Html test contains two errors
1. disabled is a boolean attribute, so it's value should be `disabled`
2. using border as style make testing IE painful, the returned value is `border-top/bottom/left/right`
   Using color reduces the problem but anyway the return value is `COLOR: black` : mixed case and no semicolon
