### PR TITLE
feat #440 autocomplete selection using multiple keys

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -876,6 +876,46 @@ Aria.beanDefinitions({
                 "listSclass" : {
                     $type : "json:String",
                     $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
+                },
+                "selectionKeys" : {
+                    $type : "json:Array",
+                    $description : "Keys defined for submitting a selected item from autocomplete dropdown, key codes and strings can be taken from aria.DomEven",
+                    $contentType : {
+                        $type : "json:Object",
+                        $properties : {
+                            "key" : {
+                                $type : "json:MultiTypes",
+                                $description : "description of the key",
+                                $mandatory : true,
+                                $contentTypes : [{
+                                            $type : "json:Integer",
+                                            $description : "key code"
+                                        }, {
+                                            $type : "json:String",
+                                            $description : "String representing the key",
+                                            $sample : "F4"
+                                        }]
+                            },
+                            "ctrl" : {
+                                $type : "json:Boolean",
+                                $description : "Whether or not the ctrl key has to pressed",
+                                $default : false
+                            },
+                            "shift" : {
+                                $type : "json:Boolean",
+                                $description : "Whether or not the shift key has to pressed",
+                                $default : false
+                            },
+                            "alt" : {
+                                $type : "json:Boolean",
+                                $description : "Whether or not the alt key has to pressed",
+                                $default : false
+                            }
+                        }
+                    },
+                    $default : [{
+                                key : "ENTER"
+                            }]
                 }
             }
         },

--- a/src/aria/widgets/controllers/AutoCompleteController.js
+++ b/src/aria/widgets/controllers/AutoCompleteController.js
@@ -82,6 +82,13 @@
 
             // Inherited from aria.html.controllers.Suggestions
             this._init();
+
+            /**
+             * Keys defined for submitting a selected item from autocomplete dropdown
+             * @type {aria.widgets.CfgBeans.AutoCompleteCfg.$properties.selectionKeys}
+             */
+            this.selectionKeys = null;
+
         },
         $destructor : function () {
             this.dispose();
@@ -462,6 +469,48 @@
                         keepSelectedValue : true
                     }
                 });
+            },
+
+            /**
+             * Validates an event against a configuration
+             * @param {Object} config
+             * @param {aria.DomEvent} event
+             * @protected
+             */
+            _validateModifiers : function (config, event) {
+                return (event.altKey == !!config.alt) && (event.shiftKey == !!config.shift)
+                        && (event.ctrlKey == !!config.ctrl);
+            },
+
+            /**
+             * Checking against special key combinations that trigger a selection of the item in the dropdown
+             * @param {aria.DomEvent} event
+             * @return {Boolean} Whether the event corresponds to a selection key
+             * @protected
+             */
+            _checkSelectionKeys : function (event) {
+                var specialKey = false, keyCode = event.keyCode;
+                for (var index = 0, keyMap; index < this.selectionKeys.length; index++) {
+                    keyMap = this.selectionKeys[index];
+                    if (this._validateModifiers(keyMap, event)) {
+                        // case real key defined. For eg: 65 for a
+                        if (aria.utils.Type.isNumber(keyMap.key)) {
+                            if (keyMap.key === keyCode) {
+                                specialKey = true;
+                                break;
+                            }
+                        } else if (typeof(keyMap.key) !== "undefined"
+                                && event["KC_" + keyMap.key.toUpperCase()] == keyCode) {
+                            specialKey = true;
+                            break;
+                        } else if (typeof(keyMap.key) !== "undefined"
+                                && String.fromCharCode(event.charCode) == keyMap.key) {
+                            specialKey = true;
+                            break;
+                        }
+                    }
+                }
+                return specialKey;
             }
 
         }

