### PR TITLE
"this.__delegateMapping is null" when unloading a page

### DIFF
--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -459,6 +459,14 @@ Aria.classDefinition({
          * @param {Object} evt
          */
         delegate : function (evt) {
+            if (!this.__delegateMapping) {
+                // there is no event listener
+                if (evt.$DomEvent) {
+                    evt.$dispose();
+                }
+                return;
+            }
+
             if (!this.__stackCache) {
                 this.__stackCache = {};
             }


### PR DESCRIPTION
The exception "this.__delegateMapping is null" could happen in some
cases when unloading a page. This commit fixes this small issue.
