### PR TITLE
fix #458 error when no skin and no widgets loaded

### DIFF
--- a/src/aria/core/TplClassLoader.js
+++ b/src/aria/core/TplClassLoader.js
@@ -150,7 +150,7 @@
         }
 
         var cssToReload = ['aria.templates.GlobalStyle'];
-        if (aria.widgets.AriaSkin) {
+        if (aria.widgets && aria.widgets.AriaSkin) {
             cssToReload.push('aria.templates.LegacyGeneralStyle');
         }
         if (cfg.reload) {

--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -170,7 +170,7 @@
                 if (this._globalCssDepsLoaded) {
                     // PTR 05086835: only unload the global CSS if it was loaded by this instance
                     var deps = ['aria.templates.GlobalStyle'];
-                    if (aria.widgets.AriaSkin) {
+                    if (aria.widgets && aria.widgets.AriaSkin) {
                         deps.push('aria.templates.LegacyGeneralStyle');
                     }
                     aria.templates.CSSMgr.unloadWidgetDependencies('aria.templates.Template', deps);


### PR DESCRIPTION
Due to a bug in the code delivered in 59e9ba72a65c810df7935c5a1a4195365e44d233 (pull request #427), when no skin and no widgets were loaded, JavaScript errors were thrown due to nullpointer exception.
