### PR TITLE
feat #80 bindable width and height for containers

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -106,24 +106,24 @@ Aria.beanDefinitions({
             $properties : {
                 "height" : {
                     $type : "json:Integer",
-                    $description : "Widget height in pixel - note: some widgets may ignore this property. If negative, the height will be considered as unset and the widget will use the most appropriate height when possible",
+                    $description : "Widget height in pixels - note: some widgets may ignore this property. If negative, the height will be considered as unset and the widget will use the most appropriate height when possible",
                     $default : -1
                 },
                 "minWidth" : {
                     $type : "json:Integer",
-                    $description : "Minimum widget width in pixel - note: some widgets may ignore this property. This requires width unset/equals to -1."
+                    $description : "Minimum widget width in pixels - note: some widgets may ignore this property. This requires width unset/equals to -1. Note that this might be constrained further for some widgets to fit into viewport if the viewport is not big enough."
                 },
                 "maxWidth" : {
                     $type : "json:Integer",
-                    $description : "Maximum widget width in pixel - note: some widgets may ignore this property. This requires width unset/equals to -1."
+                    $description : "Maximum widget width in pixels - note: some widgets may ignore this property. This requires width unset/equals to -1."
                 },
                 "minHeight" : {
                     $type : "json:Integer",
-                    $description : "Minimum widget height in pixel - note: some widgets may ignore this property. This requires height unset/equals to -1."
+                    $description : "Minimum widget height in pixels - note: some widgets may ignore this property. This requires height unset/equals to -1. Note that this might be constrained further for some widgets to fit into viewport if the viewport is not big enough."
                 },
                 "maxHeight" : {
                     $type : "json:Integer",
-                    $description : "Maximum widget height in pixel - note: some widgets may ignore this property. This requires height unset/equals to -1."
+                    $description : "Maximum widget height in pixels - note: some widgets may ignore this property. This requires height unset/equals to -1."
                 },
                 "scrollBarX" : {
                     $type : "json:Boolean",
@@ -1038,10 +1038,37 @@ Aria.beanDefinitions({
             $type : "ResizableWidgetCfg",
             $description : "The base configuration for the div widget",
             $properties : {
+                "bind" : {
+                    $type : "ResizableWidgetCfg.bind",
+                    $properties : {
+                        "width" : {
+                            $type : "common:BindingRef"
+                        },
+                        "height" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
                 "cssClass" : {
                     $type : "json:String",
                     $description : "A string to be used to inject a Class into the main content area",
                     $default : ""
+                },
+                "minWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.minWidth",
+                    $description : "Minimum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width). Note that this might be constrained further for some widgets to fit into viewport if the viewport is not big enough."
+                },
+                "maxWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.maxWidth",
+                    $description : "Maximum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width)."
+                },
+                "minHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.minHeight",
+                    $description : "Minimum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height). Note that this might be constrained further for some widgets to fit into viewport if the viewport is not big enough."
+                },
+                "maxHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.maxHeight",
+                    $description : "Maximum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height)."
                 }
             }
         },
@@ -1434,12 +1461,11 @@ Aria.beanDefinitions({
             }
         },
         "DialogCfg" : {
-            $type : "DivCfg", // It would be cleaner to put here
-            // ResizableWidgetCfg instead
+            $type : "DivCfg", // It would be cleaner to put here ResizableWidgetCfg instead
             $description : "The base configuration for the Dialog widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "DivCfg.bind",
                     $properties : {
                         "visible" : {
                             $type : "common:BindingRef"
@@ -1552,6 +1578,17 @@ Aria.beanDefinitions({
             $type : "ResizableWidgetCfg",
             $description : "The base configuration for the Fieldset widget",
             $properties : {
+                "bind" : {
+                    $type : "WidgetCfg.bind",
+                    $properties : {
+                        "width" : {
+                            $type : "common:BindingRef"
+                        },
+                        "height" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
                 "onSubmit" : {
                     $type : "common:Callback",
                     $description : "Callback function called when the user presses ENTER in a field inside the fieldset."
@@ -1559,6 +1596,22 @@ Aria.beanDefinitions({
                 "label" : {
                     $type : "json:String",
                     $description : "Text to put on the fieldset to describe its content."
+                },
+                "minWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.minWidth",
+                    $description : "Minimum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width)."
+                },
+                "maxWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.maxWidth",
+                    $description : "Maximum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width)."
+                },
+                "minHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.minHeight",
+                    $description : "Minimum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height)."
+                },
+                "maxHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.maxHeight",
+                    $description : "Maximum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height)."
                 }
             }
         },
@@ -1592,11 +1645,17 @@ Aria.beanDefinitions({
         },
         "TabPanelCfg" : {
             $type : "ContainerCfg",
-            $description : "The base configuration for the Tab widget",
+            $description : "The base configuration for the TabPanel widget",
             $properties : {
                 "bind" : {
                     $type : "WidgetCfg.bind",
                     $properties : {
+                        "width" : {
+                            $type : "common:BindingRef"
+                        },
+                        "height" : {
+                            $type : "common:BindingRef"
+                        },
                         "selectedTab" : {
                             $type : "common:BindingRef"
                         }
@@ -1614,6 +1673,22 @@ Aria.beanDefinitions({
                 "block" : {
                     $type : "WidgetCfg.block",
                     $default : true
+                },
+                "minWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.minWidth",
+                    $description : "Minimum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width)."
+                },
+                "maxWidth" : {
+                    $type : "ResizableWidgetCfg.$properties.maxWidth",
+                    $description : "Maximum widget width in pixels. Works also when width is defined and > 0 (to allow constraints on bindable width)."
+                },
+                "minHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.minHeight",
+                    $description : "Minimum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height)."
+                },
+                "maxHeight" : {
+                    $type : "ResizableWidgetCfg.$properties.maxHeight",
+                    $description : "Maximum widget height in pixels. Works also when height is defined and > 0 (to allow constraints on bindable height)."
                 }
             }
         },

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -276,7 +276,7 @@ Aria.classDefinition({
         },
 
         /**
-         * Internal method called when one of the model property that the widget is bound to has changed Must be
+         * Internal method called when one of the model property that the widget is bound to has changed. Must be
          * overridden by sub-classes defining bindable properties
          * @param {String} propertyName the property name
          * @param {Object} newValue the new value
@@ -319,6 +319,15 @@ Aria.classDefinition({
             } else if (propertyName === "center") {
                 this._cfg.center = newValue;
                 this.updatePosition();
+            } else if (propertyName === "width" || propertyName === "height") {
+                if (this._domElt) { // if bound property changed before making the Dialog visible for the first time
+                    // resize ourself and then the contained div
+                    this.$Container._onBoundPropertyChange.apply(this, arguments);
+                    this._div.updateSize(this._cfg);
+                    if (this._cfg.center) {
+                        this.updatePosition();
+                    }
+                }
             } else {
                 // delegate to parent class
                 this.$Container._onBoundPropertyChange.apply(this, arguments);

--- a/src/aria/widgets/container/Div.js
+++ b/src/aria/widgets/container/Div.js
@@ -118,14 +118,8 @@ Aria.classDefinition({
                 hasChanged = true;
             }
             if (hasChanged) {
-                /*
-                 * // Change width and height if it's too large compared to the viewport var viewport =
-                 * aria.utils.Dom._getViewportSize(); if (viewport.width < this._cfg.width) { this._cfg.width =
-                 * viewport.width; } if (viewport.height < this._cfg.height) { this._cfg.height = viewport.height; }
-                 */
-                this.$Container._updateContainerSize.call(this);
+                this.$Container._updateSize.call(this);
             }
-
         }
     }
 });

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -27,6 +27,8 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.DivTest");
         this.addTests("test.aria.widgets.container.FieldsetTest");
         this.addTests("test.aria.widgets.container.SplitterTest");
+        this.addTests("test.aria.widgets.container.dialog.HeightConstraintsTest");
+        this.addTests("test.aria.widgets.container.issue80.BindableSizeTestSuite");
         this.addTests("test.aria.widgets.controllers.SelectBoxControllerTest");
         this.addTests("test.aria.widgets.controllers.SelectControllerTest");
         this.addTests("test.aria.widgets.environment.WidgetSettings");

--- a/test/aria/widgets/container/dialog/HeightConstraintsTest.js
+++ b/test/aria/widgets/container/dialog/HeightConstraintsTest.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.container.Dialog
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.HeightConstraintsTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        // keep in sync with maxHeight in TPL
+        this.MAX_HEIGHT = 400;
+        this.MIN_HEIGHT = 150;
+        this.INITIAL_NUMBER_OF_LINES = 10;
+
+        this.data = {
+            dialogNoOfLines : this.INITIAL_NUMBER_OF_LINES
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.HeightConstraintsTestTpl",
+            data : this.data
+        });
+
+        this.widgetUnderTestId = "dialogWithConstraints";
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this._testInitialSize();
+            this._testExpandingBeyondMax();
+            this._testFurtherExpanding();
+            this._testShrinkingToInitial();
+            this._testShrinkingBelowMin();
+            this._testShrinkingEvenFurther();
+            this.finish();
+        },
+
+        _testInitialSize : function () {
+            // initially, the dialog has moderate number of lines and the height is automatic, between the min height
+            // and max height (can be several pixels difference between various browsers)
+            var h = this.__getDialogHeight();
+            this._initialHeight = h; // store for a later checkup
+            this.assertTrue(this.MIN_HEIGHT < h && h < this.MAX_HEIGHT, "Initial height should be between min and max");
+        },
+
+        _testExpandingBeyondMax : function () {
+            // after putting too many lines, we should not exceed MAX_HEIGHT
+            aria.utils.Json.setValue(this.data, "dialogNoOfLines", 50);
+            this.assertEquals(this.__getDialogHeight(), this.MAX_HEIGHT);
+        },
+
+        _testFurtherExpanding : function () {
+            // when in MAX_HEIGHT, increasing the contents further, should not change the height
+            aria.utils.Json.setValue(this.data, "dialogNoOfLines", 80);
+            this.assertEquals(this.__getDialogHeight(), this.MAX_HEIGHT);
+        },
+
+        _testShrinkingToInitial : function () {
+            // when returning to the initial contents, we should get the same height
+            aria.utils.Json.setValue(this.data, "dialogNoOfLines", this.INITIAL_NUMBER_OF_LINES);
+            var h = this.__getDialogHeight();
+            this.assertEquals(h, this._initialHeight, "Expected to shrink to initial (%2) but got %1 after shrinking");
+        },
+
+        _testShrinkingBelowMin : function () {
+            // set very small number of lines, we should not shrink below MIN_HEIGHT
+            aria.utils.Json.setValue(this.data, "dialogNoOfLines", 3);
+            this.assertEquals(this.__getDialogHeight(), this.MIN_HEIGHT);
+        },
+
+        _testShrinkingEvenFurther : function () {
+            // while in MIN_HEIGHT, reduce number of lines further; height should not change
+            aria.utils.Json.setValue(this.data, "dialogNoOfLines", 1);
+            this.assertEquals(this.__getDialogHeight(), this.MIN_HEIGHT);
+        },
+
+        finish : function () {
+            this.notifyTemplateTestEnd();
+        },
+
+        __getDialogHeight : function () {
+            var container = this.getWidgetInstance(this.widgetUnderTestId);
+            var geometry = aria.utils.Dom.getGeometry(container.getDom());
+            return geometry.height;
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/HeightConstraintsTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/HeightConstraintsTestTpl.tpl
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.dialog.HeightConstraintsTestTpl'
+}}
+
+{macro main()}
+    {@aria:Dialog {
+        id : "dialogWithConstraints",
+        title: "Dialog with constraints",
+        contentMacro : "dialogContent",
+        visible : true,
+        width : 500,
+        maxHeight : 400,
+        minHeight : 150
+    }/}
+{/macro}
+
+{macro dialogContent()}
+    {section {
+        id : "testSection",
+        macro : "sectionContent",
+        bindRefreshTo : [{
+            inside : data,
+            to : "dialogNoOfLines"
+        }]
+    } /}
+{/macro}
+
+{macro sectionContent()}
+    {for var i = 0; i < data.dialogNoOfLines; i++}
+        line ${i} <br/>
+    {/for}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/BindableSizeTestSuite.js
+++ b/test/aria/widgets/container/issue80/BindableSizeTestSuite.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.BindableSizeTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+        var packageName = this.$package;
+        this.addTests(packageName + ".DialogTest");
+        this.addTests(packageName + ".DivTest");
+        this.addTests(packageName + ".FieldsetTest");
+        this.addTests(packageName + ".TabpanelTest");
+    }
+});

--- a/test/aria/widgets/container/issue80/DialogTest.js
+++ b/test/aria/widgets/container/issue80/DialogTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.container.Dialog
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.DialogTest",
+    $extends : "test.aria.widgets.container.issue80.shared.BindableSizeTestCase",
+    $constructor : function () {
+        this._tplClasspath = "test.aria.widgets.container.issue80.DialogTestTpl";
+        this.$BindableSizeTestCase.constructor.call(this);
+    },
+    $prototype : {
+        /**
+         * @override
+         */
+        _testNoConstraints : function () {
+            this._widgetUnderTestId = 'dialogNoConstraints';
+            this._widgetUnderTestToggleVisibility = true;
+            this._testNoConstraintsStart();
+        },
+
+        /**
+         * @override
+         */
+        _testWithConstraints : function () {
+            this._widgetUnderTestId = 'dialogWithConstraints';
+            this._widgetUnderTestToggleVisibility = true;
+            this._testWithConstraintsStart();
+        }
+    }
+});

