### PR TITLE
fix #369 AT Debug Tools is not starting on IE

### DIFF
--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -395,7 +395,6 @@
              * @return the value returned by the callback, or undefined if the callback could not be called.
              */
             $callback : function (cb, res, errorId) {
-
                 if (!cb) {
                     return; // callback is sometimes not used
                 }
@@ -427,7 +426,7 @@
                 }
 
                 try {
-                    return callback.apply(scope, args);
+                    return Function.prototype.apply.call(callback, scope, args);
                 } catch (ex) {
                     this.$logError(errorId || this.CALLBACK_ERROR, [this.$classpath, scope.$classpath], ex);
                 }
@@ -624,8 +623,14 @@
                         this.$logError(this.UNDECLARED_EVENT, evt, src.$classpath);
                         continue;
                     }
-                    if (!lsn.fn) {
-                        // shortcut as in 'error' sample
+                    if (lsn.$Callback) {
+                        lsn = {
+                            fn : function (evt, cb) {cb.call(evt)},
+                            scope : this,
+                            args : lsn
+                        };
+                    } else if (!lsn.fn) {
+                         // shortcut as in 'error' sample
                         if (!defaultScope) {
                             this.$logError(this.MISSING_SCOPE, evt);
                             continue;

--- a/test/aria/core/CoreTestSuite.js
+++ b/test/aria/core/CoreTestSuite.js
@@ -46,5 +46,6 @@ Aria.classDefinition({
         this.addTests("test.aria.core.TplClassLoaderErrorTest");
         this.addTests("test.aria.core.io.IOTestSuite");
         this.addTests("test.aria.core.CSSPrefixTest");
+        this.addTests("test.aria.core.OnCallbackTest");
     }
 });

--- a/test/aria/core/FakeEvent.js
+++ b/test/aria/core/FakeEvent.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.core.FakeEvent",
+    $events : {
+        "fakeevent" : {
+            description : "This is a fake event."
+        }
+    },
+    $singleton : true,
+    $prototype : {
+    }
+});

--- a/test/aria/core/OnCallbackTest.js
+++ b/test/aria/core/OnCallbackTest.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for the $on callback
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.core.OnCallbackTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.Callback", "test.aria.core.FakeEvent"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.callback = {};
+    },
+    $destructor : function () {
+        this.callback.$dispose();
+        this.$TestCase.$destructor.call(this);
+    },
+    $prototype : {
+
+        testOnCallback : function () {
+            this.callback = new aria.utils.Callback({
+                fn : this._internalCallback,
+                scope : {test : this},
+                args : 15
+            });
+
+            test.aria.core.FakeEvent.$on({
+                'fakeevent' : this.callback,
+                scope : this
+            });
+
+            test.aria.core.FakeEvent.$raiseEvent({
+                name : 'fakeevent',
+                arg : 12
+            });
+        },
+
+        _internalCallback : function (evt, args) {
+            this.test.assertTrue(evt.arg == 12);
+            this.test.assertTrue(args == 15);
+        }
+    }
+});


### PR DESCRIPTION
The debug tools is not starting anymore after AT 1.2-4 on IE7 and IE8 due to a problem with callback.apply. IE prompts a "JScript object expetcted" error. Using Function.prototype.apply.call works fine.
