### PR TITLE
Fix #379 TemplateCtxt.getDomId does not support integers.

### DIFF
--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -1318,9 +1318,11 @@
 
             /**
              * Return the generated domId for specified id.
+             * @param {String|Number} id specified in the template
              * @return {String}
              */
             getDomId : function (id) {
+                var id = id + "";
                 if (id && id.indexOf("+") != -1) {
                     if (Aria.testMode) {
                         return this.$getAutoId(id);


### PR DESCRIPTION
Please integrate, thanks!
