### PR TITLE
feat #548 add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,20 @@
+node_modules
+.DS_Store
+target
+build/at-bootstrap
+build/at-core
+build/at-lint
+.project
+.settings
+.benchmarks.rb.swp
+.checkstyle
+*.log
+
+# npmignore only below
+.npmignore
+/.travis.yml
+/test/
+/hooks/
+/scripts/
+/build/
+/Gruntfile.js


### PR DESCRIPTION
I copied `.gitignore` and added a few lines at the end for consistency.

Added entries mostly have leading slashes to be excluded only in the root of the repo, not everywhere.

We gain ~0.5 MB here, from 1509 kB to 945 kB. Removing skin images could bring us another 200 kB.
