### PR TITLE
Change test url in jsonp test

### DIFF
--- a/src/aria/core/transport/JsonP.js
+++ b/src/aria/core/transport/JsonP.js
@@ -70,6 +70,7 @@ Aria.classDefinition({
                 script.src = request.url;
                 script.id = "xJsonP" + reqId;
                 script.async = "async";
+                script.type = "text/javascript";
 
                 script.onload = script.onreadystatechange = function (event, isAbort) {
                     if (isAbort || !script.readyState || /loaded|complete/.test(script.readyState)) {

--- a/test/aria/core/io/JSONPTest.js
+++ b/test/aria/core/io/JSONPTest.js
@@ -180,7 +180,7 @@ Aria.classDefinition({
          */
         testAsyncRemote : function () {
             aria.core.IO.jsonp({
-                url : "http://search.twitter.com/search.json?q=ariatemplates&rpp=1",
+                url : "http://jsfiddle.net/echo/jsonp/?query=ariatemplates",
                 timeout : 5000,
                 callback : {
                     fn : this._onTestRemoteSuccess,
@@ -193,7 +193,7 @@ Aria.classDefinition({
         },
         _onTestRemoteSuccess : function (response, testName) {
             try {
-                this.assertTrue(response.url.indexOf("http://search.twitter.com/search.json?q=ariatemplates") === 0, "Wrong URL: "
+                this.assertTrue(response.url.indexOf("http://jsfiddle.net/echo/jsonp/?query=ariatemplates") === 0, "Wrong URL: "
                         + response.url);
                 this.assertEquals(response.responseJSON.query, "ariatemplates");
             } catch (er) {}
@@ -224,7 +224,7 @@ Aria.classDefinition({
             };
             aria.core.IOFiltersMgr.addFilter(filterParam);
             request = {
-                url : "http://search.twitter.com/search.json?q=ariatemplates&rpp=1",
+                url : "http://jsfiddle.net/echo/jsonp/?query=ariatemplates",
                 timeout : 5000,
                 callback : {
                     fn : function (res) {
@@ -265,7 +265,7 @@ Aria.classDefinition({
                         try {
                             oSelf.assertTrue(req == request);
                             oSelf.assertTrue(req.jsonp == null);
-                            req.url = "http://search.twitter.com/search.json?q=ariatemplates&rpp=1";
+                            req.url = "http://jsfiddle.net/echo/jsonp/?query=ariatemplates";
                             req.jsonp = "callback";
                         } catch (e) {
                             this.handleAsyncTestError(e, false);


### PR DESCRIPTION
We used to target twitter for testing real jsonp requests. Lately twitter API became rate limited and thus failing from time to time.
This changes to jsfiddle echo service.
