### PR TITLE
fix #626 test case for: pageReady event not raised

### DIFF
--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -29,5 +29,6 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.PageDefinitionChangeTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTestWithAnimations");
+        this.addTests("test.aria.pageEngine.pageEngine.issue626.PageReadyEventTest");
     }
 });

--- a/test/aria/pageEngine/pageEngine/issue626/PageProvider626.js
+++ b/test/aria/pageEngine/pageEngine/issue626/PageProvider626.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.issue626.PageProvider626",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $constructor : function () {
+
+        // These are the only important things in this test provider, the rest is a boilerplate to have page engine
+        // working. We need such an animation config which would trigger `this._isSequential()` return true in
+        // utils/css/Animations and have `animateOut` enabled.
+        this._animations = true;
+        this._animationCfg = {
+            animateIn : "flip",
+            animateOut : "flip",
+            type : 1
+        };
+    },
+
+    $prototype : {
+
+        /**
+         * @override
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                appData : {},
+                containerId : "at-main",
+                animations : this._animations
+            };
+
+            this.$callback(callback.onsuccess, siteConfig);
+        },
+
+        /**
+         * @override
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            this.$callback(callback.onsuccess, {
+                pageId : "aaa",
+                url : "/pageEngine/aaa",
+                animation : this._animationCfg,
+                contents : {},
+                pageComposition : {
+                    template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
+                    placeholders : {}
+                }
+            });
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/issue626/PageReadyEventTest.js
+++ b/test/aria/pageEngine/pageEngine/issue626/PageReadyEventTest.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.issue626.PageReadyEventTest",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.defaultTestTimeout = 10000;
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.issue626.PageProvider626");
+
+        this.__pageReadyEventWasRaised = false;
+    },
+    $prototype : {
+
+        /**
+         * This function will be called if test is successful. Otherwise the test will time out.
+         */
+        _onPageReady : function () {
+            this.__pageReadyEventWasRaised = true;
+        },
+
+        /**
+         * @override
+         */
+        runTestInIframe : function () {
+            this._createPageEngine();
+        },
+
+        _createPageEngine : function () {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.issue626.PageProvider626();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+            this.pageEngine.$addListeners({
+                "pageReady" : {
+                    fn : this._onPageReady,
+                    scope : this
+                }
+            });
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this._onPageEngineStart,
+                    scope : this
+                }
+            });
+        },
+
+        _onPageEngineStart : function () {
+            this.assertTrue(this.__pageReadyEventWasRaised, "pageReady event was not raised");
+            this.end();
+        },
+
+        /**
+         * @override
+         */
+        end : function () {
+            this._disposePageEngine();
+            this.$PageEngineBaseTestCase.end.call(this);
+        },
+
+        _disposePageEngine : function () {
+            this.pageEngine.$removeListeners({
+                "pageReady" : {
+                    fn : this._onPageReady,
+                    scope : this
+                }
+            });
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+        }
+    }
+});


### PR DESCRIPTION
The fix for the issue has already been integrated in 1.4.7 via e533d6c2b29f6fa3809c5973de3e5473638855a9. This is a missing test case.
