### PR TITLE
aria.core.JsonValidator.normalize throws an object

### DIFF
--- a/src/aria/core/JsonValidator.js
+++ b/src/aria/core/JsonValidator.js
@@ -236,9 +236,9 @@
                         this.$logError(errors[i].msgId, errors[i].msgArgs);
                     }
                 } else {
-                    throw {
-                        errors : errors
-                    };
+                    var error = new Error();
+                    error.errors = errors;
+                    throw error;
                 }
                 return false;
             },


### PR DESCRIPTION
aria.core.JsonValidator.nomalize when failing throws an object, now it throws an instance of Error.