--- a/test/aria/widgets/container/issue80/DialogTestTpl.tpl
+++ b/test/aria/widgets/container/issue80/DialogTestTpl.tpl
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.issue80.DialogTestTpl',
+    $extends : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTpl'
+}}
+
+{macro noConstraints()}
+    {@aria:Dialog {
+        id : "dialogNoConstraints",
+        title: "Test1",
+        contentMacro : "contentMacroLong",
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            },
+            visible : {
+              to : "dialogNoConstraints",
+              inside: data.visible
+            }
+        }
+    }/}
+{/macro}
+{macro withConstraints()}
+    {@aria:Dialog {
+        id : "dialogWithConstraints",
+        title: "Test2",
+        contentMacro : "contentMacroLong",
+        maxWidth: 333,
+        maxHeight: 333,
+        minWidth: 111,
+        minHeight: 111,
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            },
+            visible : {
+              to : "dialogWithConstraints",
+              inside: data.visible
+            }
+        }
+    }/}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/DivTest.js
+++ b/test/aria/widgets/container/issue80/DivTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.container.Div
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.DivTest",
+    $extends : "test.aria.widgets.container.issue80.shared.BindableSizeTestCase",
+    $constructor : function () {
+        this._tplClasspath = "test.aria.widgets.container.issue80.DivTestTpl";
+        this.$BindableSizeTestCase.constructor.call(this);
+    },
+    $prototype : {
+        /**
+         * @override
+         */
+        _testNoConstraints : function () {
+            this._widgetUnderTestId = 'divNoConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testNoConstraintsStart();
+        },
+
+        /**
+         * @override
+         */
+        _testWithConstraints : function () {
+            this._widgetUnderTestId = 'divWithConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testWithConstraintsStart();
+        }
+    }
+});

