### PR TITLE
Utility class to load standard css files

### DIFF
--- a/src/aria/utils/CSSLoader.js
+++ b/src/aria/utils/CSSLoader.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility to load external CSS files. Do NOT use it for loading CSS Templates
+ */
+Aria.classDefinition({
+    $classpath : "aria.utils.CSSLoader",
+    $singleton : true,
+    $dependencies : ["aria.utils.IdManager", "aria.utils.Type", "aria.utils.Object", "aria.core.DownloadMgr"],
+    $statics : {
+
+        /**
+         * Prefix used for the ids of the style tags
+         * @type String
+         */
+        TAG_PREFIX : "xCss",
+
+        /**
+         * Default media of the style tag
+         * @type String
+         */
+        DEFAULT_MEDIA : "all"
+    },
+    $constructor : function () {
+
+        /**
+         * Store of the information on the css files that were already added
+         * @type Object
+         * @private
+         */
+        this._store = {};
+
+        /**
+         * Generator of unique ids for the style tags
+         * @type aria.utils.IdManager
+         * @private
+         */
+        this._idManager = new aria.utils.IdManager(this.TAG_PREFIX);
+
+    },
+    $destructor : function () {
+        this.removeAll();
+        this._store = null;
+        this._idManager.$dispose();
+    },
+    $prototype : {
+
+        /**
+         * Add the CSS files by creating link tags in the head of the page
+         * @param {Array|String} sources An array of CSS files to add or a single file
+         * @param {String} media Media for the link tag. It defaults to "all"
+         * @return {Array} Array of the tag elements corresponding to the required sources
+         */
+        add : function (sources, media) {
+            media = media || this.DEFAULT_MEDIA;
+            if (aria.utils.Type.isString(sources)) {
+                sources = [sources];
+            }
+            var source, storeId, tagArray = [];
+            for (var i = 0, length = sources.length; i < length; i++) {
+                source = sources[i];
+                storeId = this._getStoreId(source, media);
+                if (this._store[storeId]) {
+                    this._store[storeId].count++;
+                    tagArray.push(this._store[storeId].tag);
+                } else {
+                    var tag = this._addLinkTag(source, media, this._idManager.getId());
+                    tagArray.push(tag);
+                    this._store[storeId] = {
+                        count : 1,
+                        tag : tag
+                    };
+                }
+            }
+            return tagArray;
+        },
+
+        /**
+         * Remove link tags previously added in the head of the page. If a certain css file is added n times (for the
+         * same media), the remove method has to be called n times in order for the corresponding link tag to be removed
+         * @param {Array|String} sources An array of CSS files to remove or a single file
+         * @param {String} media Media for the link tag. It defaults to "all"
+         */
+        remove : function (sources, media) {
+            media = media || this.DEFAULT_MEDIA;
+            if (aria.utils.Type.isString(sources)) {
+                sources = [sources];
+            }
+            var source, storeId;
+            for (var i = 0, length = sources.length; i < length; i++) {
+                source = sources[i];
+                storeId = this._getStoreId(source, media);
+                this._remove(storeId);
+            }
+        },
+
+        /**
+         * Remove link tags previously added in the head of the page. If a certain css file is added n times (for the
+         * same media), the _remove method has to be called n times in order for the corresponding link tag to be
+         * removed. If the force argument is set to true, the link tag will be removed on the first call.
+         * @param {String} storeId Id used to store the information on the added file
+         * @param {Boolean} force If true, the css will be removed even if it has been added several times
+         * @private
+         */
+        _remove : function (storeId, force) {
+            var info = this._store[storeId], tag;
+            if (info) {
+                if (!force && info.count > 1) {
+                    info.count--;
+                } else {
+                    tag = info.tag;
+                    tag.parentNode.removeChild(tag);
+                    tag = null;
+                    delete this._store[storeId];
+                }
+            }
+        },
+
+        /**
+         * Unload all the CSS previously added
+         */
+        removeAll : function () {
+            var storeIds = aria.utils.Object.keys(this._store);
+            for (var i = 0, length = storeIds.length; i < length; i++) {
+                this._remove(storeIds[i], true);
+            }
+        },
+
+        /**
+         * Create a link tag in the head of the page
+         * @param {String} source
+         * @param {String} media
+         * @param {String} id
+         * @return {HTMLElement} tag that has been added
+         * @private
+         */
+        _addLinkTag : function (source, media, id) {
+            var document = Aria.$window.document;
+            var head = document.getElementsByTagName("head")[0];
+            var tag = document.createElement("link");
+
+            tag.id = id;
+            tag.type = "text/css";
+            tag.media = media;
+            tag.rel = "stylesheet";
+            tag.href = aria.core.DownloadMgr.resolveURL(source);
+
+            head.appendChild(tag);
+            tag = head.lastChild;
+            return tag;
+        },
+
+        /**
+         * Return the id that is used to store the information on the style
+         * @param {String} source Source of the file
+         * @param {String} media type of media
+         * @return {String}
+         * @private
+         */
+        _getStoreId : function (source, media) {
+            return [source, "_", media].join("");
+        }
+    }
+});

