### PR TITLE
Switching to Grunt 0.4.1. Fixes some issues on node.js 0.10.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "gzip-js": "0.3.1",
     "grunt-verifylowercase": "0.2.0",
-    "grunt": "git+https://github.com/divdavem/grunt.git#776b38f39a9d3bcc4cf083d8cb54345dfef63301",
+    "grunt": "git+https://github.com/divdavem/grunt.git#9952016e64f18404d459a39fd9273c7939693900",
     "grunt-contrib-jshint": "0.2.0",
     "attester": "1.1.0",
     "express": "3.0.3",


### PR DESCRIPTION
This pull request fixes the following error message when building with node.js 0.10.x:
`Arguments to path.join must be strings`
