### PR TITLE
feat #335 configurable number of phantomjs instances in attester

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "grunt-verifylowercase": "*"
   },
   "config": {
-    "port": "8080"
+    "port": "8080",
+    "phantomjsInstances": 2
   },
   "scripts": {
     "start": "node scripts/server.js",
     "prestart": "npm install && node node_modules/grunt/bin/grunt package",
     "grunt": "node node_modules/grunt/bin/grunt",
-    "attester": "node node_modules/attester/bin/attester.js test/attester.yml --phantomjs-instances 2",
+    "attester": "node node_modules/attester/bin/attester.js test/attester.yml",
     "lint": "node node_modules/grunt/bin/grunt checkStyle",
     "test": "npm run-script lint && npm run-script attester && npm run-script grunt"
   },


### PR DESCRIPTION
Type in the console e.g.
 `npm config set ariatemplates:phantomjsInstances 4`
to change the default to 4.

See #335.

This depends on the pull request in Attester. Before integrating, the version of Attester in `package.json` should be bumped and included in this pull request's commit.