--- a/test/aria/widgets/container/issue80/DivTestTpl.tpl
+++ b/test/aria/widgets/container/issue80/DivTestTpl.tpl
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.issue80.DivTestTpl',
+    $extends : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTpl'
+}}
+
+{macro noConstraints()}
+    <span style="border:1px solid green; display: inline-block">
+    {@aria:Div {
+        id : "divNoConstraints",
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            }
+        }
+    }}
+        {call contentMacroLong() /}
+    {/@aria:Div}
+    </span>
+{/macro}
+{macro withConstraints()}
+    <span style="border:1px solid green; display: inline-block">
+    {@aria:Div {
+        id : "divWithConstraints",
+        maxWidth: 333,
+        maxHeight: 333,
+        minWidth: 111,
+        minHeight: 111,
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            }
+        }
+    }}
+        {call contentMacroLong() /}
+    {/@aria:Div}
+    </span>
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/FieldsetTest.js
+++ b/test/aria/widgets/container/issue80/FieldsetTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.container.Fieldset
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.FieldsetTest",
+    $extends : "test.aria.widgets.container.issue80.shared.BindableSizeTestCase",
+    $constructor : function () {
+        this._tplClasspath = "test.aria.widgets.container.issue80.FieldsetTestTpl";
+        this.$BindableSizeTestCase.constructor.call(this);
+    },
+    $prototype : {
+        /**
+         * @override
+         */
+        _testNoConstraints : function () {
+            this._widgetUnderTestId = 'fsNoConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testNoConstraintsStart();
+        },
+
+        /**
+         * @override
+         */
+        _testWithConstraints : function () {
+            this._widgetUnderTestId = 'fsWithConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testWithConstraintsStart();
+        }
+    }
+});

