### PR TITLE
fix #502 SortIndicator {block:true} not working

### DIFF
--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -79,7 +79,7 @@ Aria.classDefinition({
          * @protected
          * @type String
          */
-        this._spanStyle = [(width > 0) ? "width:" + width + "px;" : "", "display:inline-block;", "white-space:nowrap;"].join("");
+        this._spanStyle = [(width > 0) ? "width:" + width + "px;" : "", "white-space:nowrap;"].join("");
 
         /**
          * Moment in which the widget gets initialized


### PR DESCRIPTION
See #502

Inline CSS is not needed here, because the widget will have either `display:block` from `xBlock` or `display:inline-block` from `xWidget` automatically.
