### PR TITLE
Invalid display of table frames when changing line-height.

### DIFF
--- a/src/aria/widgets/frames/TableFrame.js
+++ b/src/aria/widgets/frames/TableFrame.js
@@ -106,10 +106,10 @@ Aria.classDefinition({
             var displayInline = (this._inlineBlock) ? "display:inline-block;vertical-align: middle;" : "";
             out.write(['<table cellspacing="0" cellpadding="0" style="position: relative;' + displayInline + '"',
                     frameContainerClass, '><tbody isFrame="1">', '<tr>', '<td class="', cssPrefix, 'tlc ', cssPrefix,
-                    'bkgA">&nbsp;</td>', '<td class="', cssPrefix, 'ts ', cssPrefix,
+                    'bkgA"></td>', '<td class="', cssPrefix, 'ts ', cssPrefix,
                     'bkgB">' + this.__addFrameIcon(cfg, cssPrefix, 'top') + '</td>', '<td class="', cssPrefix, 'trc ',
-                    cssPrefix, 'bkgA">&nbsp;</td>', '</tr>', '<tr>', '<td class="', cssPrefix, 'ls ', cssPrefix,
-                    'bkgC">&nbsp;</td>', '<td class="', cssPrefix, 'm">', '<span ',
+                    cssPrefix, 'bkgA"></td>', '</tr>', '<tr>', '<td class="', cssPrefix, 'ls ', cssPrefix,
+                    'bkgC"></td>', '<td class="', cssPrefix, 'm">', '<span ',
                     Aria.testMode && this._baseId ? ' id="' + this._baseId + '"' : '',
                     (sizeInfo.style ? 'style="' + sizeInfo.style + '"' : ''), ' class="', sizeInfo.className, '">'].join(''));
         },
@@ -120,10 +120,10 @@ Aria.classDefinition({
          */
         writeMarkupEnd : function (out) {
             var cfg = this._cfg, sclass = cfg.sclass, cssPrefix = this._cssPrefix;
-            out.write(['</span></td>', '<td class="', cssPrefix, 'rs ', cssPrefix, 'bkgC">&nbsp;</td>', '</tr>',
-                    '<tr>', '<td class="', cssPrefix, 'blc ', cssPrefix, 'bkgA">&nbsp;</td>', '<td class="', cssPrefix,
-                    'bs ', cssPrefix, 'bkgB">', this.__addFrameIcon(cfg, cssPrefix, 'bottom'), '</td>', '<td class="',
-                    cssPrefix, 'brc ', cssPrefix, 'bkgA">&nbsp;</td>', '</tr>', '</tbody></table>'].join(''));
+            out.write(['</span></td>', '<td class="', cssPrefix, 'rs ', cssPrefix, 'bkgC"></td>', '</tr>', '<tr>',
+                    '<td class="', cssPrefix, 'blc ', cssPrefix, 'bkgA"></td>', '<td class="', cssPrefix, 'bs ',
+                    cssPrefix, 'bkgB">', this.__addFrameIcon(cfg, cssPrefix, 'bottom'), '</td>', '<td class="',
+                    cssPrefix, 'brc ', cssPrefix, 'bkgA"></td>', '</tr>', '</tbody></table>'].join(''));
 
         },
 
@@ -151,9 +151,9 @@ Aria.classDefinition({
             var stateObject = cfg.stateObject;
             var frameIconVPos = stateObject.frameIconVPos;
             if (stateObject.frameIcon && frameIconVPos == position) {
-                return '<span class="' + cssPrefix + 'frameIcon">&nbsp;</span>';
+                return '<span class="' + cssPrefix + 'frameIcon"></span>';
             }
-            return "&nbsp";
+            return "";
         },
         /**
          * Change the state of the frame. Must not be called before linkToDom has been called.

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.WidgetTest");
         this.addTests("test.aria.widgets.action.SortIndicatorTest");
         this.addTests("test.aria.widgets.calendar.CalendarControllerTest");
+        this.addTests("test.aria.widgets.calendar.lineHeight.CalendarLineHeightTest");
         this.addTests("test.aria.widgets.container.DivTest");
         this.addTests("test.aria.widgets.container.FieldsetTest");
         this.addTests("test.aria.widgets.container.SplitterTest");

--- a/test/aria/widgets/calendar/lineHeight/CalendarLineHeightStyle.tpl.css
+++ b/test/aria/widgets/calendar/lineHeight/CalendarLineHeightStyle.tpl.css
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath: "test.aria.widgets.calendar.lineHeight.CalendarLineHeightStyle"
+}}
+    {macro main()}
+        .lineHeightMain {
+            margin: 10px;
+            border: 1px solid black;
+            padding: 10px;
+            line-height: 20px;
+        }
+    {/macro}
+{/CSSTemplate}

--- a/test/aria/widgets/calendar/lineHeight/CalendarLineHeightTest.js
+++ b/test/aria/widgets/calendar/lineHeight/CalendarLineHeightTest.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.calendar.lineHeight.CalendarLineHeightTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $prototype : {
+        runTemplateTest : function () {
+            var widget = this.getWidgetInstance("myCalendar");
+            var domElt = widget.getDom();
+            var tds = domElt.getElementsByTagName("td");
+            var tdsLength = tds.length;
+            this.assertTrue(tdsLength > 6, "Could not find enough td elements.");
+            var toBeChecked = [tds[0], tds[1], tds[2], tds[tdsLength - 3], tds[tdsLength - 2], tds[tdsLength - 1]];
+            for (var i = 0, l = toBeChecked.length; i < l; i++) {
+                this.checkBorderElement(toBeChecked[i]);
+            }
+            this.end();
+        },
+
+        checkBorderElement : function (domElt) {
+            var clsName = domElt.className;
+            this.assertTrue(/xDiv_([_a-zA-Z0-9]+)_(tlc|ts|trc|blc|bs|brc)/.test(clsName), "Invalid class name: " +
+                    clsName);
+            var height = domElt.offsetHeight;
+            this.assertTrue(height < 10, "Wrong border width: " + height + " (in " + clsName + ")");
+        }
+
+    }
+});

--- a/test/aria/widgets/calendar/lineHeight/CalendarLineHeightTestTpl.tpl
+++ b/test/aria/widgets/calendar/lineHeight/CalendarLineHeightTestTpl.tpl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "test.aria.widgets.calendar.lineHeight.CalendarLineHeightTestTpl",
+    $css: ["test.aria.widgets.calendar.lineHeight.CalendarLineHeightStyle"]
+}}
+    {macro main()}
+        <div class="lineHeightMain">
+            {@aria:Calendar { id: "myCalendar" }/}
+        </div>
+    {/macro}
+{/Template}


### PR DESCRIPTION
This pull request removes spaces (&amp;nbsp;) in the markup of the table frame so that table frames are displayed correctly, even when the line-height CSS property is defined.
