### PR TITLE
fix #632 IO.swf not loaded when Aria.rootFolderPath is changed

### DIFF
--- a/src/aria/core/transport/XDR.js
+++ b/src/aria/core/transport/XDR.js
@@ -121,7 +121,8 @@ Aria.classDefinition({
             });
 
             if (!this._transport) {
-                var swfUri = Aria.rootFolderPath + 'aria/resources/handlers/IO.swf?t=' + new Date().getTime();
+                var swfUri = aria.core.DownloadMgr.resolveURL('aria/resources/handlers/IO.swf') + '?t='
+                        + new Date().getTime();
                 // note that the flash transport does not work with Safari if the following line is present in
                 // parameters:
                 // '<param name="wmode" value="transparent"/>'
@@ -157,8 +158,8 @@ Aria.classDefinition({
                     aria.core.Timer.cancelCallback(this._pending[id]);
                     aria.core.IO.reissue(id);
                 }
-                this._pending = {};
             }
+            this._pending = {};
         },
 
         /**


### PR DESCRIPTION
1) When I do sth like this in my code:

```
Aria.rootFolderPath = "http://example.org/here/is/my/stuff/";
aria.core.DownloadMgr.updateRootMap({"aria": {"*" : "http://example.org/here/is/aria-templates/"}});
```

then IO.swf will be mistakenly loaded from `here/is/my/stuff` instead of from `here/is/aria-templates/`.

This commit fixes that issue.

2) Having the above rules applied, when I make a call like this:

```
            Aria.loadTemplate({
                classpath:'testClassPath.Test',
                div:"main",
                moduleCtrl : {
                    classpath : "testClassPath.Controller"
                }
            });
```

(both paths pointing to physical files not conforming same-origin), then only one of those files was actually requested due to a bug in `XDR.js`.
