### PR TITLE
fix #626 pageEngine `pageReady` event not fired in Chrome

### DIFF
--- a/src/aria/utils/css/Transitions.tpl.css
+++ b/src/aria/utils/css/Transitions.tpl.css
@@ -20,7 +20,7 @@
 
   {macro main ()}
     .xanimation-element {
-      display: none;
+      visibility: hidden;
       {call generatePrefix("backface-visibility", "hidden") /}
     }
 


### PR DESCRIPTION
CSS transitions are not performed in Chrome and in IE10 when the container has `display:none`. Hence if `animationOut` was defined in animations configuration, page engine's `pageReady` event was never fired.
