### PR TITLE
Problem with vertical scrollbar inside selectbox widget when popupWidth=-1

### DIFF
--- a/src/aria/utils/Size.js
+++ b/src/aria/utils/Size.js
@@ -105,6 +105,8 @@ Aria.classDefinition({
         setContrains : function (element, widthConf, heightConf) {
             // PROFILING // var profilingId = this.$startMeasure("setContrains");
             var measured, newValue, result = {}, changedWidth = false, changedHeight = false;
+            var changedOverflowY = false;
+            var savedScrollBarY = element.style.overflowY;
 
             // for width
             if (widthConf) {
@@ -124,6 +126,19 @@ Aria.classDefinition({
                 if (newValue != measured) {
                     element.style.height = newValue + "px";
                     changedHeight = true;
+                    changedOverflowY = (newValue < measured);
+                    if (changedOverflowY) {
+                        element.style.overflowY = "scroll";
+                        if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
+                            var scrollbarSize = aria.templates.Layout.getScrollbarsWidth();
+                            element.style['paddingRight'] = element.style['paddingRight'] === '' ? scrollbarSize + 'px' : (parseInt(element.style['paddingRight'], 10) + scrollbarSize) + "px";
+                        }
+                        // recalculate the width
+                        var newWidth = aria.utils.Math.normalize(element.offsetWidth, widthConf.min, widthConf.max);
+                        element.style.width = newWidth + "px";
+                        changedWidth = true;
+                        result.width = newWidth;
+                    }
                 }
                 result.height = newValue;
             }
@@ -135,6 +150,14 @@ Aria.classDefinition({
                 }
                 if (!heightConf) {
                     result.height = element.offsetHeight;
+                }
+
+                if (changedOverflowY) {
+                    element.style.overflowY = savedScrollBarY;
+                    if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
+                        var scrollbarSize = aria.templates.Layout.getScrollbarsWidth();
+                        element.style['paddingRight'] = (parseInt(element.style['paddingRight'], 10) - scrollbarSize) + "px";
+                    }
                 }
                 // PROFILING // this.$stopMeasure(profilingId);
                 return result;

--- a/test/aria/widgets/container/ContainerTestSuite.js
+++ b/test/aria/widgets/container/ContainerTestSuite.js
@@ -28,6 +28,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.dialog.DialogTestSuite");
         this.addTests("test.aria.widgets.container.issue80.BindableSizeTestSuite");
         this.addTests("test.aria.widgets.container.issue367.MovableDialogTestCase");
+        this.addTests("test.aria.widgets.container.checkContent.DivTest");
     }
 });
 

--- a/test/aria/widgets/container/checkContent/DivTest.js
+++ b/test/aria/widgets/container/checkContent/DivTest.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.checkContent.DivTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $prototype : {
+        runTemplateTest : function () {
+            var div = this.getElementById('MyDiv');
+            var span = div.firstChild;
+            var spanHeight = parseInt(span.style.height, 10);
+            var spanWidth = parseInt(span.style.width, 10);
+            var expectedHeight = 400;
+            var expectedWidth = 634; // 617 from the h3 element width + 17px for the scrollbar
+
+            if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
+                var expectedWidthIE7 = 888; // 871 from the h3 element width + 17px added for the scrollbar
+                this.assertEqualsWithTolerance(spanWidth, expectedWidthIE7, 2, "The div width is %1, insted of %2");
+            } else {
+                this.assertEqualsWithTolerance(spanWidth, expectedWidth, 2, "The div width is %1, insted of %2");
+            }
+            this.assertEqualsWithTolerance(spanHeight, expectedHeight, 2, "The div height is %1, insted of %2");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/container/checkContent/DivTestTpl.tpl
+++ b/test/aria/widgets/container/checkContent/DivTestTpl.tpl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.checkContent.DivTestTpl"
+}}
+    {macro main()}
+        {@aria:Div {
+            id: 'MyDiv',
+            maxHeight : 400
+        }}
+            {for var i = 0; i < 15; i++}
+                {if (aria.core.Browser.isIE && aria.core.Browser.majorVersion == 7)}
+                    <h3 style="width: 871px;">#DivTestWithAVeryLongStringWithoutAnySpaceToCheckIfTheScrollbarsHideSomeContentOrNot</h3>
+                {else/}
+                    <h3 style="width: 617px;">#DivTestWithAVeryLongStringWithoutAnySpaceToCheckIfTheScrollbarsHideSomeContentOrNot</h3>
+                {/if}
+            {/for}
+        {/@aria:Div}
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
When the popupWidth is equals to -1 the vertical scrollbar hides part of the selectbox popup content due to a problem with the overflow-y sets to Auto. With overflow-y equals to scroll it works fine.