--- a/test/aria/widgets/container/issue80/FieldsetTestTpl.tpl
+++ b/test/aria/widgets/container/issue80/FieldsetTestTpl.tpl
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.issue80.FieldsetTestTpl',
+    $extends : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTpl'
+}}
+
+{macro noConstraints()}
+    {@aria:Fieldset {
+        id : "fsNoConstraints",
+        label : "fsNoConstraints",
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            }
+        }
+    }}
+        {call contentMacroLong() /}
+    {/@aria:Fieldset}
+{/macro}
+{macro withConstraints()}
+    {@aria:Fieldset {
+        id : "fsWithConstraints",
+        label : "fsWithConstraints",
+        maxWidth: 333,
+        maxHeight: 333,
+        minWidth: 111,
+        minHeight: 111,
+        bind : {
+            width : {
+              to : "width",
+              inside : data
+            },
+            height : {
+              to : "height",
+              inside : data
+            }
+        }
+    }}
+        {call contentMacroLong() /}
+    {/@aria:Fieldset}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/TabpanelTest.js
+++ b/test/aria/widgets/container/issue80/TabpanelTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.container.TabPanel
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.TabpanelTest",
+    $extends : "test.aria.widgets.container.issue80.shared.BindableSizeTestCase",
+    $constructor : function () {
+        this._tplClasspath = "test.aria.widgets.container.issue80.TabpanelTestTpl";
+        this.$BindableSizeTestCase.constructor.call(this);
+    },
+    $prototype : {
+        /**
+         * @override
+         */
+        _testNoConstraints : function () {
+            this._widgetUnderTestId = 'tpNoConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testNoConstraintsStart();
+        },
+
+        /**
+         * @override
+         */
+        _testWithConstraints : function () {
+            this._widgetUnderTestId = 'tpWithConstraints';
+            this._widgetUnderTestToggleVisibility = false;
+            this._testWithConstraintsStart();
+        }
+    }
+});

