### PR TITLE
Fix test.aria.widgets.container.dialog.closeOutside.Issue389TestCase

### DIFF
--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -392,7 +392,8 @@
              * @param {aria.core.CfgBeans:Callback} cb callback description
              * @param {MultiTypes} res first result argument to pass to cb.fn (second argument will be cb.args)
              * @param {String} errorId error raised if an exception occurs in the callback
-             * @return {MultiTypes} the value returned by the callback, or undefined if the callback could not be called.
+             * @return {MultiTypes} the value returned by the callback, or undefined if the callback could not be
+             * called.
              */
             $callback : function (cb, res, errorId) {
                 if (!cb) {
@@ -649,7 +650,9 @@
                             fn : lsn.fn,
                             scope : lsn.scope,
                             args : lsn.args,
-                            once : lstCfg[evt].listenOnce
+                            once : lstCfg[evt].listenOnce,
+                            apply : lsn.apply,
+                            resIndex : lsn.resIndex
                             // we keep track of listeners which are meant to be called just once
                         };
                         // lsn is an object as in 'start' or 'end' samples set default scope


### PR DESCRIPTION
This commit fixes a failing test on Firefox:
 test.aria.widgets.container.dialog.closeOutside.Issue389TestCase

The regression was caused by 6f4e5e3586e1f1ed7f721bb16fd8ff79fa9a2c86
along with the following bug in Firefox:
when inserting the java robot applet while a field is focused,
the field stays focused but no longer reacts when typing.
