### PR TITLE
Moving grunt configuration values

### DIFF
--- a/build/grunt-config/config-atpackager-bootstrap.js
+++ b/build/grunt-config/config-atpackager-bootstrap.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
                                 header : '<%= packaging.license %>'
                             }
                         },
-                        files : require('../config/files-bootstrap.json')
+                        files : '<%= packaging.bootstrap.files %>'
                     }, {
                         name : 'aria/css/atskin-<%= pkg.version %>.js',
                         files : ['aria/css/atskin.js']

--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
         options : {
             ATBootstrapFile : mainATFile,
             sourceDirectories : ['<%= packaging.bootstrap.outputdir %>'],
-            sourceFiles : ['**/*'],
+            sourceFiles : '<%= packaging.prod.source_files %>',
             defaultBuilder : {
                 type : 'ATMultipart',
                 cfg : {

--- a/build/grunt-config/config-packaging.js
+++ b/build/grunt-config/config-packaging.js
@@ -19,6 +19,7 @@ module.exports = function (grunt) {
     grunt.config.set('packaging.bootstrap.files', require('../config/files-bootstrap.json'));
     grunt.config.set('packaging.prod.outputdir', 'build/target/production');
     grunt.config.set('packaging.prod.files', require('../config/files-prod.json'));
+    grunt.config.set('packaging.prod.source_files', ['**/*']);
     grunt.config.set('packaging.prod.allow_unpackaged_files', []);
     grunt.config.set('packaging.prod.localization_files', require('../config/files-prod-localization.json'));
     grunt.config.set('packaging.prod.hash_include_files', []);


### PR DESCRIPTION
This pull request moves some build configuration values from `config-atpackager-bootstrap.js` to `config-packaging.js` to have more control on the build when overriding `config-packaging.js`.
