### PR TITLE
feat #327 improve error messages in assertEquals/NotEquals/JsonEquals

### DIFF
--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -175,17 +175,26 @@
              * @param {String} optMsg optional message to add to the failure description
              */
             assertFalse : function (value, optMsg) {
-                this.assertTrue((value === false), optMsg || ("Expected false. Got : " + value));
+                this.assertTrue((value === false), optMsg || ("Expected false. Got: " + value));
             },
 
             /**
              * AssertEquals: Check that value1 is equal to value2
              * @param {object} value1 the value to compare
              * @param {object} value2 the value to compare
-             * @param {String} optMsg optional message to add to the failure description
+             * @param {String} optMsg optional message to add to the failure description. It can contain placeholders %1
+             * and %2 which will be replaced accordingly with: %1 - value1, %2 - value2.
              */
             assertEquals : function (value1, value2, optMsg) {
-                this.assertTrue((value1 === value2), optMsg || ("Expected : " + value1 + ". Got : " + value2));
+                var msg;
+
+                if (optMsg) {
+                    msg = aria.utils.String.substitute(optMsg, ['"' + value1 + '"', '"' + value2 + '"']);
+                } else {
+                    msg = 'First value: "' + value1 + '" differs from the second: "' + value2 + '".';
+                }
+
+                this.assertTrue((value1 === value2), msg);
             },
 
             /**
@@ -193,9 +202,13 @@
              * @param {object} value1 the value to compare
              * @param {object} value2 the value to compare
              * @param {String} optMsg optional message to add to the failure description
+             * @param {String} optAssertId optional ID to quickly locate the failed assertion (in case of many
+             * assertions with the same, or default, message). Could be e.g. a line where the assertion is put at
+             * creation time.
              */
