### PR TITLE
fix #607 PageEngine containerId constraints

### DIFF
--- a/src/aria/pageEngine/CfgBeans.js
+++ b/src/aria/pageEngine/CfgBeans.js
@@ -42,7 +42,7 @@ Aria.beanDefinitions({
             $type : "json:Object",
             $description : "Configuration object for the Page Engine's start method.",
             $properties : {
-                "pageProvder" : {
+                "pageProvider" : {
                     $type : "json:Object",
                     $description : "Instance of class that implements aria.pageEngine.pageProviders.PageProviderInterface.",
                     $mandatory : true
@@ -64,7 +64,7 @@ Aria.beanDefinitions({
             $properties : {
                 "containerId" : {
                     $type : "json:String",
-                    $description : "Id of the HTML element inside which the application will be loaded.",
+                    $description : "Id of the HTML element inside which the application will be loaded. It must point to some descendant of BODY, never to the BODY element itself.",
                     $mandatory : true
                 },
                 "commonModules" : {

--- a/src/aria/pageEngine/utils/SiteConfigHelper.js
+++ b/src/aria/pageEngine/utils/SiteConfigHelper.js
@@ -41,6 +41,7 @@ Aria.classDefinition({
     },
 
     $statics : {
+        CONTAINER_ID_CANT_BE_BODY_ID : "The 'containerId' page engine config entry must not be the id of BODY element",
         MISSING_PROCESS_METHOD : "The processContent method is not implemented"
     },
     $prototype : {
@@ -52,7 +53,9 @@ Aria.classDefinition({
         getRootDiv : function () {
             var rootDivId = this.getRootDivId();
             var domElt = aria.utils.Dom.getElementById(rootDivId);
-            if (!domElt) {
+            if (domElt === Aria.$window.document.body) {
+                this.$logError(this.CONTAINER_ID_CANT_BE_BODY_ID);
+            } else if (!domElt) {
                 domElt = Aria.$window.document.createElement("DIV");
                 domElt.id = rootDivId;
                 Aria.$window.document.body.appendChild(domElt);

--- a/test/aria/pageEngine/utils/SiteConfigHelperTest.js
+++ b/test/aria/pageEngine/utils/SiteConfigHelperTest.js
@@ -102,6 +102,18 @@ Aria.classDefinition({
             this.assertTrue(aria.utils.Array.isEmpty(aria.utils.Object.keys(this.siteConfigHelper.getContentProcessorInstances())), "method getContentProcessorInstances failed");
             this.siteConfigHelper.$dispose();
 
+            this._testBodyAsPageEngineContainer();
+        },
+
+        _testBodyAsPageEngineContainer : function () {
+            // BODY is not allowed as page engine container, because we store AT event listeners on BODY.
+            // For animations to work, we need to clone the container; there can't be two <BODY> elements in the HTML.
+            var oldBodyId = Aria.$window.document.body.id;
+            Aria.$window.document.body.id = this.siteConfigHelper.getRootDivId();
+            this.siteConfigHelper.getRootDiv();
+            this.assertErrorInLogs(aria.pageEngine.utils.SiteConfigHelper.CONTAINER_ID_CANT_BE_BODY_ID);
+            Aria.$window.document.body.id = oldBodyId;
+
             this._testGetCommonModulesDescription();
         },
 


### PR DESCRIPTION
Container ID can't be body because we need to temporarily clone the container to perform animation.
Hence this would
1) violate HTML spec (two BODY elements in the page)
2) in the real world scenario (tested in Firefox and Chrome), when we switch to the "alternative BODY", no AT event listeners are working any longer, since they were registered on the "original BODY". It's better not to mess with that probably.
