### PR TITLE
fix #436 content-type header for asyncFormSubmit

### DIFF
--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -379,6 +379,13 @@ Aria.classDefinition({
                 request.method = form.method;
             }
 
+            if (form.enctype && !request.headers) {
+                request.headers = {};
+                request.headers["Content-Type"] = form.enctype;
+            } else if (form.enctype && request.headers && !request.headers["Content-Type"]) {
+                request.headers["Content-Type"] = form.enctype;
+            }
+
             request.form = form;
             request.formId = form.id;
             return this.asyncRequest(request);
@@ -966,7 +973,8 @@ Aria.classDefinition({
             } else if (expectedResponseType == "json") {
                 if (response.responseJSON == null && response.responseText != null) {
                     // convert text to JSON
-                    var errorMsg = aria.utils.String.substitute(this.JSON_PARSING_ERROR, [response.url, response.responseText]);
+                    var errorMsg = aria.utils.String.substitute(this.JSON_PARSING_ERROR, [response.url,
+                            response.responseText]);
                     response.responseJSON = aria.utils.Json.load(response.responseText, this, errorMsg);
                 }
             }

--- a/test/aria/core/io/IOTestSuite.js
+++ b/test/aria/core/io/IOTestSuite.js
@@ -26,5 +26,6 @@ Aria.classDefinition({
         this.addTests("test.aria.core.io.IOTransportTest");
         this.addTests("test.aria.core.io.FormSubmit");
         this.addTests("test.aria.core.io.JSONPTest");
+        this.addTests("test.aria.core.io.issue436.FormSubmit");
     }
 });

--- a/test/aria/core/io/issue436/FormSubmit.js
+++ b/test/aria/core/io/issue436/FormSubmit.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.core.io.issue436.FormSubmit",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.String", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.request = {};
+    },
+    $prototype : {
+
+        testAsyncFormSubmissionWithEncType : function () {
+            this._injectForm();
+            this.request = {
+                formId : "simulateAsyncFormSubmit",
+                callback : {
+                    fn : this._testFormHandlerSuccess,
+                    scope : this,
+                    args : {
+                        testName : "testAsyncFormSubmissionWithEncType"
+                    }
+                }
+            };
+            aria.core.IO.asyncFormSubmit(this.request);
+        },
+
+        testAsyncFormSubmissionWithEncTypeWithHeaders : function () {
+            this._injectForm();
+            this.request = {
+                formId : "simulateAsyncFormSubmit",
+                headers : {
+                    some : "sdsds"
+                },
+                callback : {
+                    fn : this._testFormHandlerSuccess,
+                    scope : this,
+                    args : {
+                        testName : "testAsyncFormSubmissionWithEncTypeWithHeaders"
+                    }
+                }
+            };
+            aria.core.IO.asyncFormSubmit(this.request);
+        },
+
+        /**
+         * Helper to create the mock form
+         * @protected
+         */
+        _injectForm : function () {
+            aria.utils.Dom.replaceHTML("TESTAREA", "<form enctype='multipart/form-data' name='simulateAsyncFormSubmit' id='simulateAsyncFormSubmit' method='POST' action='"
+                    + Aria.rootFolderPath
+                    + "test/aria/core/test/TestFile.html'><input type='text' id='simulateAsyncFileUpload' name='simulateAsyncFileUpload' value='test.txt' style='-moz-opacity:0;filter:alpha(opacity: 0);opacity: 0;'></form>");
+        },
+
+        /**
+         * Callback used when request was successful
+         * @param {Object} request
+         * @protected
+         */
+        _testFormHandlerSuccess : function (response, args) {
+            try {
+
+                this.assertEquals(response.status, 200, "Response status is wrong");
+                this.assertEquals(this.request.headers["Content-Type"], "multipart/form-data", "Content-type header is not set properly");
+                this.assertEquals(aria.utils.Type.isString(response.responseText), true, "responseText must be a string");
+                this.notifyTestEnd(args.testName);
+            } catch (e) {
+                this.handleAsyncTestError(e);
+            }
+        }
+
+    }
+});


### PR DESCRIPTION
A condition is added if enctype is defined in the form the content-type header will be set.
