### PR TITLE
Bug in the select html widget: the 'value' property isn't properly bound

### DIFF
--- a/src/aria/html/Select.js
+++ b/src/aria/html/Select.js
@@ -146,7 +146,7 @@ Aria.classDefinition({
             if (bindings.value) {
                 var newValue = this._transform(bindings.value.transform, bindings.value.inside[bindings.value.to], "toWidget");
                 if (newValue != null) {
-                    return newValue;
+                    return this.getIndex(newValue);
                 }
                 isBound = true;
             }

--- a/test/aria/html/select/bodycontent/BodyContentTestCase.js
+++ b/test/aria/html/select/bodycontent/BodyContentTestCase.js
@@ -40,7 +40,12 @@ Aria.classDefinition({
         afterFirstClick : function () {
             this.assertEquals(this.selectWidget.selectedIndex, 1, "The selected Index should be %2  but was %1 ");
 
+            // now refresh the template and check that the selectedValue is still the one from the model
+            this.templateCtxt.$refresh();
             this.selectWidget = null;
+            var selectWidgetAfterRefresh = this.testDiv.getElementsByTagName("select")[0];
+            this.assertEquals(selectWidgetAfterRefresh.selectedIndex, 1, "The selected Index should be %2  but was %1 ");
+
             this.end();
         }
 


### PR DESCRIPTION
Bug in the select html widget: the 'value' property isn't properly bound
