### PR TITLE
Skip resources providers at template unload

### DIFF
--- a/src/aria/templates/TemplateManager.js
+++ b/src/aria/templates/TemplateManager.js
@@ -50,7 +50,7 @@ Aria.classDefinition({
                 if (itm.$resources != null) {
                     var resources = itm.$resources;
                     for (var res in resources)
-                        if (resources.hasOwnProperty(res)) {
+                        if (resources.hasOwnProperty(res) && !resources[res].hasOwnProperty("provider")) {
                             classMgr.unloadClass(resources[res], timestampNextTime);
                         }
                 }


### PR DESCRIPTION
When unloading a template, its resources are also unloaded. When resources are coming from a provider, an error was raised.
The fix consists in skipping those types of resources.
