### PR TITLE
doc remove jsdoc @name when unnecessary

### DIFF
--- a/src/aria/DomEvent.js
+++ b/src/aria/DomEvent.js
@@ -204,7 +204,6 @@
              * Cancel any default action associated with the event
              * @param {Boolean} stopPropagation tells if event propagation must also be stopped - default: false
              * @method
-             * @name aria.DomEvent.preventDefault
              */
             this.preventDefault = !evt.preventDefault ? function (stopPropagation) {
                 this.hasPreventDefault = true;
@@ -222,7 +221,6 @@
 
             /**
              * Prevent the event from bubbling
-             * @name aria.DomEvent.stopPropagation
              * @method
              */
             this.stopPropagation = !evt.stopPropagation ? function () {

--- a/src/aria/templates/CSSTemplate.js
+++ b/src/aria/templates/CSSTemplate.js
@@ -30,7 +30,6 @@ Aria.classDefinition({
         /**
          * Path of the CSS Template. It corresponds to the classpath and starts with "/". Exposed to the {CSSTemplate}
          * @type String
-         * @name aria.templates.CSSTemplate.cssPath
          */
         this.cssPath = "/" + this.$classpath.replace(/\./g, "/");
 
@@ -38,7 +37,6 @@ Aria.classDefinition({
          * Path of the folder containing the CSS Template. It is relative to the Aria.rootFolderPath and takes into
          * account the Root Map (not the Url map). Exposed to the {CSSTemplate}
          * @type String
-         * @name aria.templates.CSSTemplate.cssFolderPath
          */
         this.cssFolderPath = url.substring(0, url.lastIndexOf("/"));
     },


### PR DESCRIPTION
@name is only needed if case when we want to document variables under
different names, or to document variables that are initialized outside
`$constructor` in `Aria.classDefinition`.

We have an issue with APIDoc extractor/viewer, it marks all props with
`@name` as `static`. By the time that gets fixed, this commit removes the
wrong `static` marker from some props. We still have `@name` though in
some other places (mainly modifiers and Aria singleton).