--- a/test/aria/widgets/container/issue80/TabpanelTestTpl.tpl
+++ b/test/aria/widgets/container/issue80/TabpanelTestTpl.tpl
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.issue80.TabpanelTestTpl',
+    $extends : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTpl'
+}}
+
+{macro main()}
+    {@aria:Tab {
+        tabId: "tab1",
+        bind : {
+          selectedTab : {
+            to : "selectedTabId",
+            inside : data
+          }
+        }
+    }}
+        {call _tabContent(1) /}
+    {/@aria:Tab}
+    {@aria:Tab {
+        tabId: "tab2",
+        bind : {
+          selectedTab : {
+            to : "selectedTabId",
+            inside : data
+          }
+        }
+    }}
+        {call _tabContent(2) /}
+    {/@aria:Tab}
+
+    <br />
+
+    {call noConstraints() /}
+    {call withConstraints() /}
+{/macro}
+
+{macro noConstraints()}
+    <span style="border:1px solid red; display: inline-block">
+    {@aria:TabPanel {
+        id : "tpNoConstraints",
+        macro: "_tabPanelMacro",
+        bind : {
+          width : {
+            to : "width",
+            inside : data
+          },
+          height : {
+            to : "height",
+            inside : data
+          },
+          selectedTab : {
+            to : "selectedTabId",
+            inside : data
+          }
+        }
+    }/}
+    </span>
+{/macro}
+{macro withConstraints()}
+    <span style="border:1px solid red; display: inline-block">
+    {@aria:TabPanel {
+        id : "tpWithConstraints",
+        macro: "_tabPanelMacro",
+        maxWidth: 333,
+        maxHeight: 333,
+        minWidth: 111,
+        minHeight: 111,
+        bind : {
+          width : {
+            to : "width",
+            inside : data
+          },
+          height : {
+            to : "height",
+            inside : data
+          },
+          selectedTab : {
+            to : "selectedTabId",
+            inside : data
+          }
+        }
+    }/}
+    </span>
+{/macro}
+
+{macro _tabPanelMacro()}
+    Selected tab: ${data.selectedTabId}
+{/macro}
+
+{macro _tabContent(tid)}
+    Tab ${tid}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/shared/BindableSizeTestCase.js
+++ b/test/aria/widgets/container/issue80/shared/BindableSizeTestCase.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Generic test case class to check if constraints are preserved when the size is bindable. Usage: inherit from this
+ * class and override the methods _testNoConstraints and _testWithConstraints with your test code.
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.issue80.shared.BindableSizeTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        /**
+         * Used to check if the subclass passed all the necessary config variables.
+         */
+        this._isTestCfgValid = true;
+
+        // keep the values below in sync with the config of the widgets with constraints in TPLs
+        this.MIN_WIDTH = 111;
+        this.MIN_HEIGHT = 111;
+
+        this.DEFAULT_WIDTH = 200;
+        this.DEFAULT_HEIGHT = 200;
+
+        this.MAX_WIDTH = 333;
+        this.MAX_HEIGHT = 333;
+
+        this.data = {
+            width : this.DEFAULT_WIDTH,
+            height : this.DEFAULT_HEIGHT,
+            visible : { // only for dialog tests
+                dialogNoConstraints : false,
+                dialogWithConstraints : false
+            },
+            selectedTabId : "tab1" // only for tabpanel tests
+        };
+
+        // setTestEnv has to be invoked before runTemplateTest fires
+        if (this._tplClasspath) {
+            this.setTestEnv({
+                template : this._tplClasspath,
+                data : this.data
+            });
+        } else {
+            this._isTestCfgValid = false;
+        }
+
+        this._widgetUnderTestId = null;
+        this._widgetUnderTestToggleVisibility = false;
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.assertTrue(this._isTestCfgValid, "Invalid test configuration. The subclass didn't provide _tplClasspath value.");
+
+            this._testNoConstraints();
+            this._testWithConstraints();
+
+            this.finish();
+        },
+
+        /* override me in the subclass */
+        _testNoConstraints : function () {},
+
+        /* override me in the subclass */
+        _testWithConstraints : function () {},
+
+        _testNoConstraintsStart : function () {
+
+            // no constraints on the dialog -> each width/height change should be reflected
+            if (this._widgetUnderTestToggleVisibility) {
+                aria.utils.Json.setValue(this.data.visible, this._widgetUnderTestId, true);
+            }
+
+            this.__checkGeometry(this._widgetUnderTestId, this.DEFAULT_WIDTH, this.DEFAULT_HEIGHT);
+
+            this.__setWidthAndHeight(this.MAX_WIDTH + 20, this.MAX_HEIGHT + 20);
+            this.__checkGeometry(this._widgetUnderTestId, this.MAX_WIDTH + 20, this.MAX_HEIGHT + 20);
+
+            this.__setWidthAndHeight(this.MIN_WIDTH - 20, this.MIN_WIDTH - 20);
+            this.__checkGeometry(this._widgetUnderTestId, this.MIN_WIDTH - 20, this.MIN_WIDTH - 20);
+
+            if (this._widgetUnderTestToggleVisibility) {
+                aria.utils.Json.setValue(this.data.visible, this._widgetUnderTestId, false);
+            }
+        },
+
+        _testWithConstraintsStart : function () {
+            // let's check what happens if we put values lower than minWidth/minHeight into
+            // data model before the dialog is shown for the first time
+            // the values should be actually changed to minWidth/minHeight
+            this.__setWidthAndHeight(this.MIN_WIDTH - 20, this.MIN_HEIGHT - 20);
+            if (this._widgetUnderTestToggleVisibility) {
+                aria.utils.Json.setValue(this.data.visible, this._widgetUnderTestId, true);
+            }
+            this.__checkGeometry(this._widgetUnderTestId, this.MIN_WIDTH, this.MIN_HEIGHT);
+
+            // now let's increase the value to exceed the maxWidth/maxHeight...
+            // the values should be changed to maxWidth/maxHeight
+            this.__setWidthAndHeight(this.MAX_WIDTH + 20, this.MAX_HEIGHT + 20);
+            this.__checkGeometry(this._widgetUnderTestId, this.MAX_WIDTH, this.MAX_HEIGHT);
+
+            // let's set valid values; they should be unchanged
+            var acceptedWidth = Math.floor((this.MAX_WIDTH - this.MIN_WIDTH) / 2);
+            var acceptedHeight = Math.floor((this.MAX_HEIGHT - this.MIN_HEIGHT) / 2);
+            this.__setWidthAndHeight(acceptedWidth, acceptedHeight);
+            this.__checkGeometry(this._widgetUnderTestId, acceptedWidth, acceptedHeight);
+
+            if (this._widgetUnderTestToggleVisibility) {
+                aria.utils.Json.setValue(this.data.visible, this._widgetUnderTestId, false);
+            }
+        },
+
+        finish : function () {
+            this.notifyTemplateTestEnd();
+        },
+
+        __reset : function () {
+            this.__setWidthAndHeight(this.DEFAULT_WIDTH, this.DEFAULT_WIDTH);
+        },
+
+        __setWidthAndHeight : function (width, height) {
+            aria.templates.RefreshManager.stop();
+            aria.utils.Json.setValue(this.data, 'width', width);
+            aria.utils.Json.setValue(this.data, 'height', height);
+            aria.templates.RefreshManager.resume();
+        },
+
+        __checkGeometry : function (widgetId, expectedWidth, expectedHeight) {
+            var container = this.getWidgetInstance(widgetId);
+            var geometry = aria.utils.Dom.getGeometry(container.getDom());
+            var wut = this._widgetUnderTestId;
+
+            this.assertEquals(geometry.width, expectedWidth, 'Expected width of ' + wut + ' was %2, but got %1');
+            this.assertEquals(geometry.height, expectedHeight, 'Expected height of ' + wut + ' was %2, but got %1.');
+        }
+    }
+});

