### PR TITLE
Error when loading missing localized resources

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -73,8 +73,8 @@ module.exports = function (grunt) {
                         cfg : {
                             mapFile : mainATFile,
                             sourceFiles : ['**/*', '!aria/css/**/*'],
-                            starCompress : ['**/*', '!aria'],
-                            starStarCompress : ['**/*', '!aria/resources']
+                            starCompress : ['**/*', '!aria', '!aria/resources/**'],
+                            starStarCompress : ['**/*']
                         }
                     }, {
                         type : 'CopyUnpackaged',

--- a/test/MainTestSuite.js
+++ b/test/MainTestSuite.js
@@ -32,6 +32,7 @@ Aria.classDefinition({
         this.addTests("test.aria.modules.ModulesTestSuite");
         this.addTests("test.aria.pageEngine.PageEngineTestSuite");
         this.addTests("test.aria.popups.PopupsTestSuite");
+        this.addTests("test.aria.resources.ResourcesTestSuite");
         this.addTests("test.aria.storage.StorageTestSuite");
         this.addTests("test.aria.templates.TemplatesTestSuite");
         this.addTests("test.aria.tools.ToolsTestSuite");

--- a/test/aria/resources/ClassWithResources.js
+++ b/test/aria/resources/ClassWithResources.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.resources.ClassWithResources",
+    $resources : {
+        date : "aria.resources.DateRes"
+    }
+});

--- a/test/aria/resources/ResourcesFallback.js
+++ b/test/aria/resources/ResourcesFallback.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.resources.ResourcesFallback",
+    $extends : "aria.jsunit.TestCase",
+    $prototype : {
+
+        setUp : function () {},
+
+        tearDown : function () {
+
+        },
+
+        testAsyncLoadClassWithResources : function () {
+            this._oldLanguageSettings = aria.core.environment.Environment.getLanguage();
+            aria.core.AppEnvironment.setEnvironment({
+                language : {
+                    "primaryLanguage" : "fr",
+                    "region" : "BE"
+                }
+            }, {
+                fn : this._afterLanguageSetting,
+                scope : this
+            }, true);
+
+        },
+
+        _afterLanguageSetting : function () {
+            Aria.load({
+                classes : ["test.aria.resources.ClassWithResources"],
+                oncomplete : {
+                    fn : this._afterClassLoad,
+                    scope : this
+                }
+            });
+        },
+
+        _afterClassLoad : function () {
+            aria.core.Timer.addCallback({
+                fn : this._waitBeforeRestore,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        _waitBeforeRestore : function () {
+            var parts = this._oldLanguageSettings.split("_");
+            aria.core.AppEnvironment.setEnvironment({
+                language : {
+                    "primaryLanguage" : parts[0],
+                    "region" : parts[1]
+                }
+            }, {
+                fn : this._afterLocaleReset,
+                scope : this
+            });
+        },
+
+        _afterLocaleReset : function () {
+            this.notifyTestEnd("testAsyncLoadClassWithResources");
+        }
+
+    }
+
+});

--- a/test/aria/resources/ResourcesTestSuite.js
+++ b/test/aria/resources/ResourcesTestSuite.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test suite grouping all tests
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.resources.ResourcesTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.resources.ResourcesFallback");
+    }
+});


### PR DESCRIPTION
The url map generated by the build was causing an error in the resources locale fallback mechanism.