--- a/test/aria/utils/UtilsTestSuite.js
+++ b/test/aria/utils/UtilsTestSuite.js
@@ -19,6 +19,7 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.utils.cssLoader.CSSLoader");
         this.addTests("test.aria.utils.dragdrop.DragDropBean");
         this.addTests("test.aria.utils.environment.EnvironmentTestSuite");
         this.addTests("test.aria.utils.json.JsonTestSuite");

--- a/test/aria/utils/cssLoader/CSSLoader.js
+++ b/test/aria/utils/cssLoader/CSSLoader.js
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.utils.CSSLoader
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.utils.cssLoader.CSSLoader",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.CSSLoader", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$TestCase.constructor.apply(this, arguments);
+        this._loader = aria.utils.CSSLoader;
+        this._testDom = this._createTestDom();
+    },
+    $destructor : function () {
+        this._loader = null;
+        aria.utils.Dom.getElementById("TESTAREA").removeChild(this._testDom);
+        this._testDom = null;
+        this.$TestCase.$destructor.apply(this, arguments);
+    },
+    $prototype : {
+
+        _createTestDom : function () {
+            var tag = Aria.$window.document.createElement("div");
+            tag.innerHTML = '<div id="test-div" class="class-one"><span>just some text to fill this span</span></div>';
+            aria.utils.Dom.getElementById("TESTAREA").appendChild(tag);
+            return tag;
+        },
+
+        testAsyncAdd : function () {
+            this._add("test/aria/utils/cssLoader/cssOne.css", {
+                fn : this._afterFirstAdd,
+                scope : this
+            });
+        },
+
+        _afterFirstAdd : function () {
+
+            this._testWidth("355px");
+            this._testLinkTag(0);
+            this._testLinkTag(1, false);
+            this._testReturnedTags([0]);
+
+            this._add(["test/aria/utils/cssLoader/cssOne.css"], {
+                fn : this._afterSecondAdd,
+                scope : this
+            });
+        },
+
+        _afterSecondAdd : function () {
+
+            this._testWidth("355px");
+            this._testLinkTag(0);
+            this._testLinkTag(1, false);
+            this._testReturnedTags([0]);
+            this._testRemove();
+
+        },
+
+        _testRemove : function () {
+            this._loader.remove(["test/aria/utils/cssLoader/cssOne.css"]);
+            this._testWidth("355px");
+            this._testLinkTag(0);
+            this._testLinkTag(1, false);
+            this._remove("test/aria/utils/cssLoader/cssOne.css", {
+                fn : this._afterFirstRemove,
+                scope : this
+            });
+        },
+
+        _afterFirstRemove : function () {
+            var domUtil = aria.utils.Dom;
+            this._testWidth("355px", false);
+            this._testLinkTag(0, false);
+
+            this._add(["test/aria/utils/cssLoader/cssOne.css", "test/aria/utils/cssLoader/cssTwo.css"], {
+                fn : this._afterThirdAdd,
+                scope : this
+            });
+        },
+
+        _afterThirdAdd : function () {
+
+            this._testWidth("455px");
+            this._testLinkTag(0, false);
+            this._testLinkTag(1);
+            this._testLinkTag(2);
+            this._testLinkTag(3, false);
+
+            this._addedTags = this._loader.add(["test/aria/utils/cssLoader/cssOne.css",
+                    "test/aria/utils/cssLoader/cssTwo.css"]);
+            this._testReturnedTags([1, 2]);
+            this._remove(null, {
+                fn : this._afterRemoveAll,
+                scope : this
+            });
+        },
+
+        _afterRemoveAll : function () {
+
+            this._testWidth("355px", false);
+            this._testLinkTag(0, false);
+            this._testLinkTag(1, false);
+            this._testLinkTag(2, false);
+            this._testLinkTag(3, false);
+
+            this._testAddWithMedia();
+
+        },
+
+        _testAddWithMedia : function () {
+            this._add(["test/aria/utils/cssLoader/cssOne.css", "test/aria/utils/cssLoader/cssTwo.css"], {
+                fn : this._afterFirstMediaAdd,
+                scope : this
+            }, "print");
+
+        },
+
+        _afterFirstMediaAdd : function () {
+
+            this._testWidth("355px", false);
+            this._testWidth("455px", false);
+            this._testLinkTag(0, false);
+            this._testLinkTag(1, false);
+            this._testLinkTag(2, false);
+            this._testLinkTag(3);
+            this._testLinkTag(4);
+            this._testLinkTag(5, false);
+            this._testReturnedTags([3, 4]);
+            this._add(["test/aria/utils/cssLoader/cssTwo.css", "test/aria/utils/cssLoader/cssOne.css"], {
+                fn : this._afterSecondMediaAdd,
+                scope : this
+            });
+
+        },
+
+        _afterSecondMediaAdd : function () {
+
+            this._testWidth("355px");
+            this._testLinkTag(3);
+            this._testLinkTag(4);
+            this._testLinkTag(5);
+            this._testLinkTag(6);
+            this._testLinkTag(7, false);
+            this._testReturnedTags([5, 6]);
+            this._add(["test/aria/utils/cssLoader/cssOne.css"], {
+                fn : this._afterThirdMediaAdd,
+                scope : this
+            }, "print");
+        },
+
+        _afterThirdMediaAdd : function () {
+            this._testWidth("355px");
+            this._testLinkTag(7, false);
+            this._testReturnedTags([3]);
+            this._testMediaRemove();
+        },
+
+        _testMediaRemove : function () {
+            this._loader.remove(["test/aria/utils/cssLoader/cssOne.css", "test/aria/utils/cssLoader/cssTwo.css"], "print");
+
+            this._testWidth("355px");
+            this._testLinkTag(3);
+            this._testLinkTag(4, false);
+            this._testLinkTag(5);
+            this._testLinkTag(6);
+            this._testLinkTag(7, false);
+            this._loader.remove(["test/aria/utils/cssLoader/cssOne.css", "test/aria/utils/cssLoader/cssTwo.css"], "print");
+            this._testLinkTag(3, false);
+            this._testLinkTag(4, false);
+            this._testLinkTag(5);
+            this._testLinkTag(6);
+            this._testLinkTag(7, false);
+
+            this._loader.removeAll();
+            this._testLinkTag(3, false);
+            this._testLinkTag(4, false);
+            this._testLinkTag(5, false);
+            this._testLinkTag(6, false);
+            this._testLinkTag(7, false);
+
+            this._testNonExistentCss();
+
+        },
+
+        _testNonExistentCss : function () {
+            this._add(["test/aria/utils/cssLoader/fake.css"], {
+                fn : this._afterFakeCssAdd,
+                scope : this
+            });
+
+        },
+
+        _afterFakeCssAdd : function () {
+            this._testLinkTag(7);
+            this._testLinkTag(8, false);
+            this._testReturnedTags([7]);
+            this._loader.removeAll();
+            this.notifyTestEnd("testAsyncAdd");
+        },
+
+        _add : function (sources, cb, media, delay) {
+            delay = (delay != null) ? delay : 100;
+            if (media) {
+                this._addedTags = this._loader.add(sources, media);
+            } else {
+                this._addedTags = this._loader.add(sources);
+            }
+            cb.delay = delay;
+            aria.core.Timer.addCallback(cb);
+        },
+
+        _remove : function (sources, cb, media, delay) {
+
+            delay = (delay != null) ? delay : 100;
+            if (sources) {
+                if (media) {
+                    this._loader.remove(sources, media);
+                } else {
+                    this._loader.remove(sources);
+                }
+            } else {
+                this._loader.removeAll();
+            }
+            cb.delay = delay;
+            aria.core.Timer.addCallback(cb);
+        },
+
+        _testWidth : function (value, equal) {
+            equal = (equal === false) ? equal : true;
+            var domUtil = aria.utils.Dom;
+            var testDiv = domUtil.getElementById("test-div");
+            var width = domUtil.getStyle(testDiv, "width");
+
+            if (equal) {
+                this.assertEquals(width, value);
+            } else {
+                this.assertNotEquals(width, value);
+            }
+        },
+
+        _testLinkTag : function (counter, value) {
+            value = (value === false) ? false : true;
+            var id = this._loader.TAG_PREFIX + counter;
+            this.assertEquals(!!aria.utils.Dom.getElementById(id), value);
+        },
+
+        _testReturnedTags : function (tagIds) {
+            var id, length = tagIds.length;
+            this.assertEquals(this._addedTags.length, length, "The number of returned tags is not correct");
+            for (var i = 0; i < length; i++) {
+                id = this._loader.TAG_PREFIX + tagIds[i];
+                this.assertEquals(this._addedTags[i].id, id);
+            }
+        }
+
+    }
+});

--- a/test/aria/utils/cssLoader/cssOne.css
+++ b/test/aria/utils/cssLoader/cssOne.css
@@ -1,0 +1,5 @@
+.class-one {
+  background: blue;
+  color: white;
+  width: 355px;
+}

--- a/test/aria/utils/cssLoader/cssTwo.css
+++ b/test/aria/utils/cssLoader/cssTwo.css
@@ -1,0 +1,5 @@
+.class-one {
+  background: red;
+  color: white;
+  width: 455px;
+}


### PR DESCRIPTION
It is possible to progrmmatically add/remove css files by using the `aria.utils.CSSLoader` singleton. Tags of type `<link>` are created and appended to the head of the document.

![cssLoader_coverage](https://f.cloud.github.com/assets/1152729/196475/8491cfca-801d-11e2-950f-e7777a49dbad.jpg)
