### PR TITLE
checkValue error when no bindings

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -251,6 +251,7 @@ Aria.classDefinition({
                 this.getTextInputField().value = "";
                 this.setHelpText(true);
             } else if (value) {
+                this.setHelpText(false);
                 this.getTextInputField().value = value;
             }
         },
@@ -442,8 +443,12 @@ Aria.classDefinition({
                     && this._cfg.formatErrorMessages.length) {
                 this.changeProperty("invalidText", null);
                 this.changeProperty("formatErrorMessages", []);
+                // setting invalid text to null means we might add helptext, this prevents any value to be applied
+                this.setHelpText(false);
             } else if (report.ok && !performCheckOnly) {
                 this.changeProperty("invalidText", null);
+                // If I get there there are no errors raised by this check, and there were no errors before, meaning the
+                // value is correct, no need to remove the helptext because it won't be set
             }
 
             if (performCheckOnly) {

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -31,18 +31,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.controllers.SelectControllerTest");
         this.addTests("test.aria.widgets.environment.WidgetSettings");
         this.addTests("test.aria.widgets.errorlist.ErrorListControllerTest");
-        this.addTests("test.aria.widgets.form.CheckBoxTest");
-        this.addTests("test.aria.widgets.form.GaugeTest");
-        this.addTests("test.aria.widgets.form.InputTest");
-        this.addTests("test.aria.widgets.form.InputValidationHandlerTest");
-        this.addTests("test.aria.widgets.form.ListControllerTest");
-        this.addTests("test.aria.widgets.form.NumberFieldTest");
-        this.addTests("test.aria.widgets.form.SelectTest");
-        this.addTests("test.aria.widgets.form.TextareaTest");
-        this.addTests("test.aria.widgets.form.TextInputTest");
-        this.addTests("test.aria.widgets.form.multiselect.issue223.MultiSelect");
-        this.addTests("test.aria.widgets.form.multiselect.issue312.Issue312TestSuite");
-        this.addTests("test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonTest");
-        this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
+        this.addTests("test.aria.widgets.form.FormTestSuite");
     }
 });

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.FormTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.widgets.form.CheckBoxTest");
+        this.addTests("test.aria.widgets.form.GaugeTest");
+        this.addTests("test.aria.widgets.form.InputTest");
+        this.addTests("test.aria.widgets.form.InputValidationHandlerTest");
+        this.addTests("test.aria.widgets.form.ListControllerTest");
+        this.addTests("test.aria.widgets.form.NumberFieldTest");
+        this.addTests("test.aria.widgets.form.SelectTest");
+        this.addTests("test.aria.widgets.form.TextareaTest");
+        this.addTests("test.aria.widgets.form.TextInputTest");
+        this.addTests("test.aria.widgets.form.multiselect.issue223.MultiSelect");
+        this.addTests("test.aria.widgets.form.multiselect.issue312.Issue312TestSuite");
+        this.addTests("test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonTest");
+        this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
+        this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
+    }
+});

--- a/test/aria/widgets/form/datefield/DateFieldTestSuite.js
+++ b/test/aria/widgets/form/datefield/DateFieldTestSuite.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.datefield.DateFieldTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.widgets.form.datefield.issue303.InvalidState");
+    }
+});

