### PR TITLE
Error when tab selection triggers refresh

### DIFF
--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -204,7 +204,7 @@ Aria.classDefinition({
          */
         _dom_onclick : function (domEvt) {
             this._selectTab();
-            if (!this._hasFocus) {
+            if (this._cfg && !this._hasFocus) {
                 this._focus();
             }
         },


### PR DESCRIPTION
When tab selection triggers a refresh of the seciton containing the @aria:Tab widget, an error is raised when trying to give focus to the widget, which has been destroyed in the mean time.
