### PR TITLE
bulletproofing the test cases

### DIFF
--- a/test/aria/core/MobileBrowserTest.js
+++ b/test/aria/core/MobileBrowserTest.js
@@ -31,12 +31,15 @@
         $prototype : {
             setUp : function () {
                 this.userAgent = aria.core.Browser;
-                this.originalUserAgent = this.userAgent.ua;
+                this.originalBrowserProps = aria.utils.Json.copy(aria.core.Browser);
             },
             tearDown : function () {
-                this.userAgent.ua = this.originalUserAgent;
+                var browser = aria.core.Browser;
+                for (var propName in this.originalBrowserProps) {
+                    browser[propName] = this.originalBrowserProps[propName];
+                }
+                this.originalBrowserProps = null;
                 this.userAgent = null;
-                this.originalUserAgent = null;
             },
             testToUAParser : function () {
                 this.userAgents = [

--- a/test/aria/core/io/JSONPTest.js
+++ b/test/aria/core/io/JSONPTest.js
@@ -20,6 +20,10 @@ Aria.classDefinition({
     $classpath : "test.aria.core.io.JSONPTest",
     $extends : "aria.jsunit.TestCase",
     $dependencies : ["test.aria.core.test.IOFilterSample"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.defaultTestTimeout = 10000;
+    },
     $prototype : {
         tearDown : function () {
             aria.core.IO.$unregisterListeners(this);
@@ -239,6 +243,7 @@ Aria.classDefinition({
                     },
                     scope : this,
                     onerror : function () {
+                        aria.core.IOFiltersMgr.removeFilter(filterParam);
                         this.fail("The request should not have failed.");
                     },
                     onerrorScope : this
@@ -289,6 +294,7 @@ Aria.classDefinition({
                     },
                     scope : this,
                     onerror : function () {
+                        aria.core.IOFiltersMgr.removeFilter(filterParam);
                         this.fail("The request should not have failed.");
                     },
                     onerrorScope : this


### PR DESCRIPTION
1. JSONP test didn't remove the IOFilters in case of failure.
2. MobileBrowserTest used to emulate numerous browsers and didn't restore original values in aria.core.Browser.

Both of the problems above had influence on another tests when run in the test suite without isolation.