-            assertNotEquals : function (value1, value2, optMsg) {
-                this.assertTrue((value1 !== value2), optMsg || ("Expected : " + value1 + ". Got : " + value2));
+            assertNotEquals : function (value1, value2, optMsg, optAssertId) {
+                var msg = optMsg || ("First and second value shouldn't be equal but they are both equal to: " + value1);
+                this.assertTrue((value1 !== value2), msg);
             },
 
             /**
@@ -302,6 +315,12 @@
              * @param {String} optMsg optional message to add to the failure description
              */
             assertJsonEquals : function (obj1, obj2, optMsg) {
+                if (!optMsg) {
+                    var s1 = aria.utils.Json.convertToJsonString(obj1);
+                    var s2 = aria.utils.Json.convertToJsonString(obj2);
+                    optMsg = "JSON comparison failed. First object: <code>" + s1
+                            + "</code> differs from the second: <code>" + s2 + "</code>.";
+                }
                 this.assertTrue(aria.utils.Json.equals(obj1, obj2), optMsg);
             },
 

--- a/test/aria/html/controllers/suggestions/ResourcesHandlerTest.js
+++ b/test/aria/html/controllers/suggestions/ResourcesHandlerTest.js
@@ -51,10 +51,8 @@ Aria.classDefinition({
 
                 var suggestions = controller.data.suggestions;
                 this.assertEquals(suggestions.length, 2, "ByInstance should have two suggestions");
-                this.assertEquals(suggestions[0], "ByInstance-", "Suggestion 0 expecting ByInstance- got "
-                        + suggestions[0]);
-                this.assertEquals(suggestions[1], "ByInstance-suggestion", "Suggestion 1 expecting ByInstance-suggestion got "
-                        + suggestions[1]);
+                this.assertEquals(suggestions[0], "ByInstance-", "Suggestion 0 expecting %2, got %1");
+                this.assertEquals(suggestions[1], "ByInstance-suggestion", "Suggestion 1 expecting %2, got %1");
 
                 controller.$dispose();
 
@@ -93,10 +91,8 @@ Aria.classDefinition({
 
                 var suggestions = controller.data.suggestions;
                 this.assertEquals(suggestions.length, 2, "ByClasspath should have two suggestions");
-                this.assertEquals(suggestions[0], "ByClasspath-", "Suggestion 0 expecting ByClasspath- got "
-                        + suggestions[0]);
-                this.assertEquals(suggestions[1], "ByClasspath-suggestion", "Suggestion 1 expecting ByClasspath-suggestion got "
-                        + suggestions[1]);
+                this.assertEquals(suggestions[0], "ByClasspath-", "Suggestion 0 expecting %2, got %1");
+                this.assertEquals(suggestions[1], "ByClasspath-suggestion", "Suggestion 1 expecting %2, got %1");
 
                 controller.$dispose();
 
@@ -134,9 +130,8 @@ Aria.classDefinition({
 
                 var suggestions = controller.data.suggestions;
                 this.assertEquals(suggestions.length, 2, "Dynamic should have two suggestions");
-                this.assertEquals(suggestions[0], "Dynamic-", "Suggestion 0 expecting Dynamic- got " + suggestions[0]);
-                this.assertEquals(suggestions[1], "Dynamic-suggestion", "Suggestion 1 expecting Dynamic-suggestion got "
-                        + suggestions[1]);
+                this.assertEquals(suggestions[0], "Dynamic-", "Suggestion 0 expecting expecting %2, got %1");
+                this.assertEquals(suggestions[1], "Dynamic-suggestion", "Suggestion 1 expecting expecting %2, got %1");
 
                 // Do another getSuggestion just in case, we do have some function rewrite in the class
                 controller.suggestValue("+");
@@ -156,9 +151,8 @@ Aria.classDefinition({
 
                 var suggestions = controller.data.suggestions;
                 this.assertEquals(suggestions.length, 2, "Dynamic should have two suggestions");
-                this.assertEquals(suggestions[0], "Dynamic+", "Suggestion 0 expecting Dynamic+ got " + suggestions[0]);
-                this.assertEquals(suggestions[1], "Dynamic+suggestion", "Suggestion 1 expecting Dynamic+suggestion got "
-                        + suggestions[1]);
+                this.assertEquals(suggestions[0], "Dynamic+", "Suggestion 0 expecting %2, got %1");
+                this.assertEquals(suggestions[1], "Dynamic+suggestion", "Suggestion 1 expecting expecting %2, got %1");
 
                 controller.$dispose();
 

--- a/test/aria/html/element/ElementBindingsTest.js
+++ b/test/aria/html/element/ElementBindingsTest.js
@@ -69,42 +69,42 @@ Aria.classDefinition({
 
             // Change a value with listener
             aria.utils.Json.setValue(basket, "apples", 3);
-            this.assertEquals(name, "apple", "Expecting name apple, got " + name);
-            this.assertEquals(value, 3, "Expecting value 3, got " + value);
+            this.assertEquals(name, "apple", "Expecting name %2, got %1");
+            this.assertEquals(value, 3, "Expecting value %2, got %1");
             this.assertTrue(old == null, "Expecting old value null, got " + old);
 
             // Change it again
             aria.utils.Json.setValue(basket, "apples", 0);
-            this.assertEquals(name, "apple", "Expecting name apple, got " + name);
-            this.assertEquals(value, 0, "Expecting value 0, got " + value);
-            this.assertEquals(old, 3, "Expecting old value 3, got " + old);
+            this.assertEquals(name, "apple", "Expecting name %2, got %1");
+            this.assertEquals(value, 0, "Expecting value %2, got %1");
+            this.assertEquals(old, 3, "Expecting old value %2, got %1");
 
             // Change a different value
             aria.utils.Json.setValue(basket, "pears", ["abate"]);
-            this.assertEquals(name, "pear", "Expecting name pear, got " + name);
-            this.assertEquals(value.length, 1, "Expecting value length 1, got " + value.length);
-            this.assertEquals(value[0], "abate", "Expecting value abate, got " + value[0]);
+            this.assertEquals(name, "pear", "Expecting name %2, got %1");
+            this.assertEquals(value.length, 1, "Expecting value length %2, got %1");
+            this.assertEquals(value[0], "abate", "Expecting value %2, got %1");
             this.assertTrue(old == null, "Expecting old value null, got " + old);
 
             // And cahnge again the previous one
             aria.utils.Json.setValue(basket, "apples", {
                 type : "golden"
             });
-            this.assertEquals(name, "apple", "Expecting name apple, got " + name);
-            this.assertEquals(value.type, "golden", "Expecting value golden, got " + value.type);
-            this.assertEquals(old, 0, "Expecting old value 0, got " + old);
+            this.assertEquals(name, "apple", "Expecting name %2, got %1");
+            this.assertEquals(value.type, "golden", "Expecting value %2, got %1");
+            this.assertEquals(old, 0, "Expecting old value %2, got %1");
 
             // Change a value with no listeners
             aria.utils.Json.setValue(shopping.bags[0], "hand", "middle");
-            this.assertEquals(name, "apple", "Expecting name apple, got " + name);
-            this.assertEquals(value.type, "golden", "Expecting value golden, got " + value.type);
-            this.assertEquals(old, 0, "Expecting old value 0, got " + old);
+            this.assertEquals(name, "apple", "Expecting name %2, got %1");
+            this.assertEquals(value.type, "golden", "Expecting value %2, got %1");
+            this.assertEquals(old, 0, "Expecting old value %2, got %1");
 
             // And now one with a listener
             aria.utils.Json.setValue(shopping.bags[1], "content", false);
-            this.assertEquals(name, "sugar", "Expecting name sugar, got " + name);
-            this.assertEquals(value, false, "Expecting value false, got " + value);
-            this.assertEquals(old, null, "Expecting old value null, got " + old);
+            this.assertEquals(name, "sugar", "Expecting name %2, got %1");
+            this.assertEquals(value, false, "Expecting value false, got %1");
+            this.assertEquals(old, null, "Expecting old value null, got %1");
 
             widget.$dispose();
         },

--- a/test/aria/utils/NumberLocale.js
+++ b/test/aria/utils/NumberLocale.js
@@ -347,8 +347,7 @@ Aria.classDefinition({
                 if (tests.hasOwnProperty(check)) {
                     var got = aria.utils.Number.interpretNumber(check);
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -372,8 +371,7 @@ Aria.classDefinition({
                 if (tests.hasOwnProperty(check)) {
                     var got = aria.utils.Number.interpretNumber(check);
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -397,8 +395,7 @@ Aria.classDefinition({
                 if (tests.hasOwnProperty(check)) {
                     var got = aria.utils.Number.interpretNumber(check);
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -422,8 +419,7 @@ Aria.classDefinition({
                 if (tests.hasOwnProperty(check)) {
                     var got = aria.utils.Number.interpretNumber(check);
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -452,8 +448,7 @@ Aria.classDefinition({
                         groupingSeparator : "\\"
                     });
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -481,8 +476,7 @@ Aria.classDefinition({
                         groupingSeparator : " "
                     });
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -507,8 +501,7 @@ Aria.classDefinition({
                 if (tests.hasOwnProperty(check)) {
                     var got = aria.utils.Number.interpretNumber(check);
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },
@@ -537,8 +530,7 @@ Aria.classDefinition({
                         strictGrouping : false
                     });
 
-                    this.assertEquals(got, tests[check], "Comparing " + check + " expected " + tests[check] + " got "
-                            + got);
+                    this.assertEquals(got, tests[check], "Comparing " + check + " expected %2, got %1");
                 }
             }
         },

--- a/test/aria/utils/String.js
+++ b/test/aria/utils/String.js
@@ -448,7 +448,7 @@ Aria.classDefinition({
                 if (holders.hasOwnProperty(key)) {
                     got = aria.utils.String.substitute(holders[key], "thisString");
 
-                    this.assertEquals(got, holders[key], "Expecting " + holders[key] + ", got " + got);
+                    this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
             }
         },
@@ -471,7 +471,7 @@ Aria.classDefinition({
                 if (holders.hasOwnProperty(key)) {
                     got = aria.utils.String.substitute(holders[key], ["thisString", "another"]);
 
-                    this.assertEquals(got, holders[key], "Expecting " + holders[key] + ", got " + got);
+                    this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
             }
         },
@@ -493,7 +493,7 @@ Aria.classDefinition({
                 if (holders.hasOwnProperty(key)) {
                     got = aria.utils.String.substitute(holders[key], ["one", "two"]);
 
-                    this.assertEquals(got, holders[key], "Expecting " + holders[key] + ", got " + got);
+                    this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
             }
         }

--- a/test/aria/widgets/form/datefield/issue303/InvalidState.js
+++ b/test/aria/widgets/form/datefield/issue303/InvalidState.js
@@ -80,7 +80,7 @@ Aria.classDefinition({
             input.value = "invalid";
             widget._dom_onblur();
 
-            this.assertEquals(input.value, "invalid", "Input should be 'invalid' got '" + input.value + "'");
+            this.assertEquals(input.value, "invalid", "Input value should be %2, got %1.");
 
             // Now try to have a valid value
             var today = new Date();
@@ -90,7 +90,7 @@ Aria.classDefinition({
             input.value = formatted.replace(/\//g, "-");
             widget._dom_onblur();
 
-            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+            this.assertEquals(input.value, formatted, "Input value should be %2, got %1.");
 
             widget.$dispose();
         },
@@ -122,7 +122,7 @@ Aria.classDefinition({
             input.value = formatted;
             widget._dom_onblur();
 
-            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+            this.assertEquals(input.value, formatted, "Input value should be %2, got %1.");
 
             // Now set another valid date
             var tomorrow = aria.utils.Date.interpret("+1");
@@ -132,7 +132,7 @@ Aria.classDefinition({
             input.value = formatted.replace(/\//g, "-");
             widget._dom_onblur();
 
-            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+            this.assertEquals(input.value, formatted, "Input value should be %2, got %1.");
 
             widget.$dispose();
         },
@@ -164,18 +164,18 @@ Aria.classDefinition({
             input.value = formatted;
             widget._dom_onblur();
 
-            this.assertEquals(input.value, formatted, "Input should be '" + formatted + "' got '" + input.value + "'");
+            this.assertEquals(input.value, formatted, "Input value should be %2, got %1.");
 
             // Now set it invalid
             widget._dom_onfocus();
             input.value = "invalid";
             widget._dom_onblur();
 
-            this.assertEquals(input.value, "invalid", "Input should be 'invalid' got '" + input.value + "'");
+            this.assertEquals(input.value, "invalid", "Input value should be %2, got %1.");
             // but we should also check it's style
             var color = aria.utils.Dom.getStyle(input, "color");
             var isBlack = color === "black" || color === "inherit";
-            this.assertTrue(isBlack,"Input should be black got color '" + input.value + "'");
+            this.assertTrue(isBlack, "Input should be black got color '" + input.value + "'");
 
             widget.$dispose();
         }

--- a/test/aria/widgets/form/datepicker/issue303/InfiniteLoop.js
+++ b/test/aria/widgets/form/datepicker/issue303/InfiniteLoop.js
@@ -80,7 +80,7 @@ Aria.classDefinition({
             var input = widget.getTextInputField();
 
             var formatted = aria.utils.Date.format(today, widget.controller._pattern);
-            this.assertEquals(input.value, formatted, "Input value should be " + formatted + " got " + input.value);
+            this.assertEquals(input.value, formatted, "Input value should be %2, got %1");
 
             // Now simulate a type
             try {
@@ -130,18 +130,15 @@ Aria.classDefinition({
             var inputTwo = other.getTextInputField();
 
             var formatted = aria.utils.Date.format(today, widget.controller._pattern);
-            this.assertEquals(inputOne.value, formatted, "Input value 1 should be " + formatted + " got '"
-                    + inputOne.value + "'");
-            this.assertEquals(inputTwo.value, formatted, "Input value 2 should be " + formatted + " got '"
-                    + inputTwo.value + "'");
+            this.assertEquals(inputOne.value, formatted, "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, formatted, "Input value 2 should be %2, got %1");
 
             // Now simulate a type
             widget._dom_onfocus();
             inputOne.value = "invalid text";
             widget._dom_onblur();
 
-            this.assertEquals(inputTwo.value, "invalid text", "Input value 3 should be 'invalid text' got '"
-                    + inputTwo.value + "'");
+            this.assertEquals(inputTwo.value, "invalid text", "Input value 2 should be %2, got %1");
 
             var tomorrow = aria.utils.Date.interpret("+1");
             var formattedTomorrow = aria.utils.Date.format(tomorrow, widget.controller._pattern);
@@ -151,10 +148,8 @@ Aria.classDefinition({
             widget._dom_onblur();
 
             // Input two should just be the same
-            this.assertEquals(inputOne.value, formattedTomorrow, "Input value 4 should be " + formattedTomorrow
-                    + " got '" + inputOne.value + "'");
-            this.assertEquals(inputTwo.value, formattedTomorrow, "Input value 5 should be " + formattedTomorrow
-                    + " got '" + inputTwo.value + "'");
+            this.assertEquals(inputOne.value, formattedTomorrow, "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, formattedTomorrow, "Input value 2 should be %2, got %1");
             // Date might differ on the time
             this.assertTrue(aria.utils.Date.isSameDay(datamodel.value, tomorrow), "Value in data model is not tomorrow");
 
@@ -198,18 +193,16 @@ Aria.classDefinition({
             var formatted = aria.utils.Date.format(tomorrow, widget.controller._pattern);
 
             // I expect to see the invalidText
-            this.assertEquals(inputOne.value, "wrong", "Input value should be 'wrong' got '" + inputOne.value + "'");
-            this.assertEquals(inputTwo.value, "wrong", "Input value should be 'wrong' got '" + inputTwo.value + "'");
+            this.assertEquals(inputOne.value, "wrong", "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, "wrong", "Input value 2 should be %2, got %1");
 
             // Now simulate canceling everything
             widget._dom_onfocus();
             inputOne.value = "";
             widget._dom_onblur();
 
-            this.assertEquals(inputOne.value, formatted, "Input value should be '" + formatted + "' got '"
-                    + inputOne.value + "'");
-            this.assertEquals(inputTwo.value, formatted, "Input value 2 should be '" + formatted + "' got '"
-                    + inputTwo.value + "'");
+            this.assertEquals(inputOne.value, formatted, "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, formatted, "Input value 2 should be %2, got %1");
 
             widget.$dispose();
             other.$dispose();
@@ -244,18 +237,16 @@ Aria.classDefinition({
             var inputTwo = other.getTextInputField();
 
             // I expect to see the invalidText
-            this.assertEquals(inputOne.value, "wrong", "Input value should be 'wrong' got '" + inputOne.value + "'");
-            this.assertEquals(inputTwo.value, "wrong", "Input value should be 'wrong' got '" + inputTwo.value + "'");
+            this.assertEquals(inputOne.value, "wrong", "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, "wrong", "Input value 2 should be %2, got %1");
 
             // Now simulate canceling everything
             widget._dom_onfocus();
             inputOne.value = "";
             widget._dom_onblur();
 
-            this.assertEquals(inputOne.value, "help me!", "Input value 1 should be 'help me!' got '" + inputOne.value
-                    + "'");
-            this.assertEquals(inputTwo.value, "help me!", "Input value 2 should be 'help me!' got '" + inputTwo.value
-                    + "'");
+            this.assertEquals(inputOne.value, "help me!", "Input value 1 should be %2, got %1");
+            this.assertEquals(inputTwo.value, "help me!", "Input value 2 should be %2, got %1");
 
             widget.$dispose();
             other.$dispose();


### PR DESCRIPTION
See #327.
1. Allow usage of %1 %2 in assertEquals messages.
   %1 and %2 are shortcuts for value1 and value2 params passed to assertEquals and can be used as placeholders in the error message. This commit implements the feature (Assert.js) and changes some of the unit tests to use the new capability.
2. Fix the obvious issue with the error message of 'assertNotEquals'.
3. Write serialized versions of JSON entities in assertJsonEquals in case there's no default error message passed.
