### PR TITLE
fix InputValidationHandler issue

### DIFF
--- a/src/aria/widgets/form/InputValidationHandler.js
+++ b/src/aria/widgets/form/InputValidationHandler.js
@@ -206,7 +206,10 @@ Aria.classDefinition({
                     state = 'normal';
                 }
                 var div = this._div, frame = div._frame;
-                div.initWidgetDom();
+
+                // Make sure that the div is initialised (only once),
+                // as _onTooltipPositioned can be called several times for the same popup
+                div.getDom();
                 // this is backward compatibility for skin without errortooltip position states
                 if (frame.checkState(state)) {
                     frame.changeState(state);


### PR DESCRIPTION
A javascript error was raised in the following use case:
- Inside a container having scrollbars, a field is in error,
- The field is focused (so that the error tooltip is open),
- Scroll the container with the mouse wheel
