### PR TITLE
Considering scrollbars width on Mac

### DIFF
--- a/src/aria/templates/Layout.js
+++ b/src/aria/templates/Layout.js
@@ -333,30 +333,34 @@
                 if (__scrollBarsWidth != null) {
                     return __scrollBarsWidth;
                 }
-                var document = Aria.$window.document;
-                var o = document.createElement("div"); // outer div
-                var i = document.createElement("div"); // inner div
-                o.style.overflow = "";
-                o.style.position = "absolute";
-                o.style.left = "-10000px";
-                o.style.top = "-10000px";
-                o.style.width = "500px";
-                o.style.height = "500px";
-                // Old solution with width 100% seems to behave correctly
-                // for all browsers except IE7. Some research gives that
-                // just for IE7 this method does not work when setting width 100%,
-                // but works correctly setting no width
-                if (!aria.core.Browser.isIE7) {
-                    i.style.width = "100%";
+                if (aria.core.Browser.isMac && aria.core.Browser.isWebkit) {
+                    return 17;  // 17px is the size of scrollbar width on Safari and Chrome on Mac
+                } else {
+                    var document = Aria.$window.document;
+                    var o = document.createElement("div"); // outer div
+                    var i = document.createElement("div"); // inner div
+                    o.style.overflow = "";
+                    o.style.position = "absolute";
+                    o.style.left = "-10000px";
+                    o.style.top = "-10000px";
+                    o.style.width = "500px";
+                    o.style.height = "500px";
+                    // Old solution with width 100% seems to behave correctly
+                    // for all browsers except IE7. Some research gives that
+                    // just for IE7 this method does not work when setting width 100%,
+                    // but works correctly setting no width
+                    if (!aria.core.Browser.isIE7) {
+                        i.style.width = "100%";
+                    }
+                    i.style.height = "100%";
+                    document.body.appendChild(o);
+                    o.appendChild(i);
+                    __scrollBarsWidth = i.offsetWidth;
+                    o.style.overflow = "scroll";
+                    __scrollBarsWidth -= i.offsetWidth;
+                    document.body.removeChild(o);
+                    return __scrollBarsWidth;
                 }
-                i.style.height = "100%";
-                document.body.appendChild(o);
-                o.appendChild(i);
-                __scrollBarsWidth = i.offsetWidth;
-                o.style.overflow = "scroll";
-                __scrollBarsWidth -= i.offsetWidth;
-                document.body.removeChild(o);
-                return __scrollBarsWidth;
             }
         }
     });

--- a/src/aria/utils/Size.js
+++ b/src/aria/utils/Size.js
@@ -129,7 +129,7 @@ Aria.classDefinition({
                     changedOverflowY = (newValue < measured);
                     if (changedOverflowY) {
                         element.style.overflowY = "scroll";
-                        if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
+                        if ((aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) || (aria.core.Browser.isMac)) {
                             var scrollbarSize = aria.templates.Layout.getScrollbarsWidth();
                             element.style['paddingRight'] = element.style['paddingRight'] === '' ? scrollbarSize + 'px' : (parseInt(element.style['paddingRight'], 10) + scrollbarSize) + "px";
                         }
@@ -154,7 +154,7 @@ Aria.classDefinition({
 
                 if (changedOverflowY) {
                     element.style.overflowY = savedScrollBarY;
-                    if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
+                    if ((aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8)  || (aria.core.Browser.isMac)) {
                         var scrollbarSize = aria.templates.Layout.getScrollbarsWidth();
                         element.style['paddingRight'] = (parseInt(element.style['paddingRight'], 10) - scrollbarSize) + "px";
                     }
@@ -164,8 +164,6 @@ Aria.classDefinition({
             }
             // PROFILING // this.$stopMeasure(profilingId);
             return null;
-
         }
-
     }
 });

--- a/test/aria/widgets/container/checkContent/DivTest.js
+++ b/test/aria/widgets/container/checkContent/DivTest.js
@@ -29,6 +29,14 @@ Aria.classDefinition({
             if (aria.core.Browser.isIE && aria.core.Browser.majorVersion < 8) {
                 var expectedWidthIE7 = 888; // 871 from the h3 element width + 17px added for the scrollbar
                 this.assertEqualsWithTolerance(spanWidth, expectedWidthIE7, 2, "The div width is %1, insted of %2");
+            } else if (aria.core.Browser.isMac) {
+                if (aria.core.Browser.isWebkit) {
+                    var expectedWidthMac = 634;
+                    this.assertEqualsWithTolerance(spanWidth, expectedWidthMac, 2, "The div width is %1, insted of %2");
+                } else {
+                    var expectedWidthMac = 647;
+                    this.assertEqualsWithTolerance(spanWidth, expectedWidthMac, 2, "The div width is %1, insted of %2");
+                }
             } else {
                 this.assertEqualsWithTolerance(spanWidth, expectedWidth, 2, "The div width is %1, insted of %2");
             }


### PR DESCRIPTION
When on mac the method aria.templates.Layout.getScrollbarsWidth() returns zero, due to the fact that on mac the scrollbars are managed differently. So in this case we add 17px in order to consider them and to avoid to crop some content.
