### PR TITLE
Focus on element inside Dialog widget not working on IE7

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -561,7 +561,13 @@ Aria.classDefinition({
                 aria.templates.NavigationManager.focusFirst(this._domElt);
             }
 
-            this.evalCallback(cfg.onOpen);
+            aria.core.Timer.addCallback({
+                fn : function () {
+                    this.evalCallback(cfg.onOpen);
+                },
+                scope : this,
+                delay : 4
+            });
 
             if (cfg.maximized) {
                 return; // don't create movable nor resizable


### PR DESCRIPTION
After dialog popup open, the $focus called from the callback it's not applied to the element.
