### PR TITLE
Fix npm start command again

### DIFF
--- a/build/grunt-config/config-checkStyle.js
+++ b/build/grunt-config/config-checkStyle.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
         },
         test : {
             files : {
-                src : ['test/**/*.js',
+                src : ['test/**/*.js', '!test/node/**/*.js',
                         // Using some window globals
                         '!test/iframeLoaderOs.js',
                         // Bad escaping
@@ -55,6 +55,12 @@ module.exports = function (grunt) {
                 "-W075" : true,
                 // Do not use String as a contructor
                 "-W053" : true
+            }
+        },
+        node : {
+            files : 'test/node/**/*.js',
+            options : {
+                "predef" : ["aria", "Aria", "require", "describe", "it", "before", "beforeEach", "after", "afterEach"]
             }
         }
     });

--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
     "grunt": "node build/grunt-cli.js",
     "attester": "node node_modules/attester/bin/attester.js test/attester.yml",
     "lint": "node build/grunt-cli.js checkStyle",
-    "test": "npm run-script lint && npm run-script attester && npm run-script grunt"
+    "mocha": "mocha --recursive test/node",
+    "test": "npm run-script lint && npm run-script grunt && npm run-script mocha && npm run-script attester"
   },
   "devDependencies": {
     "gzip-js": "0.3.1",
     "grunt-verifylowercase": "0.2.0",
     "grunt": "git+https://github.com/divdavem/grunt.git#776b38f39a9d3bcc4cf083d8cb54345dfef63301",
     "grunt-contrib-jshint": "0.2.0",
-    "attester": "1.0.2",
+    "attester": "1.1.0",
     "express": "3.0.3",
     "jade": "0.27.7",
-    "node-watch": "~0.2.4",
-    "atpackager": "0.1.0"
+    "atpackager": "0.1.0",
+    "mocha" : "1.8.2"
   }
 }

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -15,7 +15,6 @@
 
 var path = require("path");
 var express = require("express");
-var watch = require('node-watch');
 var app = express();
 
 // Render views with Jade
@@ -59,7 +58,7 @@ app.use("/css", express.static(__dirname + "/assets/css"));
 // Non minified version points to src folder
 app.use("/aria-templates/dev", express.static(__dirname + "/../src"));
 // Minified version points to standard build (npm install)
-app.use("/aria-templates", express.static(__dirname + "/../build/target/os-production"));
+app.use("/aria-templates", express.static(__dirname + "/../build/target/production"));
 // Test classpath redirects to test folder
 app.all(/^\/aria-templates\/test\/(.*)$/, function (req, res, next) {
     var file = path.normalize(__dirname + "/../test/" + req.params[0]);
@@ -80,14 +79,4 @@ server.on("error", function () {
 
 function serverStarted () {
     console.log("Server started on http://localhost:" + server.address().port);
-
-    watch(path.normalize(__dirname + "/../src/"), function (filename) {
-        console.log(filename, 'changed, starting a new package');
-
-        var spawn = require('child_process').spawn;
-        var grunt = spawn('node', ['node_modules/grunt/bin/grunt', 'package']);
-        grunt.on('exit', function (code) {
-            console.log('Framework re-packaged task ended with code ' + code);
-        });
-    });
 }

--- a/test/node/npm_start.js
+++ b/test/node/npm_start.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var spawn = require("child_process").spawn;
+var exec = require('child_process').exec;
+var path = require("path");
+var assert = require("assert");
+var http = require("http");
+
+// This test check that npm start loads correctly a web server configured to serve Aria Tests
+// It just checks that some files are served properly, hopefully the tester then works
+// This test must run after the build
+describe("npm start", function () {
+    var npm, port;
+
+    function get (url, callback) {
+        var response = "";
+
+        http.get(url, function (res) {
+            if (res.statusCode === 200) {
+                res.on("data", function (chunk) {
+                    response += chunk;
+                });
+                res.on("end", function () {
+                    process.nextTick(callback.bind(null, response));
+                });
+            } else {
+                response = false;
+                process.nextTick(callback.bind(null, response));
+            }
+        }).on("error", function (error) {
+            response = false;
+            process.nextTick(callback.bind(null, response));
+        });
+    }
+
+    before(function (callback) {
+        npm = spawn("node", ["scripts/server.js"], {
+            cwd : path.join(__dirname, "../../"),
+            stdio : "pipe"
+        });
+        npm.stdout.on("data", function (data) {
+            var info = data.toString().match(/Server started on \S+:(\d+)/i);
+            if (info) {
+                port = parseInt(info[1], 10);
+                callback();
+            }
+        });
+    });
+
+    it("should start the server", function (callback) {
+        assert.ok(port);
+
+        get("http://localhost:" + port, function (response) {
+            assert.ok(response, "Expecting to have a server response");
+            assert.ok(/run unit tests/gi.test(response), "Expecting to have a run test button");
+            callback();
+        });
+    });
+
+
+    it("should serve the test runner", function (callback) {
+        get("http://localhost:" + port + "/test", function (response) {
+            assert.ok(response, "Expecting to have a server response");
+            assert.ok(/Aria\.loadTemplate/gi.test(response), "Expecting to load a template");
+            callback();
+        });
+    });
+
+    it("should serve Aria Templates bootstrap file", function (callback) {
+        var url = "http://localhost:" + port + "/aria-templates/dev/aria/ariatemplates-bootstrap.js";
+        get(url, function (response) {
+            assert.ok(response, "Expecting to have a server response");
+            assert.ok(/rootFolderPath/gi.test(response), "Expecting to receive the bootstrap");
+            callback();
+        });
+    });
+
+    it("should serve Aria Templates bootstrap file", function (callback) {
+        var url = "http://localhost:" + port + "/aria-templates/aria/ariatemplates-" + process.env.npm_package_version + ".js";
+        get(url, function (response) {
+            assert.ok(response, "Expecting to have a server response");
+            assert.ok(/rootFolderPath/gi.test(response), "Expecting to receive the bootstrap");
+            callback();
+        });
+    });
+
+    after(function (callback) {
+        npm.on("exit", function () {
+            callback();
+        });
+        npm.kill();
+    });
+});


### PR DESCRIPTION
Since the new build changed some path, this commit is needed to fix `npm start`.
Finally it introduces a test case in node+mocha to make sure that the command keeps working.
It removes the `watch` feature as it was hogging the cpu.
