### PR TITLE
aria.widgets can be undefined

### DIFF
--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -1707,7 +1707,7 @@
                     if (this._cfg.isRootTemplate) {
                         // PTR 05086835: load the global CSS here, and remember that it was loaded
                         var deps = ['aria.templates.GlobalStyle'];
-                        if (aria.widgets.AriaSkin) {
+                        if (aria.widgets && aria.widgets.AriaSkin) {
                             deps.push('aria.templates.LegacyGeneralStyle');
                         }
                         aria.templates.CSSMgr.loadWidgetDependencies('aria.templates.Template', deps);

--- a/src/aria/tools/contextual/ContextualMenu.js
+++ b/src/aria/tools/contextual/ContextualMenu.js
@@ -138,7 +138,7 @@
                     // (required as it uses widgets)
                     // TODO: investigate to plug with event delegation
                     // when ready
-                    if (aria.widgets.AriaSkin) {
+                    if (aria.widgets && aria.widgets.AriaSkin) {
                         this._enabled = true;
                         eventUtils.addListener(document, "contextmenu", {
                             fn : this._onContextMenu,


### PR DESCRIPTION
When no class in aria.widgets package is loaded, `aria.widgets` is undefined.
Before checking if `aria.widgets.AriaSkin` is defined, the existence of `aria.widgets` has to be checked first.
