### PR TITLE
refactor env settings for template tests

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -41,7 +41,7 @@ Aria.classDefinition({
             moduleCtrl : null,
             data : {},
             iframe : false,
-            cssText : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);"
+            baseCss : this.IFRAME_BASE_CSS_TEXT
         };
 
         /**
@@ -172,7 +172,7 @@ Aria.classDefinition({
             if (!this.testDiv) {
                 var div = this.testDocument.createElement("div");
                 div.id = this.testDivId;
-                div.style.cssText = this.env.cssText;
+                div.style.cssText = this._getCssTextForTestFrame(this.env);
                 this.testDocument.body.appendChild(div);
                 this.testDiv = div;
             }
@@ -791,7 +791,7 @@ Aria.classDefinition({
             containerDiv.style.cssText = "background-color:#F7F6F1;position:absolute;";
             var iframe = document.createElement("iframe");
             iframe.id = "testIframe_" + this.$class;
-            iframe.style.cssText = args.def.cssText;
+            iframe.style.cssText = this._getCssTextForTestFrame(args.def);
             containerDiv.appendChild(iframe);
             document.body.appendChild(containerDiv);
             args.iframe = iframe;
@@ -899,6 +899,16 @@ Aria.classDefinition({
                 document : args.iframe.contentDocument || args.iframe.contentWindow.document,
                 templateCtxt : result.tplCtxt
             });
+        },
+
+        /**
+         * Merges and outputs base and additional CSS text for the iframe found in env setting of a template test.
+         * @param {Object} env
+         * @return {String}
+         * @protected
+         */
+        _getCssTextForTestFrame : function (env) {
+            return env.baseCss + (env.css ? ";" + env.css : "");
         },
 
         /**

--- a/src/aria/jsunit/TestCase.js
+++ b/src/aria/jsunit/TestCase.js
@@ -32,6 +32,8 @@ Aria.classDefinition({
         // some tests run slower on IE when they are in a suite
         "defaultTestTimeout" : 60000,
 
+        IFRAME_BASE_CSS_TEXT : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);",
+
         ERROR_NOTIFY_END : "Synchronous test is calling notifyTestEnd",
         EXCEPTION_IN_METHOD : "Exception raised while calling '%1' in an asynchronous test",
         ASYNC_IN_SYNC_TEST : "Doing asynchronous actions inside a synchronous test, please check '%1'"

--- a/test/aria/pageEngine/IframeTestCase.js
+++ b/test/aria/pageEngine/IframeTestCase.js
@@ -35,7 +35,7 @@ Aria.classDefinition({
             var document = Aria.$window.document;
             var iframe = document.createElement("iframe");
             iframe.id = "test-iframe";
-            iframe.style.cssText = "position:fixed;top:20px;left:20px;z-index:10000;width:612px;height:612px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);";
+            iframe.style.cssText = this.IFRAME_BASE_CSS_TEXT;
             document.body.appendChild(iframe);
             this._iframe = iframe;
             testEnv = iframe;

--- a/test/aria/utils/dragdrop/AbstractDragTestCase.js
+++ b/test/aria/utils/dragdrop/AbstractDragTestCase.js
@@ -23,9 +23,10 @@ Aria.classDefinition({
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
 
+        // special env settings to reproduce GH-545
         this.setTestEnv({
             template : "test.aria.utils.dragdrop.DragTestTemplate",
-            cssText : "position:relative;top:20px;left:20px;z-index:66666;width:1000px;height:700px;border:15px solid blue;background:aliceblue"
+            css : "position:relative;border:15px solid blue;"
         });
     },
     $prototype : {

--- a/test/aria/utils/dragdrop/OutOfBoundaryTest.js
+++ b/test/aria/utils/dragdrop/OutOfBoundaryTest.js
@@ -23,9 +23,10 @@ Aria.classDefinition({
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
 
+        // special env settings to reproduce GH-545
         this.setTestEnv({
             template : "test.aria.utils.dragdrop.DragTestTemplate",
-            cssText : "position:relative;top:20px;left:20px;z-index:66666;width:1000px;height:700px;border:15px solid blue;background:aliceblue"
+            css : "position:relative;border:15px solid blue;"
         });
     },
     $prototype : {

--- a/test/aria/widgets/container/dialog/bindPosition/DialogOnResizeTestCase.js
+++ b/test/aria/widgets/container/dialog/bindPosition/DialogOnResizeTestCase.js
@@ -31,8 +31,7 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.container.dialog.bindPosition.IframeTemplate",
             data : this.testData,
-            iframe : true,
-            cssText : "position:fixed;top:20px;left:20px;z-index:10000;width:612px;height:612px;border:1px solid blue;background:aliceblue"
+            iframe : true
         });
 
     },

--- a/test/aria/widgets/container/dialog/resize/test1/DialogOnResizeTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test1/DialogOnResizeTestCase.js
@@ -26,8 +26,7 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.container.dialog.resize.test1.DialogOnResize",
             data : this.data,
-            iframe : true,
-            cssText : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue"
+            iframe : true
         });
     },
     $prototype : {

--- a/test/aria/widgets/container/tooltip/TooltipTestCase.js
+++ b/test/aria/widgets/container/tooltip/TooltipTestCase.js
@@ -23,7 +23,7 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.container.tooltip.InnerTemplate",
             iframe : true,
-            cssText : "width:200px;height:200px;border:1px solid blue;"
+            css : "top:0;left:0;width:200px;height:200px;"
         });
     },
     $prototype : {


### PR DESCRIPTION
Split cssText from iframe tests cfg into baseCssText and
additionalCssText. Thanks to this, one may just add a bunch of overriden /
new css properties for a specific test, instead of having to copy-paste
everything.

---

I know it's not probably the most "clean" to move the CSS_TEXT to `TestCase.js` but I don't want to create new classes or make page engine's `IframeTestCase` depend on `TemplateTestCase`.
