### PR TITLE
fix #325 Slow robot tests in Safari.

### DIFF
--- a/src/aria/jsunit/SynEvents.js
+++ b/src/aria/jsunit/SynEvents.js
@@ -57,6 +57,7 @@ Aria.classDefinition({
             // robot actions:
             "initRobot" : 0,
             "mouseMove" : 1,
+            "smoothMouseMove" : 3,
             "absoluteMouseMove" : 1,
             "mousePress" : 1,
             "mouseRelease" : 1,
@@ -215,7 +216,7 @@ Aria.classDefinition({
         },
 
         move : function (options, from, cb) {
-            var duration = options.duration || 1000;
+            var duration = options.duration || 2000;
             var to = options.to;
             to = this._resolvePosition(to);
             from = from ? this._resolvePosition(from) : to;
@@ -223,17 +224,7 @@ Aria.classDefinition({
                 // error is already logged
                 return;
             }
-            var seq = [];
-            for (var i = 0, l = duration / 40; i < l; i++) {
-                // note that duration is approximative
-                var fraction = i / l;
-                seq.push(["mouseMove", {
-                            x : (1 - fraction) * from.x + fraction * to.x,
-                            y : (1 - fraction) * from.y + fraction * to.y
-                        }]);
-            }
-            seq.push(["mouseMove", to]);
-            this.execute(seq, cb);
+            this._robot.smoothMouseMove(from, to, duration, cb);
         },
 
         drag : function (options, from, cb) {
@@ -296,8 +287,8 @@ Aria.classDefinition({
             if (aria.utils.Type.isHTMLElement(geometry)) {
                 res = domUtils.getGeometry(geometry);
                 // TODO: check if the item is really visible
-            } else if (geometry.hasOwnProperty("x") && geometry.hasOwnProperty("y") && geometry.hasOwnProperty("width")
-                    && geometry.hasOwnProperty("height")) {
+            } else if (geometry.hasOwnProperty("x") && geometry.hasOwnProperty("y") &&
+                    geometry.hasOwnProperty("width") && geometry.hasOwnProperty("height")) {
                 res = geometry;
             } else {
                 // FIXME: log error correctly

--- a/src/aria/utils/StringCallback.js
+++ b/src/aria/utils/StringCallback.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility class allowing to store a reference to a callback object and get a string which, when evaluated, will call
+ * that callback object.
+ */
+Aria.classDefinition({
+    $classpath : "aria.utils.StringCallback",
+    $singleton : true,
+    $constructor : function () {
+        this._callbacks = {};
+        this._index = 0;
+    },
+    $destructor : function () {
+        this._callbacks = null;
+    },
+    $statics : {
+        _VALUE_REGEXP : /^aria\.utils\.StringCallback\.call\(([0-9]+)\)$/
+    },
+    $prototype : {
+
+        /**
+         * Stores a reference to the given callback and returns a string which, when evaluated, calls that callback.
+         * @param {aria.core.CfgBeans.Callback} cb callback to register.
+         * @param {Boolean} moreThanOnce If true, the callback can be called several times. Otherwise, it is removed at
+         * the first call.
+         */
+        createStringCallback : function (cb, moreThanOnce) {
+            var index = this._index;
+            this._index++;
+            var entry = {
+                cb : cb,
+                moreThanOnce : moreThanOnce
+            }
+            this._callbacks["c" + index] = entry;
+            return "aria.utils.StringCallback.call(" + index + ");";
+        },
+
+        /**
+         * Removes the reference to a previously stored callback. After calling this method, the callback can no longer
+         * be called, even if the return value from createStringCallback is evaluated.
+         * @param {String} value Return value from createStringCallback.
+         */
+        deleteStringCallback : function (value) {
+            var match = this._VALUE_REGEXP.exec(value);
+            if (match) {
+                var index = match[1];
+                delete this._callbacks["c" + index];
+            }
+        },
+
+        /**
+         * This method is used when calling a callback stored on this object.
+         * @param {Number} index Index of the callback to call.
+         */
+        call : function (index) {
+            var entry = this._callbacks["c" + index];
+            if (entry) {
+                if (!entry.moreThanOnce) {
+                    delete this._callbacks["c" + index];
+                }
+                this.$callback(entry.cb);
+            }
+        }
+    }
+});


### PR DESCRIPTION
This pull request changes the way the `move` robot operation is implemented: instead of calling multiple times the java applet for each change in the mouse position (which is very slow on Safari), it is now calling the java applet once (so there is only one slow call), and then the applet does the whole move.
