### PR TITLE
fix #364 File names with multiple dots in atmapreader grunt task

### DIFF
--- a/build/grunt-tasks/task-atmapreader.js
+++ b/build/grunt-tasks/task-atmapreader.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
             if(typeof map[k] === 'object') {
                 prepareDownloadMgrMap(map[k]);
             } else if(k.indexOf('.') !== -1) {
-                map[k.substring(0, k.indexOf('.'))] = map[k];
+                map[k.substring(0, k.lastIndexOf('.'))] = map[k];
                 delete map[k];
             }
         }


### PR DESCRIPTION
There is a discrepency between the `atmapreader` grunt task and
`aria.core.DownloadMgr.resolveURL`.

When removing the extension, the grunt task is looking for the
first dot, whereas the `DownloadMgr` is looking for the last dot,
so that there is a problem for files containing multiple
dots (such as `.tpl.txt`, `.tpl.css`).

This pull request fixes the `atmapreader` grunt task to match the behavior
of the `DownloadMgr`.
