### PR TITLE
Avoid * in the root map for the aria package itself.

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -73,6 +73,7 @@ module.exports = function (grunt) {
                         cfg : {
                             mapFile : mainATFile,
                             sourceFiles : ['**/*', '!aria/css/**/*'],
+                            starCompress : ['**/*', '!aria'],
                             starStarCompress : ['**/*', '!aria/resources']
                         }
                     }, {


### PR DESCRIPTION
With #400, the way the root map is generated changed. Now \* and *\* entries are used much more than before to try and make the root map as small as possible.

However it is not desirable for all packages, especially the `aria` package for which it should be possible to download other files which were not originally packaged with the framework.
