### PR TITLE
Release notes templates

### DIFF
--- a/scripts/release-notes/README.md
+++ b/scripts/release-notes/README.md
@@ -1,0 +1,7 @@
+This folder includes to templates to be used with [git-release-notes](https://github.com/ariatemplates/git-release-notes).
+
+    npm install -g git-release-notes
+
+From this project folder
+
+    git-release-notes v1.3.6..v1.3.7 wiki.ejs -t "^([a-z]+) #(\d+) (.*)$" -m type -m issue -m title > wiki.txt

--- a/scripts/release-notes/blog.ejs
+++ b/scripts/release-notes/blog.ejs
@@ -1,0 +1,13 @@
+<ul>
+<% commits.forEach(function (commit) { %>
+	<% if (commit.type === "feat") { %>
+		<li><strong><%= commit.title %></strong>
+			<blockquote>
+				<%= commit.messageLines.join(" ") %>
+				<br/>
+				See <a href="https://github.com/ariatemplates/ariatemplates/issue/<%= commit.issue %>">#<%= commit.issue %></a>
+			</blockquote>
+		</li>
+	<% } %>
+<% }) %>
+</ul>

--- a/scripts/release-notes/wiki.ejs
+++ b/scripts/release-notes/wiki.ejs
@@ -1,0 +1,20 @@
+newFeatures=
+<% commits.forEach(function (commit) { %>
+	<% if (commit.type === "feat") { %>
+		{{AriaTemplatesReleaseNoteItemIssue |
+			issue=<%= commit.issue %>|
+			title=<%= commit.title %>|
+			description=<%= commit.messageLines.join(" ") %>}}
+	<% } %>
+<% }) %>
+|
+correctedBugs=
+<% commits.forEach(function (commit) { %>
+	<% if (commit.type === "fix") { %>
+		{{AriaTemplatesReleaseNoteItemIssue |
+			issue=<%= commit.issue %>|
+			title=<%= commit.title %>|
+			description=<%= commit.messageLines.join(" ") %>}}
+	<% } %>
+<% }) %>
+|


### PR DESCRIPTION
Add two [release-notes](https://github.com/ariatemplates/release-notes) templates to generate wiki and blog release notes pages