--- a/test/aria/widgets/form/datefield/issue303/InvalidState.js
+++ b/test/aria/widgets/form/datefield/issue303/InvalidState.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.datefield.issue303.InvalidState",
+    $extends : "aria.jsunit.WidgetTestCase",
+    $dependencies : ["aria.widgets.form.DateField", "aria.utils.Date", "aria.utils.Dom"],
+    $prototype : {
+        tearDown : function () {
+            aria.jsunit.helpers.OutObj.clearAll();
+        },
+
+        createInstance : function (cfg) {
+            // Ignore most of the options because those are normalized from other widgets
+            var config = {
+                bind : cfg.bind,
+                helptext : cfg.helptext,
+                minValue : cfg.minValue,
+                maxValue : cfg.maxValue
+            };
+            // doing a json.clone won't work because it'll recreate the datamodel
+
+            var widget = new aria.widgets.form.DateField(config, aria.jsunit.helpers.OutObj.tplCtxt);
+
+            // Prevent the popup from opening
+            widget._validationPopupShow = Aria.empty;
+
+            return widget;
+        },
+
+        initializeWidgets : function (/* list of widgets*/) {
+            var widget;
+            for (var i = 0; i < arguments.length; i += 1) {
+                widget = arguments[i];
+                widget.writeMarkup(this.outObj);
+            }
+
+            this.outObj.putInDOM();
+
+            for (i = 0; i < arguments.length; i += 1) {
+                widget = arguments[i];
+                widget.initWidget();
+                widget.initWidgetDom();
+            }
+        },
+
+        /**
+         * When the value is not bound, check that changing from valid/invalid still works
+         */
+        testInvalidtoValid : function () {
+            var datamodel = {
+                value : ""
+            };
+
+            var cfg = {
+                helptext : "help",
+                minValue : new Date(2000, 0, 1),
+                maxValue : new Date(2100, 11, 31)
+            };
+
+            var widget = this.createInstance(cfg);
+            this.initializeWidgets(widget);
+
+            var input = widget.getTextInputField();
+
+            // Set the widgets as invalid
+            widget._dom_onfocus();
+            input.value = "invalid";
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, "invalid", "Input should be 'invalid' got '" + input.value + "'");
+
+            // Now try to have a valid value
+            var today = new Date();
+            var formatted = aria.utils.Date.format(today, widget.controller._pattern);
+
+            widget._dom_onfocus();
+            input.value = formatted.replace(/\//g, "-");
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+
+            widget.$dispose();
+        },
+
+        /**
+         * When the value is not bound, check that changing from valid/invalid still works
+         */
+        testValidToValid : function () {
+            var datamodel = {
+                value : ""
+            };
+
+            var cfg = {
+                helptext : "help",
+                minValue : new Date(2000, 0, 1),
+                maxValue : new Date(2100, 11, 31)
+            };
+
+            var widget = this.createInstance(cfg);
+            this.initializeWidgets(widget);
+
+            var input = widget.getTextInputField();
+
+            // Set the widgets as invalid
+            var today = new Date();
+            var formatted = aria.utils.Date.format(today, widget.controller._pattern);
+
+            widget._dom_onfocus();
+            input.value = formatted;
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+
+            // Now set another valid date
+            var tomorrow = aria.utils.Date.interpret("+1");
+            formatted = aria.utils.Date.format(tomorrow, widget.controller._pattern);
+
+            widget._dom_onfocus();
+            input.value = formatted.replace(/\//g, "-");
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+
+            widget.$dispose();
+        },
+
+        /**
+         * When the value is not bound, check that changing from valid/invalid still works
+         */
+        testValidToInvalid : function () {
+            var datamodel = {
+                value : ""
+            };
+
+            var cfg = {
+                helptext : "help",
+                minValue : new Date(2000, 0, 1),
+                maxValue : new Date(2100, 11, 31)
+            };
+
+            var widget = this.createInstance(cfg);
+            this.initializeWidgets(widget);
+
+            var input = widget.getTextInputField();
+
+            // Set the widgets as valid
+            var today = new Date();
+            var formatted = aria.utils.Date.format(today, widget.controller._pattern);
+
+            widget._dom_onfocus();
+            input.value = formatted;
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+
+            // Now set it invalid
+            widget._dom_onfocus();
+            input.value = "invalid";
+            widget._dom_onblur();
+
+            this.assertEquals(input.value, "invalid", "Input should be 'invalid' got '" + input.value + "'");
+            // but we should also check it's style
+            var color = aria.utils.Dom.getStyle(input, "color");
+            var isBlack = color === "black" || color === "inherit";
+            this.assertTrue(isBlack,"Input should be black got color '" + input.value + "'");
+
+            widget.$dispose();
+        }
+    }
+});


### PR DESCRIPTION
the initial fix for #303 introduces a regression when the widget value is not bound to the datamodel.
If you go from an invalid text a valid value the latter is lost.
moreover if you go from a valid value to an invalid text the widget's style is that of the helptext.