--- a/src/aria/widgets/controllers/DropDownListController.js
+++ b/src/aria/widgets/controllers/DropDownListController.js
@@ -102,18 +102,32 @@ Aria.classDefinition({
         },
 
         /**
+         * Checking against special key combinations that trigger a selection of the item in the dropdown
+         * @param {aria.DomEvent} event
+         * @return {Boolean} Whether the event corresponds to a selection key
+         * @protected
+         */
+        _checkSelectionKeys : function (event) {
+            return event.keyCode == event.KC_ENTER;
+        },
+
+        /**
          * OVERRIDE TextDataController.checkKeyStroke
          * @param {Integer} charCode
          * @param {Integer} keyCode
          * @param {String} currentText
          * @param {Integer} caretPos
+         * @parm {aria.DomEvent} event
          * @return {aria.widgets.controllers.reports.ControllerReport}
          */
-        checkKeyStroke : function (charCode, keyCode, currentText, caretPosStart, caretPosEnd) {
+        checkKeyStroke : function (charCode, keyCode, currentText, caretPosStart, caretPosEnd, event) {
             var dataModel = this._dataModel, domEvent = aria.DomEvent, report;
+            var selectionKey = null;
 
-            if (!domEvent.isNavigationKey(keyCode)) {
-
+            if (this._listWidget) {
+                selectionKey = this._checkSelectionKeys(event);
+            }
+            if (!domEvent.isNavigationKey(keyCode) && !selectionKey) {
                 // value that should be in the input after this keystroke and also the caret positions
                 var nextValueObject;
                 var isDelKey = (keyCode == domEvent.KC_DELETE || keyCode == domEvent.KC_BACKSPACE);
@@ -130,7 +144,7 @@ Aria.classDefinition({
 
             // Handling for navigation. First if dropdown list is opened
             if (this._listWidget) {
-                if (keyCode == domEvent.KC_ESCAPE) {
+                if (!selectionKey && keyCode == domEvent.KC_ESCAPE) {
                     report = this.checkText(dataModel.initialInput);
                     if (!report) {
                         report = new aria.widgets.controllers.reports.DropDownControllerReport();
@@ -141,7 +155,8 @@ Aria.classDefinition({
                     report.value = report.text;
                     dataModel.value = null;
                     return report;
-                } else if (keyCode == domEvent.KC_ENTER) {
+
+                } else if (selectionKey || keyCode == domEvent.KC_ENTER) {
                     if (dataModel.listContent.length === 1) {
                         dataModel.selectedIdx = 0;
                         dataModel.text = this._getLabelFromListValue(dataModel.listContent[dataModel.selectedIdx]);

--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -66,6 +66,7 @@ Aria.classDefinition({
         controller.freeText = this._cfg.freeText;
         controller.maxlength = this._cfg.maxlength;
         controller.expandButton = this._cfg.expandButton;
+        controller.selectionKeys = this._cfg.selectionKeys;
     },
     $destructor : function () {
         // The dropdown might still be open when we destroy the widget, destroy it now

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -111,7 +111,7 @@ Aria.classDefinition({
             var controller = this.controller;
             var cp = this.getCaretPosition();
             if (cp) {
-                var report = controller.checkKeyStroke(event.charCode, event.keyCode, this.getTextInputField().value, cp.start, cp.end);
+                var report = controller.checkKeyStroke(event.charCode, event.keyCode, this.getTextInputField().value, cp.start, cp.end, event);
                 // event may not always be a DomEvent object, that's why we check for the existence of
                 // preventDefault on it
                 if (report && report.cancelKeyStroke && event.preventDefault) {

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -18,7 +18,6 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TestSuite",
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
-
         this.addTests("test.aria.widgets.form.CheckBoxTest");
         this.addTests("test.aria.widgets.form.GaugeTest");
         this.addTests("test.aria.widgets.form.InputTest");
@@ -34,5 +33,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
         this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
         this.addTests("test.aria.widgets.form.issue411.DropdownTestSuite");
+        this.addTests("test.aria.widgets.form.autocomplete.issue440.AutoComplete");
+        this.addTests("test.aria.widgets.form.autocomplete.issue440.AutoComplete1");
     }
 });

--- a/test/aria/widgets/form/autocomplete/issue440/AutoComplete.js
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoComplete.js
@@ -1,0 +1,56 @@
+/**
+ * UI template test for Github Issue 440
+ */
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.form.autocomplete.issue440.AutoComplete',
+    $extends : 'aria.jsunit.TemplateUITestCase',
+    $constructor : function () {
+        this.$TemplateUITestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.autocomplete.issue440.AutoCompleteTpl",
+            data : {
+                ac_air_value : null
+            }
+        });
+    },
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            var field = this.getInputField("acDest1");
+            field.focus();
+            this._downArrow();
+        },
+        _downArrow : function () {
+            this.synEvent.type(this.getInputField("acDest1"), "a", {
+                fn : this._addDelay,
+                scope : this
+            });
+        },
+        _addDelay : function () {
+            aria.core.Timer.addCallback({
+                fn : this._checkSelected,
+                scope : this,
+                delay : 1000
+            });
+        },
+        _checkSelected : function () {
+            this.synEvent.type(this.getInputField("acDest1"), "[down][down][down][a]", {
+                fn : this._finishTest,
+                scope : this
+            });
+        },
+
+        /**
+         * Finalize the test, check the widgets values are the same.
+         */
+        _finishTest : function () {
+            var test1 = this.getInputField("acDest1");
+            var test2 = this.getInputField("acDest2");
+            this.assertTrue(test1.value === test2.value);
+            this.assertTrue(this.templateCtxt.data.ac_air_value.label === "Air Canada");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/issue440/AutoComplete1.js
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoComplete1.js
@@ -1,0 +1,55 @@
+/**
+ * UI template test for Github Issue 440
+ */
+Aria.classDefinition({
+    $classpath : 'test.aria.widgets.form.autocomplete.issue440.AutoComplete1',
+    $extends : 'aria.jsunit.TemplateUITestCase',
+    $constructor : function () {
+        this.$TemplateUITestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.autocomplete.issue440.AutoCompleteTpl1",
+            data : {
+                ac_air_value : null
+            }
+        });
+    },
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            var field = this.getInputField("acDest1");
+            field.focus();
+            this._downArrow();
+        },
+        _downArrow : function () {
+            this.synEvent.type(this.getInputField("acDest1"), "a", {
+                fn : this._addDelay,
+                scope : this
+            });
+        },
+        _addDelay : function () {
+            aria.core.Timer.addCallback({
+                fn : this._checkSelected,
+                scope : this,
+                delay : 1000
+            });
+        },
+        _checkSelected : function () {
+            this.synEvent.type(this.getInputField("acDest1"), "[down][down][down][ctrl][a]", {
+                fn : this._finishTest,
+                scope : this
+            });
+        },
+        /**
+         * Finalize the test, check the widgets values are the same.
+         */
+        _finishTest : function () {
+            var test1 = this.getInputField("acDest1");
+            var test2 = this.getInputField("acDest2");
+            this.assertTrue(test1.value === test2.value);
+            this.assertTrue(this.templateCtxt.data.ac_air_value.label === "Air Canada");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl.tpl
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl.tpl
@@ -1,0 +1,52 @@
+{Template {
+	$classpath:'test.aria.widgets.form.autocomplete.issue440.AutoCompleteTpl',
+	$hasScript:true,
+	$width: {min: 500}
+}}
+
+		
+
+
+	{macro main()}
+		<h2>AutoComplete with AIR resources handler</h2> <br />
+		
+		{@aria:AutoComplete {
+			id: "acDest1",
+			label:"Choose your destination: ",			
+			labelPos:"left",
+			labelAlign:"right",
+			width:400,
+			block:false,
+			labelWidth:180,
+			resourcesHandler:getAirLinesHandler(),
+			bind:{
+			  	"value" : {
+			  		inside : data, 
+			  		to : 'ac_air_value'
+		  		}
+			},
+			selectionKeys : [{
+						key : "a"
+					}]	
+		}/}		
+		
+		{@aria:AutoComplete {
+			id: "acDest2",
+			label:"Choose your destination: ",			
+			labelPos:"left",
+			labelAlign:"right",
+			width:400,
+			block:false,
+			labelWidth:180,
+			resourcesHandler:getAirLinesHandler(),
+			bind:{
+			  	"value" : {
+			  		inside : data, 
+			  		to : 'ac_air_value'
+		  		}
+			}	
+		}/}		
+		
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl1.tpl
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl1.tpl
@@ -1,0 +1,53 @@
+{Template {
+	$classpath:'test.aria.widgets.form.autocomplete.issue440.AutoCompleteTpl1',
+	$hasScript:true,
+	$width: {min: 500}
+}}
+
+		
+
+
+	{macro main()}
+		<h2>AutoComplete with AIR resources handler</h2> <br />
+		
+		{@aria:AutoComplete {
+			id: "acDest1",
+			label:"Choose your destination: ",			
+			labelPos:"left",
+			labelAlign:"right",
+			width:400,
+			block:false,
+			labelWidth:180,
+			resourcesHandler:getAirLinesHandler(),
+			bind:{
+			  	"value" : {
+			  		inside : data, 
+			  		to : 'ac_air_value'
+		  		}
+			},
+			selectionKeys : [{
+						key : "a",
+						ctrl : true
+					}]	
+		}/}		
+		
+		{@aria:AutoComplete {
+			id: "acDest2",
+			label:"Choose your destination: ",			
+			labelPos:"left",
+			labelAlign:"right",
+			width:400,
+			block:false,
+			labelWidth:180,
+			resourcesHandler:getAirLinesHandler(),
+			bind:{
+			  	"value" : {
+			  		inside : data, 
+			  		to : 'ac_air_value'
+		  		}
+			}	
+		}/}		
+		
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl1Script.js
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTpl1Script.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amadeus
+ */
+/**
+ * Script for the autocomplete sample
+ * @class samples.widgets.form.templates.AutoCompleteSampleScript
+ */
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.autocomplete.issue440.AutoCompleteTpl1Script',
+    $dependencies : ['aria.resources.handlers.LCResourcesHandler'],
+    $constructor : function () {
+        this.airlinesHandler = this.newAirLinesHandler();
+    },
+    $destructor : function () {
+        this.airlinesHandler = null;
+        if (this.resourcesHandler) {
+            this.resourcesHandler.$dispose();
+            this.resourcesHandler = null;
+        }
+    },
+    $prototype : {
+        newAirLinesHandler : function (cfg) {
+            var handler = this.resourcesHandler = new aria.resources.handlers.LCResourcesHandler(cfg);
+            handler.setSuggestions([{
+                        label : 'Air France',
+                        code : 'AF'
+                    }, {
+                        label : 'Air Canada',
+                        code : 'AC'
+                    }, {
+                        label : 'Finnair',
+                        code : 'XX'
+                    }, {
+                        label : 'Qantas',
+                        code : '--'
+                    }, {
+                        label : 'American Airlines',
+                        code : 'AA'
+                    }, {
+                        label : 'Emirates',
+                        code : 'EK'
+                    }, {
+                        label : 'Scandinavian Airlines System',
+                        code : 'SK'
+                    }]);
+            return handler;
+        },
+        getAirLinesHandler : function () {
+            return this.airlinesHandler;
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTplScript.js
+++ b/test/aria/widgets/form/autocomplete/issue440/AutoCompleteTplScript.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amadeus
+ */
+/**
+ * Script for the autocomplete sample
+ * @class samples.widgets.form.templates.AutoCompleteSampleScript
+ */
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.autocomplete.issue440.AutoCompleteTplScript',
+    $dependencies : ['aria.resources.handlers.LCResourcesHandler'],
+    $constructor : function () {
+        this.airlinesHandler = this.newAirLinesHandler();
+    },
+    $destructor : function () {
+        this.airlinesHandler = null;
+        if (this.resourcesHandler) {
+            this.resourcesHandler.$dispose();
+            this.resourcesHandler = null;
+        }
+    },
+    $prototype : {
+        newAirLinesHandler : function (cfg) {
+            var handler = this.resourcesHandler = new aria.resources.handlers.LCResourcesHandler(cfg);
+            handler.setSuggestions([{
+                        label : 'Air France',
+                        code : 'AF'
+                    }, {
+                        label : 'Air Canada',
+                        code : 'AC'
+                    }, {
+                        label : 'Finnair',
+                        code : 'XX'
+                    }, {
+                        label : 'Qantas',
+                        code : '--'
+                    }, {
+                        label : 'American Airlines',
+                        code : 'AA'
+                    }, {
+                        label : 'Emirates',
+                        code : 'EK'
+                    }, {
+                        label : 'Scandinavian Airlines System',
+                        code : 'SK'
+                    }]);
+            return handler;
+        },
+        getAirLinesHandler : function () {
+            return this.airlinesHandler;
+        }
+    }
+});


### PR DESCRIPTION
Developer should be able to define multiple keys that can be used to perform selection in an auto-complete widget. Currently ENTER key is used for this functionality.   On the other hand, if the user does not want selection upon pressing enter, he should be able to do so.
