### PR TITLE
fix #620 remove @-ms-keyframes

### DIFF
--- a/src/aria/utils/css/Transitions.tpl.css
+++ b/src/aria/utils/css/Transitions.tpl.css
@@ -356,7 +356,7 @@
   {/macro}
 
   {macro generateKeyFrames(name, from, to)}
-    {var prefixes = ["-webkit-", "-moz-", "-ms-", "-o-"] /}
+    {var prefixes = ["-webkit-", "-moz-", "-o-"] /}
 
     {for var i = 0; i < prefixes.length; i += 1}
       @${prefixes[i]}keyframes ${name} \{


### PR DESCRIPTION
`@-ms-keyframes` doesn't make sense. It's not supported by any IE version. 

It just generates a lot of unnecessary CSS (for all browsers) which is then discarded.
IE10 supports unprefixed `@keyframes` and IE9 doesn't support it at all.

According to
https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes
Firefox supports unprefixed keyframes since 16.0. Opera 15 uses `-webkit` instead of `-o`. We could remove those (`-moz` and `-o`) also later on.
