### PR TITLE
fix #601 Tooltip on aria:Icon widget

### DIFF
--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -43,5 +43,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.errorlist.ListErrorTestCase");
         this.addTests("test.aria.widgets.action.iconbutton.issue276.IconButtonTestCase");
         this.addTests("test.aria.widgets.verticalAlign.VerticalAlignTestCase");
+        this.addTests("test.aria.widgets.icon.IconTest");
     }
 });

--- a/test/aria/widgets/icon/IconTest.js
+++ b/test/aria/widgets/icon/IconTest.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.Icon
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.icon.IconTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+
+            var icon = this.getWidgetInstance("testIcon").getDom();
+
+            this.synEvent.move({
+                from : this.testWindow.aria.utils.Dom.getElementById("testSpan"),
+                to : icon
+            }, this.testWindow.aria.utils.Dom.getElementById("testSpan"), {
+                fn : this._afterFirstMove,
+                scope : this
+            });
+        },
+
+        _afterFirstMove : function () {
+
+            aria.core.Timer.addCallback({
+                fn : this._afterFirstMoveWait,
+                scope : this,
+                delay : 500
+            });
+        },
+        _afterFirstMoveWait : function () {
+
+            this.assertEquals(this.getWidgetInstance("testTooltip")._popup.isOpen, true, "The tooltip was not displayed");
+
+            var icon = this.getWidgetInstance("testIcon").getDom();
+
+            this.synEvent.move({
+                to : this.testWindow.aria.utils.Dom.getElementById("testSpan"),
+                from : icon
+            }, icon, {
+                fn : this._afterSecondMove,
+                scope : this
+            });
+        },
+
+        _afterSecondMove : function () {
+            aria.core.Timer.addCallback({
+                fn : this._afterSecondMoveWait,
+                scope : this,
+                delay : 200
+            });
+        },
+        _afterSecondMoveWait : function () {
+            this.assertEquals(this.getWidgetInstance("testTooltip")._popup, null, "The tooltip was not closed");
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/icon/IconTestTpl.tpl
+++ b/test/aria/widgets/icon/IconTestTpl.tpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ {Template {
+	$classpath : "test.aria.widgets.icon.IconTestTpl"
+}}
+
+	{macro main()}
+		<div>
+			{@aria:Icon {
+				id : "testIcon",
+				icon : "std:info",
+				tooltipId : "testTooltip"
+			}/}
+		</div>
+		{@aria:Tooltip {
+			id : "testTooltip",
+			macro : "tooltipContent"
+		}/}
+
+		<div>
+			<span id="testSpan" style="margin: 10px;">testSpan</span>
+		<div>
+
+	{/macro}
+
+	{macro tooltipContent()}
+		Some text for test purposes
+	{/macro}
+
+{/Template}


### PR DESCRIPTION
A delegate id is now added to the markup generated by the Icon widget, so that listeners to mouse events are correctly called.
