### PR TITLE
fix #424 Ctrl+click opening new tab in @aria:List in IE7

### DIFF
--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -23,7 +23,7 @@
         {var className = _getClassForItem(item)/}
         {var entry = item.object.entry/}
     
-        <a href="#" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a href="javascript:void(0)" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}

--- a/src/aria/widgets/form/list/templates/ListTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/ListTemplate.tpl
@@ -41,7 +41,7 @@
     {macro renderItem(item, itemIdx)}
         {var a = _getClassForItem(item)/}
 
-        <a href="#" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a href="javascript:void(0)" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {else/}


### PR DESCRIPTION
When Ctrl+clicking an option in List widget in IE7, new tab was opened due to the fact that options are anchors under the hood.
