### PR TITLE
[on hold] Let more appenders survive on Aria.verbose

### DIFF
--- a/src/aria/core/Log.js
+++ b/src/aria/core/Log.js
@@ -245,9 +245,14 @@ Aria.classDefinition({
          * Add a new appender to the logging system
          * @param {aria.core.log.DefaultAppender} appender An instance of appender (must implement the same methods as
          * aria.core.log.DefaultAppender)
+         * @param {Integer} position Optional position in which the appender should be added
          */
-        addAppender : function (appender) {
-            this._appenders.push(appender);
+        addAppender : function (appender, position) {
+            if (position == null || position >= this._appenders.length) {
+                this._appenders.push(appender);
+            } else {
+                this._appenders.splice(position, 0, appender);
+            }
         },
 
         /**

--- a/src/aria/core/log/WindowAppender.js
+++ b/src/aria/core/log/WindowAppender.js
@@ -24,7 +24,8 @@ Aria.classDefinition({
          * @type Object
          */
         this.w = Aria.$frameworkWindow.open("about:blank", "logger");
-        this.w.document.body.innerHTML += "<em>WindowAppender</em><hr/>";
+        // Document write seems to work better in IE7
+        this.w.document.write("<em>WindowAppender</em><hr/>");
         this.groupSpacer = "";
     },
     $destructor : function () {

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -73,13 +73,14 @@
              */
             this.evtLogs = [];
 
-            aria.core.Log.clearAppenders();
-            aria.core.Log.addAppender(new aria.core.log.SilentArrayAppender());
             if (Aria.verbose) {
-                // Readd the default appender in verbose mode to log things also to the browser console.
+                // Keep the appenders already added to have more information on errors.
                 // The order of appenders matters due to getAppenders()[0] used in assertErrorInLogs|assertLogsEmpty.
                 // Not using Aria.debug not to have a message flood in Attester.
-                aria.core.Log.addAppender(new aria.core.log.DefaultAppender());
+                aria.core.Log.addAppender(new aria.core.log.SilentArrayAppender(), 0);
+            } else {
+                aria.core.Log.clearAppenders();
+                aria.core.Log.addAppender(new aria.core.log.SilentArrayAppender());
             }
 
             aria.core.Log.resetLoggingLevels();


### PR DESCRIPTION
When `Aria.verbose = true` we remove all appenders and add back the `DefaultAppender`.
With this fix we keep all appenders already there, this allows other appenders like `WindowAppender` to keep working while testing
