### PR TITLE
fix #453 scrolling after radiogroup change from keyboard

### DIFF
--- a/src/aria/widgets/form/RadioButton.js
+++ b/src/aria/widgets/form/RadioButton.js
@@ -135,12 +135,16 @@
                     event.preventDefault(true);
                 } else if (event.keyCode == aria.DomEvent.KC_LEFT) {
                     this._navigate(-1);
+                    event.preventDefault(true);
                 } else if (event.keyCode == aria.DomEvent.KC_RIGHT) {
                     this._navigate(+1);
+                    event.preventDefault(true);
                 } else if (event.keyCode == aria.DomEvent.KC_DOWN) {
                     this._navigate(+1);
+                    event.preventDefault(true);
                 } else if (event.keyCode == aria.DomEvent.KC_UP) {
                     this._navigate(-1);
+                    event.preventDefault(true);
                 }
             },
 


### PR DESCRIPTION
When changing selected item in a radio group using keyboard arrows, default action was not prevented, hence page might have scrolled if scrollbars were present.
