### PR TITLE
Reducing number of instructions in template markup generation

### DIFF
--- a/src/aria/templates/CSSCtxt.js
+++ b/src/aria/templates/CSSCtxt.js
@@ -299,6 +299,19 @@ Aria.classDefinition({
          */
         __$write : function (text) {
             this._out = this._out.concat(text);
+        },
+
+        /**
+         * Write some text. This method is intended to be called only from the generated code of templates (created in
+         * aria.templates.ClassGenerator) and never directly from developer code. A call to this method is generated for
+         * simple text in templates and for ${...} statements.
+         * @param {Array} text Text to write.
+         * @private
+         * @implements aria.templates.ICSS
+         */
+
+        __$writeArray : function (text) {
+            this._out = this._out.concat(text);
         }
     }
 });

--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -231,7 +231,7 @@ Aria.classDefinition({
          * @param {aria.templates.ClassWriter} out
          * @param {aria.templates.TreeBeans.Statement} statement
          */
-        __processStatement : function (out, statement) {
+        __processStatement : function (out, statement, merge) {
             var statname = statement.name;
             if (statname.charAt(0) == '@') {
                 statname = '@';
@@ -259,13 +259,13 @@ Aria.classDefinition({
                         if (this._isDebug) {
                             out.trackLine(statement.lineNumber);
                         }
-                        handler.process(out, statement, res);
+                        handler.process(out, statement, res, merge);
                     }
                 } else {
                     if (this._isDebug) {
                         out.trackLine(statement.lineNumber);
                     }
-                    handler.process(out, statement, this);
+                    handler.process(out, statement, this, merge);
                 }
             }
         },

--- a/src/aria/templates/ClassWriter.js
+++ b/src/aria/templates/ClassWriter.js
@@ -354,8 +354,46 @@ Aria.classDefinition({
          * @param {Array} content list of statements
          */
         processContent : function (content) {
+            var merge = 0;
+
             for (var i = 0; i < content.length; i++) {
-                this.processStatement(content[i]);
+                if (!Aria.debug) {
+                    merge = this.__computeMergeState(merge, content, i);
+                }
+
+                this.processStatement(content[i], merge);
+            }
+        },
+
+        /**
+         * Computes merge state (0: no merge, 1: merge started, 2: merging, 3: merge ended)
+         * @param {Number} merge status of the merging process for TEXT and EXPRESSION items
+         * @param {Array} content list of statements
+         * @param {Number} index content's index
+         * @return {Number} merge status of the merging process
+         */
+        __computeMergeState : function (merge, content, index) {
+            var numElements = content.length;
+            var item = content[index].name;
+            var nextItem = null;
+            var goodToMerge = (item == "#TEXT#" || item == "#EXPRESSION#");
+
+            if (!goodToMerge) {
+                return 0;
+            }
+
+            if (index == numElements - 1) {
+                return merge ? 3 : 0;
+            } else {
+                nextItem = content[index + 1].name;
+                var isNextGoodToMerge = (nextItem == "#TEXT#" || nextItem == "#EXPRESSION#");
+
+                switch (merge) {
+                    case 0: return isNextGoodToMerge ? 1 : 0;
+                    case 1: return isNextGoodToMerge ? 2 : 3;
+                    case 2: return isNextGoodToMerge ? merge : 3;
+                    case 3: return 0;
+                }
             }
         },
 
@@ -363,8 +401,8 @@ Aria.classDefinition({
          * Process a statement calling the callback defined in the constructor
          * @param {aria.templates.TreeBeans.Statement} statement Statement to be processed
          */
-        processStatement : function (statement) {
-            this._processStatement.fn.call(this._processStatement.scope, this, statement);
+        processStatement : function (statement, merge) {
+            this._processStatement.fn.call(this._processStatement.scope, this, statement, merge);
         },
 
         /**
@@ -423,9 +461,7 @@ Aria.classDefinition({
          */
         writeln : function () {
             var out = this._curblock.out;
-            if (this._curindent) {
-                out.push(this._curindent);
-            }
+            this.writeIndent();
             out.push.apply(out, arguments);
             out.push('\n');
         },
@@ -437,6 +473,16 @@ Aria.classDefinition({
         write : function () {
             var out = this._curblock.out;
             out.push.apply(out, arguments);
+        },
+
+        /**
+         * Write the indetation in the current output block.
+         */
+        writeIndent : function () {
+            var out = this._curblock.out;
+            if (this._curindent) {
+                out.push(this._curindent);
+            }
         },
 
         /**

--- a/src/aria/templates/IBaseTemplate.js
+++ b/src/aria/templates/IBaseTemplate.js
@@ -30,6 +30,15 @@ Aria.interfaceDefinition({
          * @param {String} markup Markup to write.
          * @private
          */
-        __$write : function (markup) {}
+        __$write : function (markup) {},
+
+        /**
+         * Write some markup. This method is intended to be called only from the generated code of templates (created in
+         * aria.templates.ClassGenerator) and never directly from developer code. A call to this method is generated for
+         * simple text in templates and for ${...} statements.
+         * @param {String} markup Markup to write.
+         * @private
+         */
+        __$writeArray : function (markup) {}
     }
 });

--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -224,6 +224,8 @@
 
                 // remove manually set methods
                 tpl.__$write = null;
+                tpl.__$writeArray = null;
+
                 for (var index = 0, name; name = paramMapping[index]; index++) {
                     delete tpl[name];
                 }
@@ -1096,6 +1098,10 @@
                 tpl.__$write = function (s, line) {
                     return oSelf.__$write(s, line, this.$classpath);
                 };
+                // do not use bind for __$write as this method is called intensively (Perf improvment)
+                tpl.__$writeArray = function (s, line) {
+                    return oSelf.__$writeArray(s, line);
+                };
 
                 if (this.moduleCtrl) {
                     this.moduleCtrl.$on({
@@ -1184,6 +1190,22 @@
                     this.$logWarn(this.VAR_NULL_OR_UNDEFINED, [lineNumber, classpath]);
                 }
                 return this._out.write(a);
+            },
+
+            /**
+             * Write some markup using the join function. This method is intended to be called only from the generated code of templates
+             * (created in aria.templates.ClassGenerator) and never directly from developper code. A call to this method
+             * is generated for simple text in templates and for ${...} statements.
+             * @param {String} a Markup to write.
+             * @param {Number} lineNumber Number of the line in the Template that is writing some markup
+             * @private
+             * @implements aria.templates.ITemplate
+             */
+            __$writeArray : function (a, lineNumber) {
+                if (a === undefined || a === null) {
+                    this.$logWarn(this.VAR_NULL_OR_UNDEFINED, [lineNumber, this.tplClasspath]);
+                }
+                return this._out.write(a.join(""));
             },
 
             /**

--- a/src/aria/templates/TxtCtxt.js
+++ b/src/aria/templates/TxtCtxt.js
@@ -92,6 +92,10 @@ Aria.classDefinition({
                 return oSelf.__$write.call(oSelf, text);
             };
 
+            tpl.__$writeArray = function (text) {
+                return oSelf.__$writeArray.call(oSelf, text);
+            };
+
             if (!tpl.__$initTemplate()) {
                 return false;
             }
@@ -123,6 +127,18 @@ Aria.classDefinition({
          */
         __$write : function (text) {
             this._out.push(text);
+        },
+
+        /**
+         * Write some text. This method is intended to be called only from the generated code of templates (created in
+         * aria.templates.ClassGenerator) and never directly from developer code. A call to this method is generated for
+         * simple text in templates and for ${...} statements.
+         * @param {Array} text Text to write.
+         * @private
+         * @implements aria.templates.IBaseTemplate
+         */
+        __$writeArray : function (text) {
+            this._out = this._out.concat(text);
         }
     }
 });


### PR DESCRIPTION
Adding feature for merging text and expression items after template parsing in order to reduce the number of instructions on IE 7/8
