### PR TITLE
fix #349 maximizable Dialog service pack

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -235,17 +235,35 @@ Aria.classDefinition({
          * iframe.
          * @param {String} iframeId HTML id of the iframe element
          * @param {String} widgetId id of the Aria Templates widget inside the iframe for which we want to wait
+         * @param {Array} widgetProps names of properties to check for being non-null in widget with id `widgetId`. Pass
+         * null if not needed.
          * @param {Function} continueWith Callback to be executed when iframe is ready (within "this" scope)
          */
-        waitForIframe : function (iframeId, widgetId, continueWith) {
+        waitForIframe : function (iframeId, widgetId, widgetProps, continueWith) {
             var iframe = aria.utils.Dom.getElementById(iframeId);
             this.waitFor({
                 condition : function () {
-                    return Aria.$window.iframeLoaded && iframe.contentWindow.aria != null
+                    var widgetLoaded = Aria.$window.iframeLoaded && iframe.contentWindow.aria != null
                             && iframe.contentWindow.aria.templates != null
                             // Mandatory check, otherwise getWidgetInstanceInIframe raises a JS error in the test suite
                             && iframe.contentWindow.aria.templates.RefreshManager != null
                             && this.getWidgetInstanceInIframe(iframe, widgetId) != null;
+
+                    if (!widgetLoaded) {
+                        return false;
+                    }
+
+                    if (widgetProps) {
+                        var widget = this.getWidgetInstanceInIframe(iframe, widgetId);
+                        for (var i = 0, len = widgetProps.length; i < len; i++) {
+                            var propName = widgetProps[i];
+                            if (widget[propName] == null) {
+                                return false;
+                            }
+                        }
+                    }
+
+                    return true;
                 },
                 callback : {
                     fn : continueWith,

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1563,7 +1563,7 @@ Aria.beanDefinitions({
                 },
                 "maximizable" : {
                     $type : "json:Boolean",
-                    $description : "Whether the dialog has a maximize button in its title bar.",
+                    $description : "Whether the dialog has a maximize button in its title bar. Note that you can set this to false and programatically maximize the Dialog to achieve a fullscreen-only Dialog solution.",
                     $default : false
                 },
                 "closeOnMouseClick" : {

--- a/src/aria/widgets/container/Container.js
+++ b/src/aria/widgets/container/Container.js
@@ -106,22 +106,26 @@ Aria.classDefinition({
             // PROFILING // this.$logTimestamp("updateContainerSize");
             var cfg = this._cfg, domElt = this.getDom();
 
-            if (!domElt)
+            if (!domElt) {
                 return;
+            }
 
             var widthConf = this._getWidthConf();
             var heightConf = this._getHeightConf();
 
             if (this._changedContainerSize || this._sizeConstraints) { // if we are bound to min and max size
                 if (this._changedContainerSize) {
-                    var constrainedWidth = aria.utils.Math.normalize(cfg.width, widthConf.min, widthConf.max);
-                    var constrainedHeight = aria.utils.Math.normalize(cfg.height, heightConf.min, heightConf.max);
+                    // when maximized from start, widthMaximized will be empty initially, but it'll be adjusted later
+                    var width = cfg.widthMaximized || cfg.width;
+                    var height = cfg.heightMaximized || cfg.height;
+                    var constrainedWidth = aria.utils.Math.normalize(width, widthConf.min, widthConf.max);
+                    var constrainedHeight = aria.utils.Math.normalize(height, heightConf.min, heightConf.max);
 
-                    domElt.style.width = cfg.width > -1 ? constrainedWidth + "px" : "";
-                    domElt.style.height = cfg.height > -1 ? constrainedHeight + "px" : "";
+                    domElt.style.width = width > -1 ? constrainedWidth + "px" : "";
+                    domElt.style.height = height > -1 ? constrainedHeight + "px" : "";
                     if (this._frame) { // this is required if the frame is being shrinked
-                        var frameWidth = cfg.width > -1 ? constrainedWidth : -1;
-                        var frameHeight = cfg.height > -1 ? constrainedHeight : -1;
+                        var frameWidth = width > -1 ? constrainedWidth : -1;
+                        var frameHeight = height > -1 ? constrainedHeight : -1;
                         this._frame.resize(frameWidth, frameHeight);
                     }
                 }

--- a/src/aria/widgets/container/Div.js
+++ b/src/aria/widgets/container/Div.js
@@ -92,31 +92,35 @@ Aria.classDefinition({
         /**
          * Change the width, height, max width and max height of the configuration, then update the container size
          * @param {aria.widgets.CfgBeans.ActionWidgetCfg} cfg the widget configuration (only width, height, maxWidth,
-         * maxHeight will be used)
+         * maxHeight, maximized will be used)
          */
         updateSize : function (cfg) {
-            var hasChanged = false;
-            var value;
-            value = cfg.maxWidth;
-            if (value && value != this._cfg.maxWidth) {
-                this._cfg.maxWidth = value;
+            var hasChanged = false, prefName, newVal;
+            var prefs = ['maxWidth', 'maxHeight', 'width', 'height'];
+
+            for (var i = 0, len = prefs.length; i < len; i++) {
+                prefName = prefs[i];
+                newVal = cfg[prefName];
+                if (newVal && newVal != this._cfg[prefName]) {
+                    this._cfg[prefName] = newVal;
+                    hasChanged = true;
+                }
+            }
+
+            if (cfg.maximized !== this._cfg.maximized) {
+                this._cfg.maximized = cfg.maximized;
                 hasChanged = true;
             }
-            value = cfg.width;
-            if (value && value != this._cfg.width) {
-                this._cfg.width = value;
+
+            if (cfg.maximized) {
+                this._cfg.widthMaximized = cfg.widthMaximized;
+                this._cfg.heightMaximized = cfg.heightMaximized;
                 hasChanged = true;
+            } else {
+                this._cfg.widthMaximized = null;
+                this._cfg.heightMaximized = null;
             }
-            value = cfg.maxHeight;
-            if (value && value != this._cfg.maxHeight) {
-                this._cfg.maxHeight = value;
-                hasChanged = true;
-            }
-            value = cfg.height;
-            if (value && value != this._cfg.height) {
-                this._cfg.height = value;
-                hasChanged = true;
-            }
+
             if (hasChanged) {
                 this.$Container._updateSize.call(this);
             }

--- a/test/aria/widgets/container/dialog/MaximizableDialogTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/MaximizableDialogTestTpl.tpl
@@ -22,8 +22,24 @@
 
     {call makeOverflows() /}
 
+    // wrapping Dialogs in a section to simulate liquid-layout full section refresh in a test
+    {section {
+        macro : "macroWithDialogs",
+        bindRefreshTo : [{
+            inside : data,
+            to : "sectionRefreshTimeStamp"
+        }]
+    } /}
+{/macro}
+
+{macro macroWithDialogs()}
+        {call dialogMaxi() /}
+        {call dialogMaxiFromStart() /}
+{/macro}
+
+{macro dialogMaxi()}
     {@aria:Dialog {
-        id : "maxiDialog",
+        id : "dialogMaxi",
         title: "Maximizable Dialog",
         contentMacro : "dialogContent",
         center : true,
@@ -64,8 +80,49 @@
     }/}
 {/macro}
 
+{macro dialogMaxiFromStart()}
+    {@aria:Dialog {
+        id : "dialogMaxiFromStart",
+        contentMacro : "dialogContent",
+        center : false, // true is the default, we want to override it
+        movable : true,
+        resizable : true,
+        maximizable : true,
+        bind : {
+            width : {
+                inside : data.dialogMaxiFromStart,
+                to : "width"
+            },
+            height : {
+                inside : data.dialogMaxiFromStart,
+                to : "height"
+            },
+            xpos : {
+                inside : data.dialogMaxiFromStart,
+                to : "xpos"
+            },
+            ypos : {
+                inside : data.dialogMaxiFromStart,
+                to : "ypos"
+            },
+            visible : {
+                inside : data.dialogMaxiFromStart,
+                to : "visible"
+            },
+            maximized : {
+                inside : data.dialogMaxiFromStart,
+                to : "maximized"
+            }
+        }
+    }/}
+{/macro}
+
 {macro dialogContent()}
-    {for var i = 0; i < 15; i++}
+    <p>
+        {for var j=0; j<14; j++}Lorem ipsum dolor sit amet {/for}
+    </p>
+
+    {for var i = 0; i < 45; i++}
         line ${i} <br/>
     {/for}
 {/macro}

--- a/test/iframeLoaderOs.js
+++ b/test/iframeLoaderOs.js
@@ -73,7 +73,7 @@
                         if (tpl) {
                             // if there's some callback passed from the parent frame for execution
                             if (Aria.$window.parent.onBeforeTemplateLoadInIframe) {
-                                Aria.$window.parent.onBeforeTemplateLoadInIframe(aria);
+                                Aria.$window.parent.onBeforeTemplateLoadInIframe(aria, Aria);
                             }
 
                             Aria.loadTemplate({


### PR DESCRIPTION
Fixed issues with:
1. Dialog maximized from start
2. Resizing Dialog while maximized
3. Resizing viewport while Dialog maximized
4. Unmaximizing the Dialog after full section refresh

Additionally:
1. Perf and readability improvements (`changeProperty` vs
`setProperty`).
2. Test for destroying/creating Draggable/Resizable.
