### PR TITLE
fix #642 Some wrong scrollbars were displayed in the splitter panels.

### DIFF
--- a/src/aria/css/atskin.js
+++ b/src/aria/css/atskin.js
@@ -145,6 +145,7 @@ Aria.classDefinition({
             Splitter : {
                 std : {
                     borderColor : "#AB9B85",
+                    borderWidth : 1,
                     proxySpriteURLh : "atskin/sprites/splitter.gif",
                     proxyBackgroundColor : "#BBBBBB",
                     handleBackgroundColor : "#FFFBF1",

--- a/src/aria/widgets/AriaSkinBeans.js
+++ b/src/aria/widgets/AriaSkinBeans.js
@@ -943,6 +943,10 @@ Aria.beanDefinitions({
                 },
                 borderColor : {
                     $type : "Color"
+                },
+                borderWidth : {
+                    $type : "Pixels",
+                    $default : 1
                 }
             }
         },

--- a/src/aria/widgets/container/Splitter.js
+++ b/src/aria/widgets/container/Splitter.js
@@ -97,6 +97,14 @@ Aria.classDefinition({
          */
         this._width = null;
 
+        /**
+         * Override default widget's span style
+         * @protected
+         * @override
+         * @type String
+         */
+        this._spanStyle = "overflow: hidden;";
+
     },
     $destructor : function () {
         this._skinObj = null;
@@ -107,10 +115,6 @@ Aria.classDefinition({
         this._splitBarProxyClass.$dispose();
         this._destroyDraggable();
         this.$Container.$destructor.call(this);
-    },
-    $statics : {
-        SPLITTER_BORDER_SIZE : 2
-        // Default 2px;
     },
     $prototype : {
         /**
@@ -205,15 +209,18 @@ Aria.classDefinition({
             var borderClass = "", splitterBarSize = orientation ? cfg.width : cfg.height;
             var height = this._height + this._skinObj.separatorHeight, width = this._width
                     + this._skinObj.separatorWidth;
+            var bordersWidth = 0;
+
             if (cfg.border) {
                 borderClass = "xSplitter_" + cfg.sclass + "_sBdr";
+                bordersWidth = this._skinObj.borderWidth * 2;
             }
             this._handleBarClass = "xSplitter_" + cfg.sclass + (orientation ? "_sHandleH" : "_sHandleV");
 
             if (orientation) {
-                cfgH = height, cfgW = cfg.width, cfgHclass = size.size1, cfgWclass = cfg.width;
+                cfgH = height, cfgW = cfgWclass = cfg.width - bordersWidth, cfgHclass = size.size1;
             } else {
-                cfgH = cfg.height, cfgW = width, cfgHclass = cfg.height, cfgWclass = size.size1;
+                cfgH = cfgHclass = cfg.height - bordersWidth, cfgW = width, cfgWclass = size.size1;
             }
 
             out.write(['<span class="xSplitter_', cfg.sclass, '_sContainer ', borderClass, '" style="height:', cfgH,
@@ -229,10 +236,11 @@ Aria.classDefinition({
 
             var sDimension, sPosition, sEndPosition;
             if (orientation) {
-                cfgHclass = size.size2, cfgWclass = cfg.width, sDimension = "width", sPosition = "top", sEndPosition = "bottom";
+                cfgHclass = size.size2, cfgWclass = cfg.width - bordersWidth, sDimension = "width", sPosition = "top", sEndPosition = "bottom";
             } else {
-                cfgHclass = cfg.height, cfgWclass = size.size2, sDimension = "height", sPosition = "left", sEndPosition = "right";
+                cfgHclass = cfg.height - bordersWidth, cfgWclass = size.size2, sDimension = "height", sPosition = "left", sEndPosition = "right";
             }
+
             out.write(['<span class="', this._handleBarClass, '" style="' + sDimension + ':', splitterBarSize,
                     'px;' + sPosition + ':', size.size1, 'px; "> </span><span id="splitBarProxy_', this._domId,
                     '" class="', this._handleBarClass, ' " style="' + sPosition + ':', size.size1,
@@ -253,7 +261,7 @@ Aria.classDefinition({
          * @param {aria.widgets.CfgBeans:SplitterCfg}
          */
         _calculateSize : function (cfg) {
-            var border = cfg.border ? this.SPLITTER_BORDER_SIZE : 0, size = {}, totalHeight, initDimension;
+            var border = cfg.border ? this._skinObj.borderWidth * 2 : 0, size = {}, totalHeight, initDimension;
             this._height = cfg.height - this._skinObj.separatorHeight - border;
             this._width = cfg.width - this._skinObj.separatorWidth - border;
             if (this._height < 0) {

--- a/src/aria/widgets/container/SplitterStyle.tpl.css
+++ b/src/aria/widgets/container/SplitterStyle.tpl.css
@@ -73,7 +73,7 @@
 }
 
 .xSplitter_${skinClassName}_sBdr{
-   border:1px solid ${skinClass.borderColor} ;
+   border:${skinClass.borderWidth}px solid ${skinClass.borderColor} ;
 }
 
 .xSplitter_${skinClassName}_sMacro {

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -46,5 +46,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.action.iconbutton.issue276.IconButtonTestCase");
         this.addTests("test.aria.widgets.verticalAlign.VerticalAlignTestCase");
         this.addTests("test.aria.widgets.icon.IconTest");
+        this.addTests("test.aria.widgets.splitter.scrollbars.ScrollbarTestCase");
+
     }
 });

--- a/test/aria/widgets/splitter/scrollbars/ScrollbarTestCase.js
+++ b/test/aria/widgets/splitter/scrollbars/ScrollbarTestCase.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.splitter.scrollbars.ScrollbarTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $prototype : {
+        runTemplateTest : function () {
+            // Test that no scrollbar is displayed on the second xSplitter_std_sMacro (check issue #642)
+            // as it can hides the inner ones.
+            var els = this.getElementsByClassName(Aria.$window.document.body, "xSplitter_std_sMacro");
+
+            for(var i = 0, ii = els.length; i < ii; i++) {
+                var el = els[i];
+                this.assertTrue(
+                    (el.scrollHeight - el.offsetHeight < 1) && (el.scrollWidth - el.offsetWidth < 1),
+                    "Element " + i + "shouldn't have a scrollbar"
+                );
+            }
+
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/splitter/scrollbars/ScrollbarTestCaseTpl.tpl
+++ b/test/aria/widgets/splitter/scrollbars/ScrollbarTestCaseTpl.tpl
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.splitter.scrollbars.ScrollbarTestCaseTpl"
+}}
+
+    {macro main()}
+        {@aria:Splitter {
+            sclass: "std",
+            orientation:"vertical",
+            border:true,
+            size2:300,
+            height:200,
+            width:600,
+            adapt:"both", //["size1","size2","both"]
+            macro1:'Panel1',
+            macro2:'Panel2'
+        }}
+    {/@aria:Splitter}
+    {/macro}
+
+    {macro Panel1()}
+        <div style="padding:5px;">
+            <h3> Third panel </h3>
+            <p>es simplemente el texto.  </p>
+        </div>
+    {/macro}
+
+    {macro Panel2()}
+
+         {@aria:Splitter {
+            sclass: "std",
+            orientation:"horizontal",
+            border:true,
+            size1:90,
+            size2:90,
+            height:196,
+            width:298,
+            adapt:"size1", //["size1","size2","both"]
+            macro1:'Panel3',
+            macro2:'Panel4'
+        }}
+        {/@aria:Splitter}
+
+      {/macro}
+      {macro Panel3()}
+          <div style="padding:5px;">
+              <h3> Fifth panel </h3>
+          </div>
+      {/macro}
+      {macro Panel4()}
+          <div style="padding:5px;">
+              <h3> Sixth panel </h3>
+          </div>
+
+      {/macro}
+
+
+{/Template}


### PR DESCRIPTION
In these cases, this prevented from scrolling the content panel.
Some miscalculations of the width and height have also been fixed.
The splitter border  width is now accessible from the skinning system (by the new borderWidth property).
