### PR TITLE
fix #481 selectionKey/AutoCompleteModifier fail in IE

### DIFF
--- a/test/aria/widgets/form/autocomplete/selectionKey/AutoComplete.js
+++ b/test/aria/widgets/form/autocomplete/selectionKey/AutoComplete.js
@@ -48,8 +48,8 @@ Aria.classDefinition({
         _finishTest : function () {
             var test1 = this.getInputField("acDest1");
             var test2 = this.getInputField("acDest2");
-            this.assertTrue(test1.value === test2.value);
-            this.assertTrue(this.templateCtxt.data.ac_air_value.label === "Air Canada");
+            this.assertEquals(test1.value, test2.value);
+            this.assertEquals(this.templateCtxt.data.ac_air_value.label, "Air Canada");
             this.notifyTemplateTestEnd();
         }
     }

--- a/test/aria/widgets/form/autocomplete/selectionKey/AutoCompleteModifier.js
+++ b/test/aria/widgets/form/autocomplete/selectionKey/AutoCompleteModifier.js
@@ -48,7 +48,7 @@ Aria.classDefinition({
             });
         },
         _checkSelected : function () {
-            this.synEvent.type(this.getInputField("acDest1"), "[down][down][down][ctrl][a]", {
+            this.synEvent.type(this.getInputField("acDest1"), "[down][down][down][shift][a]", {
                 fn : this._finishTest,
                 scope : this
             });
@@ -59,8 +59,8 @@ Aria.classDefinition({
         _finishTest : function () {
             var test1 = this.getInputField("acDest1");
             var test2 = this.getInputField("acDest2");
-            this.assertTrue(test1.value === test2.value);
-            this.assertTrue(this.templateCtxt.data.ac_air_value.label === "Air Canada");
+            this.assertEquals(test1.value, test2.value);
+            this.assertEquals(this.templateCtxt.data.ac_air_value.label, "Air Canada");
             this.notifyTemplateTestEnd();
         }
     }

--- a/test/aria/widgets/form/autocomplete/selectionKey/AutoCompleteTplModifier.tpl
+++ b/test/aria/widgets/form/autocomplete/selectionKey/AutoCompleteTplModifier.tpl
@@ -39,7 +39,7 @@
 			},
 			selectionKeys : [{
 						key : "a",
-						ctrl : true
+						shift : true
 					}]
 		}/}
 


### PR DESCRIPTION
This is a temporary fix to make the test pass in IE, by changing the
modifier from Ctrl to Shift.

A new test with `ctrl` as a modifier should be added later. Perhaps an update of Syn will be needed. This commit: https://github.com/bitovi/syn/commit/c77936b3b625428441fc01d337dfd79186c48400 partially resolves the issue but not entirely.
