### PR TITLE
Explain why a frame cannot be loaded

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -113,7 +113,7 @@ Aria.classDefinition({
     $dependencies : ["aria.utils.SynEvents", "aria.templates.RefreshManager", "aria.utils.Type"],
     $statics : {
         IFRAME_LOAD_TEMPLATE : "Error loading template '%1' in iframe",
-        IFRAME_LOADER : "Unable to load Aria Templates in iframe"
+        IFRAME_LOADER : "Unable to load Aria Templates in iframe because: %1"
     },
     $prototype : {
         /**
@@ -808,7 +808,7 @@ Aria.classDefinition({
          */
         _iframeInnerDepLoad : function (result, args) {
             if (!result.success) {
-                return this._iframeLoadError(args);
+                return this._iframeLoadError(args, result.reason);
             }
             var window = args.iframe.contentWindow;
             var appenders = aria.core.Log.getAppenders();
@@ -823,7 +823,10 @@ Aria.classDefinition({
                     args : args
                 },
                 onerror : {
-                    fn : this._iframeLoadError,
+                    fn : function (args) {
+                        // FIXME Doing this because onerror is not an aria.core.CfgBean.Callback so I can't use apply:true
+                        this._iframeLoadError(args, "onerror callback of Aria.load(aria.jsunit.TemplateTestCase)");
+                    },
                     scope : this,
                     args : args
                 }
@@ -866,8 +869,13 @@ Aria.classDefinition({
          * @param {Object} args
          * @protected
          */
-        _iframeLoadError : function (args) {
-            this.$logError(this.IFRAME_LOADER);
+        _iframeLoadError : function (args, reason) {
+            if (reason === aria.utils.FrameATLoader.BOOTSTRAP) {
+                reason = "unable to load the bootstrap in the iframe";
+            } else if (reason === aria.utils.FrameATLoader.WAIT) {
+                reason = "the iframe didn't load the framework quick enough";
+            }
+            this.$logError(this.IFRAME_LOADER, reason);
             return this.$callback(args.err, args);
         },
 
@@ -888,6 +896,19 @@ Aria.classDefinition({
                 document : args.iframe.contentDocument || args.iframe.contentWindow.document,
                 templateCtxt : result.tplCtxt
             });
+        },
+
+        /**
+         * Executed when an unhandled exception is thrown inside a method.
+         * @param {Error} ex Exception
+         * @param {String} methodName Method that threw the exception
+         * @private
+         * @override
+         */
+        __failInTestMethod : function (ex, methodName) {
+            // Template tests are always asynchronous, but we need to call notifyTemplateTestEnd
+            this.$logError(this.EXCEPTION_IN_METHOD, methodName, ex);
+            this.notifyTemplateTestEnd();
         }
     }
 });

--- a/src/aria/utils/FrameATLoader.js
+++ b/src/aria/utils/FrameATLoader.js
@@ -23,6 +23,12 @@ Aria.classDefinition({
     $events : {
         "bootstrapLoaded" : "Raised when the bootstrap is loaded."
     },
+    $statics : {
+        // Loading failed because the bootstrap couldn't be loaded
+        BOOTSTRAP : -1,
+        // Loading failed because the iframe didn't load the framework quick enough
+        WAIT : -2
+    },
     $constructor : function () {
         /**
          * Pattern used to find the script tag corresponding to the framework js file.
@@ -91,7 +97,8 @@ Aria.classDefinition({
         _loadATInFrameCb1 : function (evt, args) {
             if (evt === true) {
                 this.$callback(args.cb, {
-                    success : false
+                    success : false,
+                    reasone : this.BOOTSTRAP
                 });
                 return;
             }
@@ -138,25 +145,26 @@ Aria.classDefinition({
         _loadATInFrameCb3 : function (res, args) {
             // In IE7 the callback might get called before Aria is available in the frame, poll
             var window = args.frame.contentWindow || args.frame;
-            var maxTimes = 3;
+            var maxTimes = 5;
 
             var self = this;
             var waitFunction = function () {
                 maxTimes -= 1;
                 if (maxTimes >= 0) {
                     if (window.aria == null) {
-                        setTimeout(waitFunction, 20);
+                        setTimeout(waitFunction, 30);
                     } else {
                         self._loadATInFrameCb4(res, args);
                     }
                 } else {
                     return self.$callback(args.cb, {
-                        success : false
+                        success : false,
+                        reason : this.WAIT
                     });
                 }
             };
 
-            setTimeout(waitFunction, 20);
+            setTimeout(waitFunction, 30);
         },
 
         /**


### PR DESCRIPTION
Improve the logging in case a frame cannot be loaded and give it a bit more time to load.
If the iframe doesn't load correctly you might get exceptions like

```
'eval' is undefined
Could not complete the operation due to error 80020101.
```

This also overrides the mechanism for handling errors in `TemplateTestCase` to make sure that the template is disposed in case of errors.
It should make #587 less important, or useless, or an eye-candy while testing.
