### PR TITLE
fix #600 general.disable was not checked in aria.templates.LegacyGeneralStyle

### DIFF
--- a/src/aria/templates/LegacyGeneralStyle.tpl.css
+++ b/src/aria/templates/LegacyGeneralStyle.tpl.css
@@ -38,7 +38,7 @@
     {/if}
 
 
-    {if ! general.disable.ul.list.style}
+    {if !general.disable || !general.disable.ul.list.style}
         ul, li {list-style-type:none;}
     {/if}
 


### PR DESCRIPTION
It can raise some javascript errors if the property is not defined in the skins
