### PR TITLE
Error tool tip enhancement

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -46,9 +46,9 @@ Aria.classDefinition({
         onBeforeOpen : "",
         onAfterOpen : "",
         onPositioned : {
-            description : "Triggered when position of the popup is choosen, according to prefered position provided",
+            description : "Triggered when position of the popup is chosen, according to prefered position provided",
             properties : {
-                position : "Position choosed if any. If empty, no position in viewset was found."
+                position : "Position chosen if any. If empty, no position in viewset was found."
             }
         }
     },
@@ -469,7 +469,6 @@ Aria.classDefinition({
          * @protected
          */
         _getPositionForAnchor : function (preferredPosition, size) {
-            var base = this.reference;
             var referenceAnchor = preferredPosition.reference;
             var popupAnchor = preferredPosition.popup;
 
@@ -632,13 +631,17 @@ Aria.classDefinition({
             } else {
                 this.computedStyle = this._getComputedStyle();
             }
-
-            this.domElement.style.cssText = ['top:', this.computedStyle.top, 'px;', 'left:', this.computedStyle.left,
-                    'px;', 'z-index:', this.computedStyle.zIndex, ';', 'position:absolute;display:inline-block;'].join('');
-            if (aria.core.Browser.isIE7 && !this.isOpen) {
-                // Without the following line, the autocomplete does not
-                // initially display its content on IE7:
-                this._document.body.appendChild(this.domElement);
+            // Need to check that the reference point is still completely visible after a scroll
+            var referenceIsInViewSet = aria.utils.Dom.isInViewport(this.referencePosition, this.referenceSize, this.domElement);
+            if (referenceIsInViewSet) {
+                this.domElement.style.cssText = ['top:', this.computedStyle.top, 'px;', 'left:',
+                        this.computedStyle.left, 'px;', 'z-index:', this.computedStyle.zIndex, ';',
+                        'position:absolute;display:inline-block;'].join('');
+                if (aria.core.Browser.isIE7 && !this.isOpen) {
+                    // Without the following line, the autocomplete does not
+                    // initially display its content on IE7:
+                    this._document.body.appendChild(this.domElement);
+                }
             }
         },
 

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -180,6 +180,9 @@ Aria.beanDefinitions({
                         },
                         "name" : {
                             $type : "common:BindingRef"
+                        },
+                        "errorTipPosition" : {
+                            $type : "common:BindingRef"
                         }
                     }
                 },
@@ -307,6 +310,11 @@ Aria.beanDefinitions({
                     $type : "json:Boolean",
                     $description : "Indicates if the label must be displayed or not (if true the label is hidden)",
                     $default : false
+                },
+                "errorTipPosition" : {
+                    $type : "json:String",
+                    $description : "Possible values are: 'bottom left', 'bottom right', 'top left', 'top right'.",
+                    $default : "top right"
                 }
             }
         },
@@ -857,6 +865,20 @@ Aria.beanDefinitions({
             $type : "WidgetCfg",
             $description : "The base configuration for the button widget",
             $properties : {
+                "bind" : {
+                    $type : "WidgetCfg.bind",
+                    $properties : {
+                        "error" : {
+                            $type : "common:BindingRef"
+                        },
+                        "errorMessages" : {
+                            $type : "common:BindingRef"
+                        },
+                        "errorTipPosition" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
                 "label" : {
                     $type : "json:String",
                     $description : "Text to put inside the label in the button",
@@ -865,6 +887,25 @@ Aria.beanDefinitions({
                 "onclick" : {
                     $type : "common:Callback",
                     $description : "Function to be called when the user clicks on the button."
+                },
+                "error" : {
+                    $type : "json:Boolean",
+                    $description : "Highlights the widget to notify an error to the user, defined in a template script.",
+                    $default : false
+                },
+                "errorMessages" : {
+                    $type : "json:Array",
+                    $description : "List of error messages associated to the widget, defined in a template script - these messages will be automatically displayed in a contextual error tooltip. If this array is not empty the error property is automatically set to true",
+                    $contentType : {
+                        $type : "json:String",
+                        $description : "Error message associated to the widget"
+                    },
+                    $default : []
+                },
+                "errorTipPosition" : {
+                    $type : "json:String",
+                    $description : "Possible values are: 'bottom left', 'bottom right', 'top left', 'top right'.",
+                    $default : "top right"
                 }
             }
         },
@@ -874,7 +915,7 @@ Aria.beanDefinitions({
             $description : "The base configuration for the button widget",
             $properties : {
                 "bind" : {
-                    $type : "WidgetCfg.bind",
+                    $type : "ActionWidgetCfg.bind",
                     $properties : {
                         "disabled" : {
                             $type : "common:BindingRef"

--- a/src/aria/widgets/WidgetTrait.js
+++ b/src/aria/widgets/WidgetTrait.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WidgetTrait is a class to share code between input widgets and action widgets, although this can be extended to
+ * include other widget types in the future. The purpose of this class is not to be created directly, but to allow its
+ * prototype to be imported.
+ */
+Aria.classDefinition({
+    $classpath : "aria.widgets.WidgetTrait",
+    $dependencies : ["aria.widgets.form.InputValidationHandler"],
+    $constructor : function () {
+        // The purpose of this class is to provide a prototype to be imported, not to be created directly.
+        this.$assert(11, false);
+    },
+    $prototype : {
+        /**
+         * Method used when a validation popup is needed for an input field
+         * @protected
+         */
+        _validationPopupShow : function () {
+            // check validation popup isn't already displayed
+            if (!this._onValidatePopup) {
+                this._onValidatePopup = new aria.widgets.form.InputValidationHandler(this);
+            }
+            this._onValidatePopup.show();
+        },
+
+        /**
+         * Method used to close the validation popup of an input field
+         * @protected
+         */
+        _validationPopupHide : function () {
+            if (this._onValidatePopup) {
+                this._onValidatePopup.hide();
+            }
+        }
+    }
+});

--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -19,8 +19,8 @@
 Aria.classDefinition({
     $classpath : "aria.widgets.form.Input",
     $extends : "aria.widgets.Widget",
-    $dependencies : ["aria.utils.Dom", "aria.widgets.form.InputValidationHandler", "aria.utils.Data",
-            "aria.utils.String", "aria.widgets.environment.WidgetSettings", "aria.core.Browser"],
+    $dependencies : ["aria.utils.Dom", "aria.utils.Data", "aria.utils.String",
+            "aria.widgets.environment.WidgetSettings", "aria.core.Browser", "aria.widgets.WidgetTrait"],
     /**
      * Input constructor
      * @param {aria.widgets.CfgBeans.InputCfg} cfg the widget configuration
@@ -106,11 +106,18 @@ Aria.classDefinition({
          * @param {Object} sdef the superclass class definition
          */
         $init : function (p, def, sdef) {
+            var src = aria.widgets.WidgetTrait.prototype;
+            for (var key in src) {
+                if (src.hasOwnProperty(key) && !p.hasOwnProperty(key)) {
+                    // copy methods which are not already on this object (this avoids copying $classpath and
+                    // $destructor)
+                    p[key] = src[key];
+                }
+            }
             // we add the bindable properties to the Widget prototype
             p.automaticallyBindedProperties = ["formatError", "formatErrorMessages", "error", "errorMessages",
                     "requireFocus"];
         },
-
         /**
          * Override the Widget _init method
          * @protected
@@ -356,28 +363,6 @@ Aria.classDefinition({
         },
 
         /**
-         * Method used when a validation popup is needed for an input field
-         * @protected
-         */
-        _validationPopupShow : function () {
-            // check validation popup isn't already displayed
-            if (!this._onValidatePopup) {
-                this._onValidatePopup = new aria.widgets.form.InputValidationHandler(this);
-            }
-            this._onValidatePopup.show();
-        },
-
-        /**
-         * Method used to close the validation popup of an input field
-         * @protected
-         */
-        _validationPopupHide : function () {
-            if (this._onValidatePopup) {
-                this._onValidatePopup.hide();
-            }
-        },
-
-        /**
          * Internal method called when one of the model property that the widget is bound to has changed Must be
          * overridden by sub-classes defining bindable properties
          * @param {String} propertyName the property name
@@ -422,7 +407,7 @@ Aria.classDefinition({
 
         /**
          * Apply the automatic bindings
-         * @param {aria.widgets.CfgBeans.InputCfg} cfg
+         * @param {aria.widgets.CfgBeans.InputCfg|aria.widgets.CfgBeans.ActionWidgetCfg} cfg
          * @protected
          */
         _setAutomaticBindings : function (cfg) {

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -19,6 +19,9 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.widgets.errorTip.ButtonErrorTipsTest");
+        this.addTests("test.aria.widgets.errorTip.IconButtonErrorTipsTest");
+        this.addTests("test.aria.widgets.errorTip.LinkErrorTipsTest");
         this.addTests("test.aria.widgets.AriaSkinInterfaceTest");
         this.addTests("test.aria.widgets.AriaSkinNormalizationTest");
         this.addTests("test.aria.widgets.WidgetTest");

--- a/test/aria/widgets/errorTip/ButtonErrorTipsTest.js
+++ b/test/aria/widgets/errorTip/ButtonErrorTipsTest.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.errorTip.ButtonErrorTipsTest',
+    $extends : 'aria.jsunit.TemplateTestCase',
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this._errorTipsTestCaseEnv = {
+            template : "test.aria.widgets.errorTip.TemplateButtonErrorTips",
+            moduleCtrl : {
+                classpath : 'test.aria.widgets.errorTip.ErrorTipsController'
+            },
+            data : null
+        };
+        this.setTestEnv(this._errorTipsTestCaseEnv);
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.synEvent.click(this.getElementById('submitButton1'), {
+                fn : this._checkErrorToolTipOpen,
+                scope : this
+            });
+        },
+
+        _checkErrorToolTipOpen : function () {
+            var buttonWidget = this.getWidgetInstance('submitButton1');
+            this.assertTrue(buttonWidget._cfg.error);
+            this.assertTrue(!!buttonWidget._onValidatePopup);
+            this.finishTest();
+        },
+
+        finishTest : function () {
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/errorTip/ErrorTipsController.js
+++ b/test/aria/widgets/errorTip/ErrorTipsController.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Controller for error tips samples.
+ * @class AppModule
+ */
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.errorTip.ErrorTipsController',
+    $extends : 'aria.templates.ModuleCtrl',
+    $implements : ['test.aria.widgets.errorTip.IErrorTipsController'],
+    $dependencies : ['aria.utils.validators.Mandatory', 'aria.utils.Data'],
+    $constructor : function () {
+        this.$ModuleCtrl.constructor.call(this);
+        this._data = {
+            field1 : "",
+            errorMessages : [],
+            error : false
+        };
+        this.myDataUtil = aria.utils.Data;
+        this.validator = new aria.utils.validators.Mandatory("This field is a required field using a mandatory validator.");
+    },
+    $destructor : function () {
+        this.validator.$dispose();
+        this.$ModuleCtrl.$destructor.call(this);
+    },
+    $prototype : {
+        $publicInterfaceName : "test.aria.widgets.errorTip.IErrorTipsController",
+        init : function (arg, cb) {
+            var validatorOnSubmit = this.validator;
+            this.myDataUtil.setValidator(this._data, "field1", validatorOnSubmit);
+            this.$callback(cb);
+        },
+        submit : function () {
+            var messages = {};
+            this.myDataUtil.validateModel(this._data, messages);
+            this.json.setValue(this._data, "errorMessages", messages.listOfMessages);
+            this.json.setValue(this._data, "error", (!!messages.nbrOfE));
+        }
+    }
+});

--- a/test/aria/widgets/errorTip/IErrorTipsController.js
+++ b/test/aria/widgets/errorTip/IErrorTipsController.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface for the error tips module controller.
+ * @class test.templateTests.tests.features.errorTips.IErrorTipsController
+ */
+Aria.interfaceDefinition({
+    $classpath : 'test.aria.widgets.errorTip.IErrorTipsController',
+    $extends : 'aria.templates.IModuleCtrl',
+    $interface : {
+        submit : function () {}
+    }
+});

--- a/test/aria/widgets/errorTip/IconButtonErrorTipsTest.js
+++ b/test/aria/widgets/errorTip/IconButtonErrorTipsTest.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.errorTip.IconButtonErrorTipsTest',
+    $extends : 'aria.jsunit.TemplateTestCase',
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this._errorTipsTestCaseEnv = {
+            template : "test.aria.widgets.errorTip.TemplateIconButtonErrorTips",
+            moduleCtrl : {
+                classpath : 'test.aria.widgets.errorTip.ErrorTipsController'
+            },
+            data : null
+        };
+        this.setTestEnv(this._errorTipsTestCaseEnv);
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.synEvent.click(this.getElementById('iconButton1'), {
+                fn : this._checkErrorToolTipOpen,
+                scope : this
+            });
+        },
+
+        _checkErrorToolTipOpen : function () {
+            var iconButtonWidget = this.getWidgetInstance('iconButton1');
+            this.assertTrue(iconButtonWidget._cfg.error);
+            this.assertTrue(!!iconButtonWidget._onValidatePopup);
+            this.finishTest();
+        },
+
+        finishTest : function () {
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/errorTip/LinkErrorTipsTest.js
+++ b/test/aria/widgets/errorTip/LinkErrorTipsTest.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.errorTip.LinkErrorTipsTest',
+    $extends : 'aria.jsunit.TemplateTestCase',
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this._errorTipsTestCaseEnv = {
+            template : "test.aria.widgets.errorTip.TemplateLinkErrorTips",
+            moduleCtrl : {
+                classpath : 'test.aria.widgets.errorTip.ErrorTipsController'
+            },
+            data : null
+        };
+        this.setTestEnv(this._errorTipsTestCaseEnv);
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.synEvent.click(this.getElementById('link1'), {
+                fn : this._checkErrorToolTipOpen,
+                scope : this
+            });
+        },
+
+        _checkErrorToolTipOpen : function () {
+            var linkWidget = this.getWidgetInstance('link1');
+            this.assertTrue(linkWidget._cfg.error);
+            this.assertTrue(!!linkWidget._onValidatePopup);
+            this.finishTest();
+        },
+
+        finishTest : function () {
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/errorTip/TemplateButtonErrorTips.tpl
+++ b/test/aria/widgets/errorTip/TemplateButtonErrorTips.tpl
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	"$classpath" : 'test.aria.widgets.errorTip.TemplateButtonErrorTips',
+	"$hasScript" : false
+}}
+
+{var titleMessage = null /}
+
+	{macro main()}
+			<h2>Button Error Tips</h2>
+			<div class="sampleDiv" >
+				<div class="title">
+					In this scenario clicking on the button will trigger validation failure for all empty fields, when this happens an error tool tip should display for the button.
+				</div>
+				<div class="sampleDiv" >
+				{@aria:TextField {
+					id : "textField1",
+					label : "Field 1",
+					bind: {
+						value: {
+							to: "field1",
+							inside: data
+						}
+					}
+				}/}
+				</div>
+				<div class="sampleDiv" >
+				{@aria:Button {
+					id: "submitButton1",
+					label: "Submit",
+					errorMessages: ["Please complete all fields before clicking submit."],
+					bind: {
+						error : {
+							to: "error",
+							inside: data
+						}
+					},
+					onclick: {
+						fn : "submit",
+						scope : moduleCtrl
+					}
+				}/}
+				</div>
+			</div>
+	{/macro}
+{/Template}
+
+
+
+
+

--- a/test/aria/widgets/errorTip/TemplateIconButtonErrorTips.tpl
+++ b/test/aria/widgets/errorTip/TemplateIconButtonErrorTips.tpl
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	"$classpath" : 'test.aria.widgets.errorTip.TemplateIconButtonErrorTips',
+	"$hasScript" : false
+}}
+
+{var titleMessage = null /}
+
+	{macro main()}
+			<h2>Icon Button Error Tips</h2>
+			<div class="sampleDiv" >
+				<div class="title">
+					In this scenario clicking on the icon button will trigger validation failure for all empty fields, when this happens an error tool tip should display for the icon button.
+				</div>
+				<div class="sampleDiv" >
+				{@aria:TextField {
+					id : "textField1",
+					label : "Field 1",
+					bind: {
+						value: {
+							to: "field1",
+							inside: data
+						}
+					}
+				}/}
+				</div>
+				<div class="sampleDiv" >
+				{@aria:IconButton {
+					id: "iconButton1",
+					label: "next",
+					icon:"std:right_arrow",
+					errorMessages: ["Please complete all fields before clicking next."],
+					bind: {
+						error : {
+							to: "error",
+							inside: data
+						}
+					},
+					onclick: {
+						fn : "submit",
+						scope : moduleCtrl
+					}
+				}/}
+				</div>
+			</div>
+	{/macro}
+{/Template}
+
+
+
+
+

--- a/test/aria/widgets/errorTip/TemplateLinkErrorTips.tpl
+++ b/test/aria/widgets/errorTip/TemplateLinkErrorTips.tpl
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	"$classpath" : 'test.aria.widgets.errorTip.TemplateLinkErrorTips',
+	"$hasScript" : false
+}}
+
+{var titleMessage = null /}
+
+	{macro main()}
+			<h2>Link Error Tips</h2>
+			<div class="sampleDiv" >
+				<div class="title">
+					In this scenario clicking on the link will trigger validation failure for all empty fields, when this happens an error tool tip should display for the link.
+				</div>
+				<div class="sampleDiv" >
+				{@aria:TextField {
+					id : "textField1",
+					label : "Field 1",
+					bind: {
+						value: {
+							to: "field1",
+							inside: data
+						}
+					}
+				}/}
+				</div>
+				<div class="sampleDiv" >
+				{@aria:Link {
+					id: 'link1',
+					label: "More >>",
+					errorMessages: ["Please complete all fields before clicking 'More >>'."],
+					bind: {
+						error : {
+							to: "error",
+							inside: data
+						}
+					},
+					onclick: {
+						fn : "submit",
+						scope : moduleCtrl
+					}
+				}/}
+				</div>
+			</div>
+	{/macro}
+{/Template}
+
+
+
+
+

--- a/test/aria/widgets/form/InputValidationHandlerTest.js
+++ b/test/aria/widgets/form/InputValidationHandlerTest.js
@@ -52,9 +52,10 @@ Aria.classDefinition({
                 _context : new aria.templates.TemplateCtxt(),
                 _cfg : {
                     formatError : true,
-                    formatErrorMessages : ["<div id='error'>this is an error</div>"]
+                    formatErrorMessages : ["<div id='error'>this is an error</div>"],
+                    errorTipPosition : "top right"
                 },
-                getTextInputField : function () {
+                getDom : function () {
                     return anchor;
                 }
             }


### PR DESCRIPTION
Currently the logic for the error tool tip is contained within aria.widgets.form.Input, the aim of this enhancement is to share code efficiently between multiple types of widgets. Specifically for the requirement of this feature, this means making the code for the error tool tip not only available for "Input" type widgets, but also for "Action" type widgets.  

In addition, it must also be possible from within a template to have a new widget property called errorTipPosition that will be used as the preferred position for the error tool tip, if there is not enough available space the framework will automatically calculate the best position for the error tool tip. The property will be added for both "Input" type widgets and also "Action" type widgets. 
