### PR TITLE
feat demo attribute for test cases

### DIFF
--- a/src/aria/jsunit/NewTestRunner.js
+++ b/src/aria/jsunit/NewTestRunner.js
@@ -189,6 +189,13 @@ Aria.classDefinition({
         },
 
         /**
+         * Return the root test case
+         */
+         getRootTest : function () {
+             return this._rootTest;
+         },
+
+         /**
          * Retrieve all the TestCase objects contained in a given TestSuite instance. This will recursively inspect all
          * the sub test suites as well. TestCases will be returned as an array of test wrappers
          * {instance:{aria.jsunit.TestCase},classpath:{String}}. As usual, only the classpath property might be

--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -300,6 +300,9 @@ Aria.classDefinition({
          * the test is ended.
          */
         notifyTemplateTestEnd : function () {
+            if (this.demoMode) {
+                return;
+            }
             aria.core.Timer.addCallback({
                 fn : function () {
                     // Need to dispose the template since we are always using the same div to do Aria.loadTemplate

--- a/src/aria/jsunit/TestCase.js
+++ b/src/aria/jsunit/TestCase.js
@@ -286,6 +286,9 @@ Aria.classDefinition({
          * @param {String} testName
          */
         setTestTimeout : function (timeout, testName) {
+            if (this.demoMode) {
+                return;
+            }
             if (this._timeoutTimer) {
                 aria.core.Timer.cancelCallback(this._timeoutTimer);
             }

--- a/src/aria/jsunit/TestWrapper.js
+++ b/src/aria/jsunit/TestWrapper.js
@@ -100,6 +100,11 @@ Aria.classDefinition({
                 '*' : this._testEvent,
                 scope : this
             });
+
+            if (this.demoMode) {
+                this._testInstance.demoMode = true;
+            }
+
             this._testInstance.run();
         },
 

--- a/src/aria/tester/runner/ModuleController.js
+++ b/src/aria/tester/runner/ModuleController.js
@@ -116,6 +116,10 @@ Aria.classDefinition({
             if (__hash.getParameter("runIsolated") == "true") {
                 json.setValue(campaignData, "runIsolated", true);
             }
+
+            if (__hash.getParameter("demo") == "true") {
+                json.setValue(campaignData, "demoMode", true);
+            }
         },
 
         /**
@@ -295,6 +299,11 @@ Aria.classDefinition({
 
             // Notify testacular in case it is available:
             aria.jsunit.TestacularReport.attachTestEngine(this._testRunner.getEngine());
+
+            if (this.getData().campaign.demoMode) {
+                this._testRunner.getRootTest().demoMode = true;
+            }
+
             this._testRunner.run(this.testObject, skipTests);
         },
 


### PR DESCRIPTION
demoMode can now be set on a testcase object (testObj.demoMode = true) in order to disable the global timeout and to not dispose the template test case at the end of the test.

It can be usefull to keep the ui of a template test case in order to perform manual tests or debug.
