### PR TITLE
fix #550 reorder some tests

### DIFF
--- a/test/MainTestSuite.js
+++ b/test/MainTestSuite.js
@@ -30,17 +30,17 @@ Aria.classDefinition({
         this.addTests("test.aria.html.HTMLTestSuite");
         this.addTests("test.aria.jsunit.JsunitTestSuite");
         this.addTests("test.aria.modules.ModulesTestSuite");
+        this.addTests("test.aria.map.MapTestSuite");
         this.addTests("test.aria.pageEngine.PageEngineTestSuite");
         this.addTests("test.aria.popups.PopupsTestSuite");
         this.addTests("test.aria.resources.ResourcesTestSuite");
         this.addTests("test.aria.storage.StorageTestSuite");
         this.addTests("test.aria.templates.TemplatesTestSuite");
         this.addTests("test.aria.tools.ToolsTestSuite");
+        this.addTests("test.aria.touch.TouchTestSuite");
         this.addTests("test.aria.utils.UtilsTestSuite");
         this.addTests("test.aria.widgetLibs.WidgetLibsTestSuite");
         this.addTests("test.aria.widgets.WidgetsTestSuite");
         this.addTests("test.performance.PerfTestSuite");
-        this.addTests("test.aria.touch.TouchTestSuite");
-        this.addTests("test.aria.map.MapTestSuite");
     }
 });

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -19,6 +19,8 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.widgets.form.FormTestSuite");
+        this.addTests("test.aria.widgets.container.ContainerTestSuite");
         this.addTests("test.aria.widgets.autoselect.AutoSelect");
         this.addTests("test.aria.widgets.autoselect.programmatic.AutoSelect");
         this.addTests("test.aria.widgets.errorTip.ButtonErrorTipsTest");
@@ -33,16 +35,13 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.action.sortindicator.block.SortIndicatorBlockTest");
         this.addTests("test.aria.widgets.calendar.CalendarControllerTest");
         this.addTests("test.aria.widgets.calendar.lineHeight.CalendarLineHeightTest");
-        this.addTests("test.aria.widgets.container.ContainerTestSuite");
         this.addTests("test.aria.widgets.controllers.SelectBoxControllerTest");
         this.addTests("test.aria.widgets.controllers.SelectControllerTest");
         this.addTests("test.aria.widgets.dropdown.DropDownTestSuite");
         this.addTests("test.aria.widgets.environment.WidgetSettings");
         this.addTests("test.aria.widgets.errorlist.ErrorListControllerTest");
         this.addTests("test.aria.widgets.errorlist.ListErrorTestCase");
-        this.addTests("test.aria.widgets.form.FormTestSuite");
         this.addTests("test.aria.widgets.action.iconbutton.issue276.IconButtonTestCase");
-        this.addTests("test.aria.widgets.container.issue367.MovableDialogTestCase");
         this.addTests("test.aria.widgets.verticalAlign.VerticalAlignTestCase");
     }
 });

--- a/test/aria/widgets/container/ContainerTestSuite.js
+++ b/test/aria/widgets/container/ContainerTestSuite.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.tooltip.TooltipTestCase");
         this.addTests("test.aria.widgets.container.dialog.DialogTestSuite");
         this.addTests("test.aria.widgets.container.issue80.BindableSizeTestSuite");
+        this.addTests("test.aria.widgets.container.issue367.MovableDialogTestCase");
     }
 });
 

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -18,6 +18,8 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TestSuite",
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
+        this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
         this.addTests("test.aria.widgets.form.CheckBoxTest");
         this.addTests("test.aria.widgets.form.checkbox.SetDisabledTest");
         this.addTests("test.aria.widgets.form.GaugeTest");
@@ -30,8 +32,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.SelectTest");
         this.addTests("test.aria.widgets.form.TextInputTest");
         this.addTests("test.aria.widgets.form.textinput.TextInputTestSuite");
-        this.addTests("test.aria.widgets.form.datepicker.DatePickerTestSuite");
-        this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
         this.addTests("test.aria.widgets.form.issue411.DropdownTestSuite");
         this.addTests("test.aria.widgets.form.autocomplete.AutoCompleteTestSuite");
         this.addTests("test.aria.widgets.form.selectbox.SelectboxTestSuite");

--- a/test/aria/widgets/form/datepicker/DatePickerTestSuite.js
+++ b/test/aria/widgets/form/datepicker/DatePickerTestSuite.js
@@ -19,9 +19,9 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.widgets.form.datepicker.errorstate.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.issue303.InfiniteLoop");
         this.addTests("test.aria.widgets.form.datepicker.issue429.DateFormatTestCase");
-        this.addTests("test.aria.widgets.form.datepicker.errorstate.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.checkValue.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.checkFormat.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.checkBind.DatePicker");


### PR DESCRIPTION
Change order of the tests so the long ones do not block the whole campaign at the end. Speeds up the whole campaign by ~20s (from 2m10s to 1m49 on my machine) on 8 CPUs.

Related to #538.
