### PR TITLE
Test on utils.Dom fails in Chrome

### DIFF
--- a/src/aria/widgets/controllers/DropDownListController.js
+++ b/src/aria/widgets/controllers/DropDownListController.js
@@ -15,8 +15,6 @@
 
 /**
  * Controller for the a widget with a dropdown that contains a list.
- * @class aria.widgets.controllers.DropDownListController
- * @extends aria.widgets.controllers.TextDataController
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.controllers.DropDownListController",

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -15,8 +15,6 @@
 
 /**
  * SelectBox widget allows to select a value in an array of predefined values
- * @extends aria.widgets.form.DropDownTextInput
- * @class aria.widgets.form.SelectBox
  */
 Aria.classDefinition({
     $classpath : "aria.widgets.form.SelectBox",
@@ -34,10 +32,6 @@ Aria.classDefinition({
         var controller = new aria.widgets.controllers.SelectBoxController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         this.controller.setListOptions(this._cfg.options);
-    },
-
-    $destructor : function () {
-        this.$DropDownTextInput.$destructor.call(this);
     },
     $prototype : {
         $init : function (p) {

--- a/test/aria/utils/Dom.js
+++ b/test/aria/utils/Dom.js
@@ -243,9 +243,14 @@ Aria.classDefinition({
             var document = Aria.$window.document;
             var test = document.createElement("div");
             this.domCreated.push(test);
+            var height = document.createElement("div");
+            this.domCreated.push(height);
 
             document.body.appendChild(test);
+            document.body.appendChild(height);
             test.style.cssText = 'display:block;position:absolute;top:150px;left:50px;';
+            // Put some content in the body to make sure that on every test environment the body has height > 0
+            height.style.cssText = 'display:block;position:relative;width:200px;height:200px;';
             var innerHTML = ["<div id='cont' style='width:300px;height:300px;background:#EFE4BD;border:"
                     + "20px solid #333;overflow:auto;margin:10px;padding:10px;'><div style='width:1000px;'>"];
             for (var i = 0; i < 100; i++) {

--- a/test/aria/widgets/form/selectbox/checkValue/MainTemplateTestCase.js
+++ b/test/aria/widgets/form/selectbox/checkValue/MainTemplateTestCase.js
@@ -16,12 +16,11 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.selectbox.checkValue.MainTemplateTestCase",
     $extends : "aria.jsunit.TemplateTestCase",
-    $dependencies : ["aria.utils.Dom", "aria.utils.Json"],
+    $dependencies : ["aria.utils.Json"],
     $constructor : function () {
 
         this.$TemplateTestCase.constructor.call(this);
         this.data = {
-
             countries : [{
                         value : "FR",
                         label : "France"
@@ -47,14 +46,13 @@ Aria.classDefinition({
                         value : "USA",
                         label : "United States of America"
                     }]
-        }, this.setTestEnv({
-            template : 'test.aria.widgets.form.selectbox.checkValue.MainTemplate',
+        };
+
+        this.setTestEnv({
+            template : "test.aria.widgets.form.selectbox.checkValue.MainTemplate",
             data : this.data
         });
         this.defaultTestTimeout = 10000;
-    },
-    $destructor : function () {
-        this.$TemplateTestCase.$destructor.call(this);
     },
     $prototype : {
         /**
@@ -94,7 +92,7 @@ Aria.classDefinition({
             });
         },
         /**
-         * This method searchs for a country in options list. The goal is to interact with the widget and check that it
+         * This method searches for a country in options list. The goal is to interact with the widget and check that it
          * still working fine
          */
         searchForCountry : function () {


### PR DESCRIPTION
In Chrome and Safari the test test.aria.utils.Dom fails in attester because the body of the iframe content doesn't have an height and doesn't scroll properly
