### PR TITLE
selectbox doesn't work when selected value is equal to zero

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -589,9 +589,16 @@ Aria.beanDefinitions({
             $restricted : false,
             $properties : {
                 "value" : {
-                    $type : "json:String",
+                    $type : "json:MultiTypes",
                     $description : "Internal value associated to the option - usually a language-independent code",
-                    $mandatory : true
+                    $mandatory : true,
+                    $contentTypes : [{
+                        $type : "json:Integer",
+                        $description : ""
+                    }, {
+                        $type : "json:String",
+                        $description : ""
+                    }]
                 },
                 "label" : {
                     $type : "json:String",

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -1042,7 +1042,7 @@ Aria.classDefinition({
                 // if the value is not set (namely it is null, undefined, an
                 // empty string or an empty array) and the
                 // prefill is defined
-                if ((aria.utils.Type.isArray(value) && aria.utils.Array.isEmpty(value)) || !value) {
+                if ((aria.utils.Type.isArray(value) && aria.utils.Array.isEmpty(value)) || (!value && value !== 0)) {
                     if (cfg.prefill && cfg.prefill + "") {
                         this._isPrefilled = true;
                     } else {

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -34,5 +34,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
         this.addTests("test.aria.widgets.form.issue411.DropdownTestSuite");
         this.addTests("test.aria.widgets.form.autocomplete.AutoCompleteTestSuite");
+        this.addTests("test.aria.widgets.form.selectbox.SelectboxTestCase");
     }
 });

--- a/test/aria/widgets/form/selectbox/SelectboxTestCase.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestCase.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+	$classpath : "test.aria.widgets.form.selectbox.SelectboxTestCase",
+	$extends : "aria.jsunit.TemplateTestCase",
+	$dependencies : ["aria.jsunit.SynEvents", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this.cont = 0;
+        this.selectbox = null;
+        this.inputField = null;
+        this.expandButton = null;
+        this.dropdown = null;
+        this.options = null;
+
+        this.data = {
+            selection : ''
+        };
+
+        this.setTestEnv({
+            template : "test.aria.widgets.form.selectbox.SelectboxTestCaseTpl",
+            data : this.data
+        });
+    },
+    $destructor : function () {
+        this.cont = null;
+        this.selectbox = null;
+        this.inputField = null;
+        this.expandButton = null;
+        this.dropdown = null;
+        this.options = null;
+        this.$TemplateTestCase.$destructor.call(this);
+    },
+	$prototype : {
+		runTemplateTest : function () {
+            this.selectbox = this.getWidgetInstance("myId");
+            this.inputField = this.getInputField("myId");
+            this.expandButton = this.getExpandButton("myId");
+
+            aria.utils.SynEvents.click(this.expandButton, {
+                fn : this._afterClick,
+                scope : this
+            });
+		},
+
+        _afterClick : function () {
+            this.cont += 1;
+            aria.core.Timer.addCallback({
+                fn : this._afterTimer,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        _afterTimer : function () {
+            this.dropdown = this.getWidgetDropDownPopup("myId");
+            this.options = this.getElementsByClassName(this.dropdown, "xLISTEnabledItem_dropdown");
+
+            var opts = {};
+            opts.to = this.cont == 1 ? this.options[0] : this.options[1];
+
+            aria.utils.SynEvents.move(opts, this.inputField, {
+                fn : this._afterMouseMoveDown,
+                scope : this
+            });
+        },
+
+        _afterMouseMoveDown : function () {
+            if (this.cont == 1) {
+                aria.utils.SynEvents.click(this.options[0], {
+                    fn : this._afterItemClick,
+                    scope : this
+                });
+            } else {
+                aria.utils.SynEvents.click(this.options[1], {
+                    fn : this._afterItemClick,
+                    scope : this
+                });
+            }
+        },
+
+        _afterItemClick : function () {
+            if (this.cont === 1) {
+                this.assertTrue(this.inputField.value === "option 0");
+            } else {
+                this.inputField = this.getInputField("myId");
+                this.assertTrue(this.inputField.value === "option 1");
+                this.end();
+            }
+
+            aria.core.Timer.addCallback({
+                fn : this._afterSecondTimer,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        _afterSecondTimer : function () {
+            this.expandButton = this.getExpandButton("myId");
+            aria.utils.SynEvents.click(this.expandButton, {
+                fn : this._afterClick,
+                scope : this
+            });
+        }
+	}
+});

--- a/test/aria/widgets/form/selectbox/SelectboxTestCaseTpl.tpl
+++ b/test/aria/widgets/form/selectbox/SelectboxTestCaseTpl.tpl
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath : "test.aria.widgets.form.selectbox.SelectboxTestCaseTpl",
+	$hasScript : true
+}}
+
+{macro main()}
+
+<div id="justToGetTheCorrectDom">
+
+  {@aria:SelectBox {
+      id : "myId",
+      options : getOptions(),
+      bind: {
+        value: {
+          inside: data,
+          to: 'selection'
+        }
+      },
+        helptext: 'HELPTEXT'
+  }/}
+
+</div>
+
+<div id="outsideDiv">&nbsp;</div>
+
+{/macro}
+{/Template}

--- a/test/aria/widgets/form/selectbox/SelectboxTestCaseTplScript.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestCaseTplScript.js
@@ -1,0 +1,16 @@
+Aria.tplScriptDefinition({
+    $classpath: 'test.aria.widgets.form.selectbox.SelectboxTestCaseTplScript',
+    $constructor: function() {},
+    $prototype: {
+        getOptions: function() {
+            var opts = [];
+            for (var i = 0; i < 10; i++) {
+                opts.push({
+                    value: i,
+                    label: 'option ' + i
+                });
+            }
+            return opts;
+        }
+    }
+});


### PR DESCRIPTION
When the selected value is zero, the selectbox doesn't work properly. If condition changed in order to avoid weird behaves with value equals to zero.
