### PR TITLE
feat #218 better stack trace in Firebug and Safari devtools

### DIFF
--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -1079,6 +1079,10 @@
             }
             for (var k in defPrototype) {
                 if (defPrototype.hasOwnProperty(k) && k != '$init') {
+                    if (typeof defPrototype[k] === "function") {
+                        // enable naming of anonymous functions in the stack trace in Firebug and Safari
+                        defPrototype[k].displayName = "#" + k;
+                    }
                     // TODO: check method names?
                     p[k] = defPrototype[k];
                 }


### PR DESCRIPTION
This adds support for `Function.displayName` to have better stack
traces in debugger in Firebug and Safari dev tools for the functions
in `$prototype` of classes loaded via `Aria.classDefinition`.

Chrome and IE9+ do not support `displayName` but they have a good
built-in inferring of names of anonymous functions.

IE8- do not support `displayName` nor infer the name by itself.

Close #218.
