### PR TITLE
fix #454 can not select options in AutoComplete

### DIFF
--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -23,7 +23,7 @@
         {var className = _getClassForItem(item)/}
         {var entry = item.object.entry/}
     
-        <a href="#" class="${className}" _itemIdx="${itemIdx}" onclick="return false;">
+        <a href="#" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}


### PR DESCRIPTION
In b88bc5173c227746af98dc6fab20f58235f8c164, deprecated usage of expandos was removed from DomElementWrapper, but it was still used in the TPL code and due to it, options could not be selected in AutoComplete.
