### PR TITLE
feat #486 enhancements in DomElementWrapper

### DIFF
--- a/src/aria/templates/CfgBeans.js
+++ b/src/aria/templates/CfgBeans.js
@@ -582,7 +582,7 @@ Aria.beanDefinitions({
         },
         "HtmlAttribute" : {
             $type : "json:Object",
-            $description : "HTML attributes that can safely be used in a template",
+            $description : "HTML attributes that can safely be used in a template. Additionally, all aria-* (WAI-ARIA) and custom data-* attributes can be used.",
             $properties : {
                 "name" : {
                     $type : "json:String",

--- a/test/aria/templates/DomElementWrapper.js
+++ b/test/aria/templates/DomElementWrapper.js
@@ -65,7 +65,7 @@ Aria.classDefinition({
 
             // try to get the id property
             element.id = "myTestId";
-            this.assertTrue(wrapper.getProperty("id") == "myTestId");
+            this.assertEquals(wrapper.getProperty("id"), "myTestId");
             this.assertLogsEmpty();
 
             // try to get the parentNode property
@@ -116,7 +116,7 @@ Aria.classDefinition({
          */
         testGetParentWithData : function () {
             var document = Aria.$window.document;
-            this.container.innerHTML = '<div data-test1="test1" data-test3="false"><div data-test2="second" data-test3="" id="parent_getParentWithData"><div><div data-test1="itself" id="child_getParentWithData"></div></div></div></div>';
+            this.container.innerHTML = '<div data-test1="test1" data-test3="false"><div data-test2="second" data-test3="" data-test4-with-dashes="test4value" id="parent_getParentWithData"><div><div data-test1="itself" id="child_getParentWithData"></div></div></div></div>';
             var child = document.getElementById("child_getParentWithData");
             var wrapperOnChild = new aria.templates.DomElementWrapper(child);
 
@@ -124,21 +124,58 @@ Aria.classDefinition({
 
             // the expando on the element itself should be used
             var parentTest1 = wrapperOnChild.getParentWithData("test1");
-            this.assertTrue(parentTest1.getData("test1", false) == "itself");
-            this.assertTrue(parentTest1.getProperty("id") == "child_getParentWithData");
+            this.assertEquals(parentTest1.getData("test1", false), "itself");
+            this.assertEquals(parentTest1.getProperty("id"), "child_getParentWithData");
             parentTest1.$dispose();
 
             var parentTest2 = wrapperOnChild.getParentWithData("test2");
-            this.assertTrue(parentTest2.getData("test2", false) == "second");
-            this.assertTrue(parentTest2.getProperty("id") == "parent_getParentWithData");
+            this.assertEquals(parentTest2.getData("test2", false), "second");
+            this.assertEquals(parentTest2.getAttribute("data-test2"), "second");
+            this.assertEquals(parentTest2.getProperty("id"), "parent_getParentWithData");
             parentTest2.$dispose();
 
             var parentTest3 = wrapperOnChild.getParentWithData("test3");
-            this.assertTrue(parentTest3.getData("test3", false) === "");
-            this.assertTrue(parentTest3.getProperty("id") == "parent_getParentWithData");
+            this.assertEquals(parentTest3.getData("test3", false), "");
+            this.assertEquals(parentTest3.getProperty("id"), "parent_getParentWithData");
             parentTest3.$dispose();
 
+            var parentTest4 = wrapperOnChild.getParentWithData("test4-with-dashes");
+            this.assertEquals(parentTest4.getData("test4-with-dashes", false), "test4value");
+            this.assertEquals(parentTest4.getAttribute("data-test4-with-dashes"), "test4value");
+            this.assertEquals(parentTest4.getProperty("id"), "parent_getParentWithData");
+            parentTest4.$dispose();
+
             wrapperOnChild.$dispose();
+        },
+
+        testSetAttribute : function () {
+            var document = Aria.$window.document;
+            this.container.innerHTML = '<a id="div1"></a><input id="input2" type="text">';
+
+            // test positive setting
+            var aWrapper = new aria.templates.DomElementWrapper(document.getElementById("div1"));
+
+            aWrapper.setAttribute("type", "test1");
+            this.assertEquals(aWrapper.getAttribute("type"), "test1");
+
+            aWrapper.setAttribute("aria-selected", "true");
+            this.assertEquals(aWrapper.getAttribute("aria-selected"), "true");
+
+            aWrapper.setAttribute("data-my-custom-attribute", "foobar");
+            this.assertEquals(aWrapper.getAttribute("data-my-custom-attribute"), "foobar");
+
+            aWrapper.$dispose();
+
+            // test forbidden edge cases
+            var inputWrapper = new aria.templates.DomElementWrapper(document.getElementById("input2"));
+
+            inputWrapper.setAttribute("type", "test2"); // input + type = denied
+            this.assertErrorInLogs(aria.templates.DomElementWrapper.ATTRIBUTE_WRITE_DENIED);
+
+            inputWrapper.setAttribute("id", "newId"); // id = always denied
+            this.assertErrorInLogs(aria.templates.DomElementWrapper.ATTRIBUTE_WRITE_DENIED);
+
+            inputWrapper.$dispose();
         }
     }
 });

--- a/test/aria/utils/Html.js
+++ b/test/aria/utils/Html.js
@@ -42,7 +42,7 @@ Aria.classDefinition({
                         }
                     } else if (key === "dataset") {
                         for (var dataKey in attribute) {
-                            if (attribute.hasOwnProperty(dataKey) && dataKey.substr(0, 5) != "data-") {
+                            if (attribute.hasOwnProperty(dataKey)) {
                                 var value = stringUtil.encodeForQuotedHTMLAttribute(attribute[dataKey]);
                                 var got = div.getAttribute("data-" + dataKey);
                                 this.assertEquals(got, value, "data-" + dataKey + " should be %2, got %1");
@@ -84,9 +84,11 @@ Aria.classDefinition({
                 classList : ["class1", "class2", "class3"],
                 cols : "2",
                 colspan : "2",
-                dataset : {
+                dataset : { /* in the dataset, keys are camelCased, and do not have "data-" prefix */
                     data1 : "data1-value",
                     data2 : "data2-value",
+                    "foo" : "data-foo-value",
+                    "fooBar" : "data-foo-bar-value",
                     data3 : "data3-value"
                 },
                 dir : "ltr",
@@ -108,6 +110,9 @@ Aria.classDefinition({
                 valign : "middle",
                 value : "my value",
                 width : "100px",
+                "aria-label" : "label",
+                "data-testExpando" : "testExpando",
+                "data-attrib-with-dashes" : "test", /* on the "root" attributes level, keys are "data-"-prefixed and dashed */
                 autocomplete : "off",
                 autofocus : "autofocus",
                 autocorrect : "on",


### PR DESCRIPTION
1. Added support for WAI ARIA (`aria-*`) attributes in `getAttribute`
2. Added support for custom `data-*` attributes in `getAttribute`
   (previously they could have been retrieved only with `getData`)
3. Added support for expandos with multiple dashes (`data-foo-bar`) in
   `getData`/`getAttribute`
4. Added `setAttribute`
