### PR TITLE
feat #587 semi-transparency on test iframe

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -41,7 +41,7 @@ Aria.classDefinition({
             moduleCtrl : null,
             data : {},
             iframe : false,
-            cssText : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue"
+            cssText : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);"
         };
 
         /**

--- a/test/aria/pageEngine/IframeTestCase.js
+++ b/test/aria/pageEngine/IframeTestCase.js
@@ -35,7 +35,7 @@ Aria.classDefinition({
             var document = Aria.$window.document;
             var iframe = document.createElement("iframe");
             iframe.id = "test-iframe";
-            iframe.style.cssText = "position:fixed;top:20px;left:20px;z-index:10000;width:612px;height:612px;border:1px solid blue;background:aliceblue";
+            iframe.style.cssText = "position:fixed;top:20px;left:20px;z-index:10000;width:612px;height:612px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);";
             document.body.appendChild(iframe);
             this._iframe = iframe;
             testEnv = iframe;


### PR DESCRIPTION
If the iframe test fails and the iframe is not disposed, it's hard to
see if there was some error or no (on beta.html).

In general it's good to be able to see the status of the current test.

Tested quickly on Firefox/IE8/IE8 as IE7/Phantom and it seems that opacity < 1.0 doesn't affect the test execution negatively.

---

Also things should be refactored later on as reported in #586
