### PR TITLE
fix #452 MouseEvent.pageX/Y not supported in Firefox 3.6 (FireDomEvent)

### DIFF
--- a/src/aria/utils/FireDomEvent.js
+++ b/src/aria/utils/FireDomEvent.js
@@ -525,8 +525,47 @@
         $constructor : function () {
             typeUtils = aria.utils.Type;
             fireDomEvent = this;
+
+            // Workaround for the bug in Firefox 3.6 where customEvent.pageX is unsettable
+            var browser = aria.core.Browser;
+            if (browser.isFirefox && browser.majorVersion == 3) {
+                var mouseEventProto = Aria.$window.MouseEvent.prototype;
+
+                this.originalPageXsetter = mouseEventProto.__lookupSetter__('pageX');
+                this.originalPageXgetter = mouseEventProto.__lookupGetter__('pageX');
+                this.originalPageYsetter = mouseEventProto.__lookupSetter__('pageY');
+                this.originalPageYgetter = mouseEventProto.__lookupGetter__('pageY');
+
+                mouseEventProto.__defineSetter__('pageX', function (val) {
+                    this.__pageX = val;
+                });
+                mouseEventProto.__defineGetter__('pageX', function () {
+                    return this.__pageX;
+                });
+                mouseEventProto.__defineSetter__('pageY', function (val) {
+                    this.__pageY = val;
+                });
+                mouseEventProto.__defineGetter__('pageY', function () {
+                    return this.__pageY;
+                });
+            }
         },
         $destructor : function () {
+            var browser = aria.core.Browser;
+            if (browser.isFirefox && browser.majorVersion == 3) {
+                var mouseEventProto = Aria.$window.MouseEvent.prototype;
+
+                mouseEventProto.__defineSetter__('pageX', this.originalPageXsetter);
+                mouseEventProto.__defineGetter__('pageX', this.originalPageXgetter);
+                mouseEventProto.__defineSetter__('pageY', this.originalPageYsetter);
+                mouseEventProto.__defineGetter__('pageY', this.originalPageYgetter);
+
+                this.originalPageXsetter = null;
+                this.originalPageXgetter = null;
+                this.originalPageYsetter = null;
+                this.originalPageYgetter = null;
+            }
+
             typeUtils = null;
             fireDomEvent = null;
         },


### PR DESCRIPTION
Since e4e3296618f13aa307a7acc4e9a452381f003985, multiple test cases were failing in Firefox 3.6 due to the bug in the browser where an error was thrown when trying to override pageX/pageY of a custom event. This commit adds a workaround for that bug.
