### PR TITLE
fix #401 HashManager works correctly in IE7 even after a domain change

### DIFF
--- a/build/config/jshint.json
+++ b/build/config/jshint.json
@@ -43,7 +43,7 @@
     "onecase" : false,
     "proto" : true,
     "regexdash" : true,
-    "scripturl" : false,
+    "scripturl" : true,
     "smarttabs" : false,
     "shadow" : true,
     "sub" : true,

--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -483,6 +483,16 @@
     Aria.memCheckMode = Aria.memCheckMode === true;
 
     /**
+     * The domain variable has to be set only when you explicitly set the value of document.domain. It is needed by
+     * classes using iframes (like aria.utils.HashManager) in order to overcome the limitations imposed by IE6/7 on the
+     * access of the iframe contents. It is desirable to set it at the very beginning, even before loading the bootstrap
+     * file of the framework.
+     * @type String
+     * @name Aria.domain
+     */
+    Aria.domain = Aria.domain || null;
+
+    /**
      * Prefix used for all parameters added in objects by the framework for internal requirements
      * @type String
      * @name Aria.FRAMEWORK_PREFIX


### PR DESCRIPTION
In order to provide support for back and forward in hash-based navigation in Internet Explorer 7, class `aria.utils.HashManager` creates a hidden iframe to open and close each time the history has to be populated with an entry.

When the `document.domain` is changed, IE7 denies access to some global variables of the iframe, unless the `document.domain` is updated inside the iframe, too. **In order to notify that document.domain has been explicly set, variable `Aria.domain` has to be set to the same value.**
