### PR TITLE
fix #394 tplScript unnecessarily extending Template

### DIFF
--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -154,6 +154,7 @@
     Aria.RESOURCES_HANDLE_CONFLICT = "Template error: can't load resources '%1' defined in '%2'. A macro, a library, a text template, a variable or another resource has already been declared with the same name.";
     Aria.CANNOT_EXTEND_SINGLETON = "Class %1 cannot extend singleton class %2";
     Aria.FUNCTION_PROTOTYPE_RETURN_NULL = "Prototype function of %1 cannot returns null";
+    Aria.TPLSCRIPT_INSTANTIATED_DIRECTLY = "Template scripts can not be instantiated directly";
 
     Aria.$classpath = "Aria";
     /**
@@ -748,17 +749,12 @@
             $onload : function (constructor) {
                 constructor.tplScriptDefinition = def;
             },
-            $extends : "aria.templates.Template",
             $constructor : function () {
-                this.$Template.constructor.call(this);
-                if (def.$constructor) {
-                    def.$constructor.call(this);
-                }
-            },
-            $destructor : def.$destructor ? function () {
-                def.$destructor.call(this);
-                this.$Template.$destructor.call(this);
-            } : null
+                // This is to prevent direct instantiation of template scripts.
+                // Yet it is still possible do define $constructor and $destructor on template scripts, as they will be
+                // imported later on in TplClassLoader._importScriptPrototype()
+                this.$logError(Aria.TPLSCRIPT_INSTANTIATED_DIRECTLY);
+            }
         });
     };
 


### PR DESCRIPTION
If a template had a CSS template with script in its dependencies, then
a circular dependency error might have happened due to that.

Close #395.
