### PR TITLE
setJsonPostData uses deprecated properties

### DIFF
--- a/src/aria/core/IOFilter.js
+++ b/src/aria/core/IOFilter.js
@@ -16,10 +16,9 @@
 /**
  * Base class for any filter that needs to be plugged on IO.
  * @see aria.core.IOFiltersMgr.addFilter()
- * @class aria.core.IOFilter
  */
 Aria.classDefinition({
-    $classpath : 'aria.core.IOFilter',
+    $classpath : "aria.core.IOFilter",
     $constructor : function (args) {
         /**
          * Delay (in milliseconds) to be added to all requests, before the request is made.
@@ -69,7 +68,7 @@ Aria.classDefinition({
          */
         setJsonPostData : function (req, jsonData) {
             // cf aria.modules.RequestMgr._callAsyncRequest:
-            req.postData = 'data=' + aria.utils.Json.convertToJsonString(jsonData, {
+            req.data = 'data=' + aria.utils.Json.convertToJsonString(jsonData, {
                 encodeParameters : true
             });
         },


### PR DESCRIPTION
Instead of using the deprecated `jsonData` now use the standard `data` property to encode data information from a request filter.

Fixes #373