--- a/test/aria/widgets/container/issue80/shared/BindableSizeTestTpl.tpl
+++ b/test/aria/widgets/container/issue80/shared/BindableSizeTestTpl.tpl
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTpl',
+    $hasScript : true
+}}
+
+{macro main()}
+    {call noConstraints() /}
+    {call withConstraints() /}
+{/macro}
+
+/* override me */
+{macro noConstraints()}
+{/macro}
+
+/* override me */
+{macro withConstraints()}
+{/macro}
+
+{macro contentMacroLong()}
+    There <br> is <br> really <br> lots <br> lots <br> lots <br> lots <br>
+    lots <br> lots <br> lots <br> lots <br>of <br> lines <br> here.
+{/macro}
+
+{macro putButtons()}
+    // buttons for manual testing
+    {@aria:Button {
+      label : "Resize +40",
+      onclick : {
+        fn : buttonClickPlus
+      }
+    }/}
+    {@aria:Button {
+      label : "Resize -30",
+      onclick : {
+        fn : buttonClickMinus
+      }
+    }/}
+    {@aria:Button {
+      label : "Resize to 166",
+      onclick : {
+        fn : buttonClick166
+      }
+    }/}
+    {@aria:Button {
+      label : "Resize to 666",
+      onclick : {
+        fn : buttonClick666
+      }
+    }/}
+    {@aria:Button {
+      label : "Resize to 400x300",
+      onclick : {
+        fn : buttonClick400x300
+      }
+    }/}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/issue80/shared/BindableSizeTestTplScript.js
+++ b/test/aria/widgets/container/issue80/shared/BindableSizeTestTplScript.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.container.issue80.shared.BindableSizeTestTplScript',
+    $prototype : {
+        buttonClickPlus : function () {
+            this.$json.setValue(this.data, "width", this.data.width + 40);
+            this.$json.setValue(this.data, "height", this.data.height + 40);
+        },
+        buttonClickMinus : function () {
+            this.$json.setValue(this.data, "width", this.data.width - 30);
+            this.$json.setValue(this.data, "height", this.data.height - 30);
+        },
+        buttonClick166 : function () {
+            this.$json.setValue(this.data, "width", 166);
+            this.$json.setValue(this.data, "height", 166);
+        },
+        buttonClick666 : function () {
+            this.$json.setValue(this.data, "width", 666);
+            this.$json.setValue(this.data, "height", 666);
+        },
+        buttonClick400x300 : function () {
+            this.$json.setValue(this.data, "width", 400);
+            this.$json.setValue(this.data, "height", 300);
+        }
+    }
+});


### PR DESCRIPTION
Adds possibility to bind width and height for some of container-based widgets (Div, Dialog, Fieldset, TabPanel). The bound size is a subject to min/max size constraints for all of those widgets.

This commit lifts the requirement for widgets to have width/height = -1 for min/max width/height to work. So this is backward-incompatible change in some way, but the behavior of width & maxwidth etc. when provided
together was undefined earlier, so it should not have relied upon by anyone.

Close #80.
