### PR TITLE
bug spotted in IE 7

### DIFF
--- a/src/aria/html/RadioButton.js
+++ b/src/aria/html/RadioButton.js
@@ -24,7 +24,7 @@
     function bidirectionalClickBinding (event) {
         var bind = this._bindingListeners.selectedValue;
         var newValue = this._transform(bind.transform, this._cfg.value, "fromWidget");
-        aria.utils.Json.setValue(bind.inside, bind.to, newValue, bind.cb);
+        aria.utils.Json.setValue(bind.inside, bind.to, newValue);
     }
 
     /**
@@ -70,6 +70,7 @@
              * @param {Object} oldValue Value of the property before the change happened
              */
             onbind : function (name, value, oldValue) {
+
                 this.$InputElement.onbind.apply(this, arguments);
                 if (name === "selectedValue") {
                     this._domElt.checked = (value === this._cfg.value);

--- a/src/aria/html/beans/RadioButtonCfg.js
+++ b/src/aria/html/beans/RadioButtonCfg.js
@@ -22,10 +22,6 @@ Aria.beanDefinitions({
             $type : "base:Properties",
             $description : "Properties of a RadioButton widget.",
             $properties : {
-                "name" : {
-                    $type : "json:String",
-                    $description : "The radio button name. Radio buttons with the same name will form a radio button group."
-                },
                 "value" : {
                     $type : "json:String",
                     $description : "The value associated with the radio button."

--- a/test/aria/html/radioButton/RadioButtonTest.js
+++ b/test/aria/html/radioButton/RadioButtonTest.js
@@ -32,12 +32,10 @@ Aria.classDefinition({
             };
 
             var cfg1 = {
-                name : "group1",
                 value : "a",
                 bind : bindingConfig
             };
             var cfg2 = {
-                name : "group1",
                 value : "b",
                 bind : bindingConfig
             };
@@ -76,12 +74,10 @@ Aria.classDefinition({
             };
 
             var cfg1 = {
-                name : "group1",
                 value : "a",
                 bind : bindingConfig
             };
             var cfg2 = {
-                name : "group1",
                 value : "b",
                 bind : bindingConfig
             };
@@ -108,7 +104,6 @@ Aria.classDefinition({
             };
 
             var cfg = {
-                name : "group1",
                 value : "a",
                 bind : {
                     selectedValue : {
@@ -144,7 +139,6 @@ Aria.classDefinition({
             var container = {};
 
             var cfg = {
-                name : "group1",
                 value : "a",
                 bind : {
                     selectedValue : {
@@ -171,7 +165,6 @@ Aria.classDefinition({
             var container = {};
 
             var cfg = {
-                name : "group1",
                 value : "a"
             };
 


### PR DESCRIPTION
radio button needs a name to get selected by a click. As there is no need for a name in this widget,
the workaround is to call the onbind method on every radio button bound to the model.
