### PR TITLE
Fix #526 Floating point display issue in Numberfield widget

### DIFF
--- a/test/aria/utils/Number.js
+++ b/test/aria/utils/Number.js
@@ -294,6 +294,12 @@ Aria.classDefinition({
             formattedCurrency = aria.utils.Number.formatNumber('1000000.0333');
             this.assertTrue(formattedCurrency == '1,000,000.0333');
 
+            formattedCurrency = aria.utils.Number.formatNumber('0.1', "0.0###################");
+            this.assertTrue(formattedCurrency == '0.1');
+
+            formattedCurrency = aria.utils.Number.formatNumber('0.1', "0.000000000000000000000"); // 21 decimals
+            this.assertTrue(formattedCurrency == '0.10000000000000000000'); // 20 decimals
+
         }
     }
 });


### PR DESCRIPTION
Fixes the display issue by working with Strings when necessary.
This fix also limits the `maxDecLen` property of a pattern to 20 to prevent potential errors when passed to toFixed().
