### PR TITLE
Better mouse position detect in Chrome

### DIFF
--- a/src/aria/utils/Event.js
+++ b/src/aria/utils/Event.js
@@ -233,14 +233,26 @@
 
                         var pageX = e.pageX;
                         var pageY = e.pageY;
+                        var touchPositions = "";
+                        if (e.touches) {
+                            for (var i = 0; i < e.touches.length; i += 1) {
+                                touchPositions += e.touches[i].pageX + "." + e.touches[i].pageY + "|";
+                            }
+                        }
 
-                        if (mousePosition && mousePosition.x == pageX && mousePosition.y == pageY) {
-                            return;
+                        if (mousePosition && mousePosition.x === pageX && mousePosition.y === pageY) {
+                            // Apparently the mouse didn't move
+                            if (!touchPositions || touchPositions === mousePosition.touches) {
+                                // not a touch or a touch in which none of the position changed
+                                return;
+                            }
+                            // else one of the touches has a different position, go on
                         }
 
                         mousePosition = {
                             x : pageX,
-                            y : pageY
+                            y : pageY,
+                            touches : touchPositions
                         };
 
                         return handlerCBInstance.call(e);

--- a/src/aria/utils/FireDomEvent.js
+++ b/src/aria/utils/FireDomEvent.js
@@ -349,8 +349,8 @@
                 customEvent.button = button;
                 customEvent.relatedTarget = relatedTarget;
             }
-            customEvent.touches = touches;
-            customEvent.changedTouches = changedTouches;
+            customEvent.touches = generateTouchList(touches);
+            customEvent.changedTouches = generateTouchList(changedTouches);
             customEvent.isPrimary = isPrimary;
             customEvent.pageX = clientX;
             customEvent.pageY = clientY;
@@ -512,6 +512,39 @@
         } else {
             fireDomEvent.$logError("simulate(): Event '" + type + "' can't be simulated.");
         }
+    };
+
+    /**
+     * Generate an object that looks like a [TouchList](https://developer.mozilla.org/en-US/docs/Web/API/TouchList)
+     * The [Touch](https://developer.mozilla.org/en-US/docs/Web/API/Touch) objects inside the list have at least
+     * pageX and pageY that if not specified are set equal to clintX and clientY
+     * @param {Array} list An array of touch descriptions
+     * @return {Array} that looks like a TouchList
+     * @private
+     * @method generateTouchList
+     */
+    var generateTouchList = function (list) {
+        if (!list || list.length === 0) {
+            return list;
+        }
+        var  touchList = [];
+        for (var i = 0; i < list.length; i += 1) {
+            var touch = list[i];
+            if (!("pageX" in touch)) {
+                touch.pageX = touch.clientX;
+            }
+            if (!("pageY" in touch)) {
+                touch.pageY = touch.clientY;
+            }
+            touchList.push(touch);
+        }
+        touchList.identifiedTouch = function () {
+            return this[0];
+        };
+        touchList.item = function (i) {
+            return this[i];
+        };
+        return touchList;
     };
 
     /**


### PR DESCRIPTION
The framework stores the position of the last mouse event to prevent firing it multiple times in Chrome.
However in case of touch events this position might not be accurate.
