### PR TITLE
fix #273 additional whitelisted attributes

### DIFF
--- a/src/aria/templates/CfgBeans.js
+++ b/src/aria/templates/CfgBeans.js
@@ -719,6 +719,26 @@ Aria.beanDefinitions({
                 "placeholder" : {
                     $type : "json:String",
                     $description : "short hint intended to aid the user with data entry"
+                },
+                "autocomplete" : {
+                    $type : "json:String",
+                    $description : "control whether autocompletion is enabled in input fields"
+                },
+                "autofocus" : {
+                    $type : "json:String",
+                    $description : "control whether the input should receive focus automatically after displaying the page. Possible values are \"autofocus\" or an empty string"
+                },
+                "autocorrect" : {
+                    $type : "json:String",
+                    $description : "whether autocorrection is activated in an editable field. Useful for mobiles"
+                },
+                "autocapitalize" : {
+                    $type : "json:String",
+                    $description : "whether the typed text should be automatically capitalized"
+                },
+                "spellcheck" : {
+                    $type : "json:String",
+                    $description : "whether or not to check the spelling/grammar of the text in an editable element"
                 }
             }
         },

--- a/src/aria/templates/DomElementWrapper.js
+++ b/src/aria/templates/DomElementWrapper.js
@@ -304,7 +304,7 @@ Aria.classDefinition({
     },
     $statics : {
 
-        attributesWhiteList : /^(name|title|style|dir|lang|abbr|height|width|size|cols|rows|rowspan|colspan|nowrap|valign|align|border|cellpadding|cellspacing|disabled|readonly|checked|selected|multiple|value|alt|maxlength|type|accesskey|tabindex|placeholder)$/,
+        attributesWhiteList : /^(name|title|style|dir|lang|abbr|height|width|size|cols|rows|rowspan|colspan|nowrap|valign|align|border|cellpadding|cellspacing|disabled|readonly|checked|selected|multiple|value|alt|maxlength|type|accesskey|tabindex|placeholder|autocomplete|autofocus|autocorrect|autocapitalize|spellcheck)$/,
 
         // ERROR MESSAGE:
         INVALID_EXPANDO_NAME : "Invalid expando name: '%1'.",

--- a/test/aria/utils/Html.js
+++ b/test/aria/utils/Html.js
@@ -108,7 +108,12 @@ Aria.classDefinition({
                 type : "text",
                 valign : "middle",
                 value : "my value",
-                width : "100px"
+                width : "100px",
+                autocomplete : "off",
+                autofocus : "autofocus",
+                autocorrect : "on",
+                autocapitalize : "off",
+                spellcheck : "true"
 
             };
 


### PR DESCRIPTION
autofocus, autocomplete, autocapitalize, autocorrect and spellcheck attributes are now in the whitelist.
