### PR TITLE
hashchange listener broken after overlay creation

### DIFF
--- a/src/aria/utils/HashManager.js
+++ b/src/aria/utils/HashManager.js
@@ -133,10 +133,22 @@ Aria.classDefinition({
          */
         this._hashPollCallback = null;
 
+        /**
+         * Whether the listener to the hashchange event has been added
+         * @type Boolean
+         * @private
+         */
+        this._hashChangeCallbackAdded = false;
+
         if (this._isIE7OrLess) {
             this._createIframe();
             this._hashPoll();
         }
+
+        aria.utils.AriaWindow.$on({
+            "unloadWindow" : this._removeHashChangeInternalCallback,
+            scope : this
+        });
 
     },
     $destructor : function () {
@@ -144,7 +156,6 @@ Aria.classDefinition({
          * Remove the default callback for hashchange
          */
         this._removeHashChangeInternalCallback();
-
         if (this._hashPollCallback) {
             aria.core.Timer.cancelCallback(this._hashPollCallback);
             this._hashPollCallback = null;
@@ -218,7 +229,6 @@ Aria.classDefinition({
         addCallback : function (cb) {
             if (this._hashChangeCallbacks == null) {
                 this._hashChangeCallbacks = [];
-                // aria.utils.AriaWindow.attachWindow();
                 this._addHashChangeInternalCallback();
             }
             this._hashChangeCallbacks.push(cb);
@@ -240,7 +250,6 @@ Aria.classDefinition({
                     if (hcC.length === 0) {
                         this._hashChangeCallbacks = null;
                         this._removeHashChangeInternalCallback();
-                        // aria.utils.AriaWindow.detachWindow();
                     }
                 }
             }
@@ -367,6 +376,8 @@ Aria.classDefinition({
          */
         _addHashChangeInternalCallback : function () {
             if (!this._isIE7OrLess) {
+                this._hashChangeCallbackAdded = true;
+                aria.utils.AriaWindow.attachWindow();
                 aria.utils.Event.addListener(Aria.$window, 'hashchange', {
                     fn : this._internalCallback,
                     scope : this
@@ -427,10 +438,12 @@ Aria.classDefinition({
          * @protected
          */
         _removeHashChangeInternalCallback : function () {
-            if (!this._isIE7OrLess) {
+            if (!this._isIE7OrLess && this._hashChangeCallbackAdded) {
+                this._hashChangeCallbackAdded = false;
                 aria.utils.Event.removeListener(Aria.$window, 'hashchange', {
                     fn : this._internalCallback
                 });
+                aria.utils.AriaWindow.detachWindow();
             }
         },
 

--- a/src/aria/utils/History.js
+++ b/src/aria/utils/History.js
@@ -412,7 +412,7 @@
              * Retrieve the state from the store.
              * @param {String} id Id of the state
              * @return {Object}
-             * 
+             *
              * <pre>
              * {
              *     position : {Number} position in the store,
@@ -424,7 +424,7 @@
              *     }
              * }
              * </pre>
-             * 
+             *
              * @private
              */
             _retrieveFromMemory : function (id) {
@@ -592,7 +592,7 @@
             /**
              * Apply a state by also checking whether it is discarded or not
              * @param {Objet} stateInfo
-             * 
+             *
              * <pre>
              * {
              *     position : {Number} position in the store,
@@ -604,7 +604,7 @@
              *     }
              * }
              * </pre>
-             * 
+             *
              * @return {Boolean} true if the state has been applied, false if the state is discarded
              * @private
              */

--- a/test/aria/utils/UtilsTestSuite.js
+++ b/test/aria/utils/UtilsTestSuite.js
@@ -24,6 +24,7 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.dragdrop.DragDropBean");
         this.addTests("test.aria.utils.css.AnimationsTestSuite");
         this.addTests("test.aria.utils.environment.EnvironmentTestSuite");
+        this.addTests("test.aria.utils.hashManager.HashManagerTestSuite");
         this.addTests("test.aria.utils.json.JsonTestSuite");
         this.addTests("test.aria.utils.overlay.OverlayTestSuite");
         this.addTests("test.aria.utils.sandbox.DOMPropertiesTest");
@@ -46,7 +47,6 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.FireDomEvent");
         this.addTests("test.aria.utils.Function");
         this.addTests("test.aria.utils.FunctionWriterTest");
-        this.addTests("test.aria.utils.HashManager");
         this.addTests("test.aria.utils.History");
         this.addTests("test.aria.utils.Html");
         this.addTests("test.aria.utils.IdManager");

--- a/test/aria/utils/hashManager/HashManagerTestOne.js
+++ b/test/aria/utils/hashManager/HashManagerTestOne.js
@@ -17,7 +17,7 @@
  * Test case for aria.utils.HashManager
  */
 Aria.classDefinition({
-    $classpath : "test.aria.utils.HashManager",
+    $classpath : "test.aria.utils.hashManager.HashManagerTestOne",
     $extends : "aria.jsunit.TestCase",
     $constructor : function () {
         this.$TestCase.constructor.call(this);

--- a/test/aria/utils/hashManager/HashManagerTestSuite.js
+++ b/test/aria/utils/hashManager/HashManagerTestSuite.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath: "test.aria.utils.hashManager.HashManagerTestSuite",
+    $extends: "aria.jsunit.TestSuite",
+    $constructor: function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.utils.hashManager.HashManagerTestOne");
+        this.addTests("test.aria.utils.hashManager.HashManagerTestTwo");
+    }
+});

--- a/test/aria/utils/hashManager/HashManagerTestTwo.js
+++ b/test/aria/utils/hashManager/HashManagerTestTwo.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.utils.HashManager. In particular, it tests that the listeners of the hashChange event are called
+ * after a DomOverlay is displayed
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.utils.hashManager.HashManagerTestTwo",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.DomOverlay"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.__callbackCalled = false;
+        this._hcCB = {
+            fn : this._onHashChange,
+            scope : this
+        };
+    },
+    $destructor : function () {
+        this.hm = null;
+        this.$TestCase.$destructor.call(this);
+    },
+    $prototype : {
+        setUp : function () {
+            var window = Aria.$window;
+            this.__initialHash = window.location.hash;
+            window.location.hash = "init";
+        },
+
+        tearDown : function () {
+            var window = Aria.$window;
+            window.location.hash = this.__initialHash;
+        },
+
+        testAsyncStart : function () {
+            Aria.load({
+                classes : ["aria.utils.HashManager"],
+                oncomplete : {
+                    fn : this._testCallbackCalled,
+                    scope : this
+                }
+            });
+        },
+
+        _testCallbackCalled : function () {
+            this.hm = aria.utils.HashManager;
+            this.hm.addCallback(this._hcCB);
+            aria.utils.DomOverlay.create(Aria.$window.document.body);
+            aria.utils.DomOverlay.detachFrom(Aria.$window.document.body);
+
+            this.hm.setHash("somethingDifferent");
+            aria.core.Timer.addCallback({
+                fn : this._afterHashChange,
+                scope : this,
+                delay : 2 * this.hm.ie7PollDelay
+            });
+        },
+
+        _afterHashChange : function () {
+            this.assertEquals(this.__callbackCalled, true, "hashchange listener has not been called.");
+
+            this.notifyTestEnd("testAsyncInitial");
+        },
+
+        _onHashChange : function (hashObject) {
+            this.__callbackCalled = true;
+        }
+
+    }
+});


### PR DESCRIPTION
After a DomOverlay is created, the hashchange listener added by aria.utils.HashManager class was not called any longer.
