### PR TITLE
Adding support to content when generating HtmlTemplate files

### DIFF
--- a/src/aria/ext/filesgenerator/Generator.js
+++ b/src/aria/ext/filesgenerator/Generator.js
@@ -92,10 +92,11 @@ Aria.classDefinition({
          * Simple shortcut method that creates an HTML templates only given a classpath.
          * @param {Boolean} hasScript Will also generate a template script if set to true
          * @param {Boolean} hasCss Will also generate a CSS template if set to true
+         * @param {String} content Will add an optional content to the template
          * @return {Array} An array of objects of the following format: {type: <typeString>, classpath:
          * <classpathString>, content: <contentString>} Even if only one file is generated, an array will be produced.
          */
-        generateHtmlTemplate : function (classpath, hasScript, hasCss) {
+        generateHtmlTemplate : function (classpath, hasScript, hasCss, content) {
             var skeletonArray = [];
 
             var tplCfg = {
@@ -117,6 +118,9 @@ Aria.classDefinition({
                 skeletonArray.push(this.generateFile(this.TYPE_CSSTEMPLATE, {
                     $classpath : cssClasspath
                 }));
+            }
+            if (content) {
+                tplCfg.content = content;
             }
 
             skeletonArray.push(this.generateFile(this.TYPE_HTMLTEMPLATE, tplCfg));

--- a/test/aria/ext/filesgenerator/GeneratorTest.js
+++ b/test/aria/ext/filesgenerator/GeneratorTest.js
@@ -188,6 +188,28 @@ Aria.classDefinition({
         },
 
         /**
+         * Test content feature for generateHtmlTemplate method
+         */
+        testHtmlTemplateGeneratedWithContent : function () {
+            var generator = aria.ext.filesgenerator.Generator;
+            var myClasspath = generator.getUniqueClasspathIn("my.package");
+            var strPackage = myClasspath.substr(0, 10);
+            var className = myClasspath.substr(11);
+            var content = "{macro main()}my content{/macro}";
+
+            this.assertTrue(strPackage === "my.package", "Generated classpath is in wrong package");
+            this.assertTrue(/^[A-Z]\w*$/.test(className) === true, "Generated class name is not a class name.");
+            var fileInfo = generator.generateHtmlTemplate(myClasspath, false, false, content);
+
+            this.assertEquals(fileInfo.length, 1, "The incorrect number of files were generated. There should be only the template");
+
+            // content should be available in result template
+            this.assertTrue(/\{macro main\(\)\}my content\{\/macro\}/.test(fileInfo[0].content), "Content is not available in generated template");
+            // there should be only one main macro
+            this.assertTrue(fileInfo[0].content.match(/\{macro main\(/).length == 1, "There can be only one ... macro main");
+        },
+
+        /**
          * Test content feature
          */
         testHmlTemplateWithContent : function () {


### PR DESCRIPTION
Now is possible to pass a specific content to the method in order to have it inside the template generated.
