### PR TITLE
fix #309 vertical splitter bug in IE9

### DIFF
--- a/src/aria/widgets/container/Splitter.js
+++ b/src/aria/widgets/container/Splitter.js
@@ -180,6 +180,10 @@ Aria.classDefinition({
             this.setProperty("size2", size2);
             this._splitPanel1.style[dimType] = size1 + "px";
             this._splitPanel2.style[dimType] = size2 + "px";
+            if (dimType == "width") { // IE9 sometimes shows full-width scrollbars even on 0px-width containers!
+                this._splitPanel1.style.overflowY = (size1 <= 16) ? "hidden" : "";
+                this._splitPanel2.style.overflowY = (size2 <= 16) ? "hidden" : "";
+            }
             this._splitBar.style[dimMode] = size1 + "px";
             this._splitBarProxy.style[dimMode] = size1 + "px";
             this._context.$refresh({


### PR DESCRIPTION
Hotfix for the CR #309 delivered in the pull request #311.

In IE9 a vertical scrollbar can appear even in 0px width container (likely a browser bug), this fixes that issue.
