### PR TITLE
Fix and simplify page url resolution in the default BasePageProvider

### DIFF
--- a/src/aria/pageEngine/pageProviders/BasePageProvider.js
+++ b/src/aria/pageEngine/pageProviders/BasePageProvider.js
@@ -33,13 +33,6 @@ Aria.classDefinition({
          */
         this._config = config;
 
-        /**
-         * Base location of pages
-         * @type String
-         * @protected
-         */
-        this._basePageUrl = null;
-
         if (!("cache" in config)) {
             config.cache = true;
         }
@@ -87,9 +80,8 @@ Aria.classDefinition({
                 this.$callback(callback.onsuccess, this.processPageDefinition(pageDefinition));
                 return;
             }
-            this._basePageUrl = this._basePageUrl
-                    || aria.core.DownloadMgr.resolveURL(this._config.pageBaseLocation + "fake.json").replace(/fake\.json$/, "");
-            this._sendRequest(this._basePageUrl + pageId + ".json", {
+            var pageUrl = aria.core.DownloadMgr.resolveURL(this._config.pageBaseLocation + pageId + ".json");
+            this._sendRequest(pageUrl, {
                 pageRequest : pageRequest,
                 callback : callback
             }, "page");


### PR DESCRIPTION
The previous logic fails if the resolution of a path's URL does not end with the path itself

e.g. if  `aria.core.DownloadMgr.resolveURL("foo.bar")` returns `"http://whatever/the/path?path=foo.bar&param=value"`

i.e. if the `DownloadMgr` has been customized (thanks to the `updateUrlMap(...)` function) to be redirected to a servlet with additional parameters (here the `'param=value'` appended to the url).

That's why I suggest this simplification including the removal of the variable `this._basePageUrl` made useless.
