### PR TITLE
fix #434 iframe tests timing out in devmode

### DIFF
--- a/test/iframeLoaderOs.js
+++ b/test/iframeLoaderOs.js
@@ -33,8 +33,7 @@
     window.loader = {
         changeRootFolder : function () {
             // Need to wait for some special classes to be here, before to continue
-            if (window.Aria && window.aria && window.aria.core && window.aria.core.DownloadMgr && aria.core.MultiLoader
-                    && (!isDev || (aria.widgets && aria.widgets.AriaSkin))) {
+            if (window.Aria && window.aria && window.aria.core && window.aria.core.DownloadMgr && aria.core.MultiLoader) {
                 Aria.rootFolderPath = baseUrl + "/";
                 aria.core.DownloadMgr.updateRootMap({
                     "aria" : {


### PR DESCRIPTION
Iframe loader kept waiting indefinitely for the skin to be loaded in dev mode. This was a clear code mistake, since the skin is loaded actually later in loadSkin() function.

The problem was manifesting itself in browser-based test runner.
An example failing test: test.aria.widgets.container.dialog.MaximizableDialogTest
