### PR TITLE
Page Engine issue with pageDefinition.animation = null

### DIFF
--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -543,7 +543,7 @@ Aria.classDefinition({
 
             var cfgTemplate = {
                 classpath : cfg.template,
-                div : this._getContainer(false),
+                div : pageConfig.animation === null ? (this._activeDiv === 0 ? this._firstDiv : this._secondDiv) : this._getContainer(false),
                 moduleCtrl : this._rootModule
             };
 

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -26,6 +26,7 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestThree");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestFour");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestFive");
+        this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestSix");
         this.addTests("test.aria.pageEngine.pageEngine.PageDefinitionChangeTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTestWithAnimations");

--- a/test/aria/pageEngine/pageEngine/PageEngineTestSix.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTestSix.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.PageEngineTestSix",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.site.PageProviderSix");
+        this._animations = true;
+    },
+    $prototype : {
+
+        runTestInIframe : function () {
+            this._createPageEngine({
+                oncomplete : "_onPageEngineStarted"
+            });
+        },
+
+        _onPageEngineStarted : function () {
+            if (this.pageEngine._animationsDisabled) {
+                this.end();
+            } else {
+                // Check page aaa
+                this._checkPageAAA();
+
+                this.pageEngine.navigate({
+                    pageId : "bbb"
+                }, {
+                    fn : this._afterSecondPageReady,
+                    scope : this
+                });
+            }
+        },
+
+        _afterSecondPageReady : function () {
+            // Check page bbb
+            this._checkPageBBB();
+
+            this.pageEngine.navigate({
+                pageId : "ccc"
+            }, {
+                fn : this._afterThirdPageReady,
+                scope : this
+            });
+        },
+
+        _afterThirdPageReady : function () {
+            // Check page ccc
+            this._checkPageCCC();
+            this.end();
+        },
+
+        _createPageEngine : function (args) {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.site.PageProviderSix(this._animations);
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this[args.oncomplete],
+                    scope : this
+                }
+            });
+        },
+
+        end : function () {
+            this._disposePageEngine();
+            this.$PageEngineBaseTestCase.end.call(this);
+        },
+
+        _disposePageEngine : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+        },
+
+        _checkPageAAA : function () {
+            var elt = this._testWindow.aria.utils.Dom.getElementById("at-main");
+            var firstDiv = elt.innerHTML;
+            var secondDiv = elt.nextSibling.innerHTML;
+
+            this.assertTrue(firstDiv.match(/Page Name: aaa/) !== null);
+            this.assertTrue(secondDiv === "");
+        },
+
+        _checkPageBBB : function () {
+            var elt = this._testWindow.aria.utils.Dom.getElementById("at-main");
+            var firstDiv = elt.innerHTML;
+            var secondDiv = elt.nextSibling.innerHTML;
+            this.assertTrue(firstDiv.match(/Page Name: bbb/) !== null);
+            this.assertTrue(secondDiv === "");
+        },
+
+        _checkPageCCC : function () {
+            var elt = this._testWindow.aria.utils.Dom.getElementById("at-main");
+            var firstDiv = elt.innerHTML;
+            var secondDiv = elt.nextSibling.innerHTML;
+            this.assertTrue(firstDiv === "");
+            this.assertTrue(secondDiv.match(/Page Name: ccc/) !== null);
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/PageProviderSix.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderSix.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Page provider
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.PageProviderSix",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $constructor : function (animations) {
+        this._animations = animations;
+    },
+    $prototype : {
+
+        /**
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                appData : {},
+                containerId : "at-main",
+                animations : this._animations
+            };
+
+            if (this._navigation) {
+                siteConfig.navigation = this._navigation;
+            }
+            this.$callback(callback.onsuccess, siteConfig);
+
+        },
+
+        /**
+         * @param {String} pageId Id of the page
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            var pageId = pageRequest.pageId;
+            if ((!pageId) || (pageId == "aaa")) {
+                this.$callback(callback.onsuccess, {
+                    pageId : "aaa",
+                    url : "/pageEngine/aaa",
+                    animation : {
+                        animateIn : "slide left",
+                        animateOut : "slide left",
+                        type : 1
+                    },
+                    contents : {
+                        menus : {
+                            mymenu : []
+                        },
+                        placeholderContents : {}
+                    },
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.MainLayout",
+                        placeholders : {
+                            "body" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.Body"
+                            }
+                        },
+                        pageData : {
+                            name : "aaa"
+                        }
+                    }
+                });
+            }
+            if (pageId == "bbb") {
+                this.$callback(callback.onsuccess, {
+                    pageId : "bbb",
+                    url : "/pageEngine/bbb",
+                    animation : null,
+                    contents : {
+                        menus : {
+                            mymenu : []
+                        },
+                        placeholderContents : {}
+                    },
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.MainLayout",
+                        placeholders : {
+                            "body" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.Body"
+                            }
+                        },
+                        pageData : {
+                            name : "bbb"
+                        }
+                    }
+                });
+            }
+            if (pageId == "ccc") {
+                this.$callback(callback.onsuccess, {
+                    pageId : "ccc",
+                    url : "/pageEngine/ccc",
+                    animation : {
+                        animateOut : "pop",
+                        animateIn : "fade",
+                        type : 3
+                    },
+                    contents : {
+                        menus : {
+                            mymenu : []
+                        },
+                        placeholderContents : {}
+                    },
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.MainLayout",
+                        placeholders : {
+                            "body" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.Body"
+                            }
+                        },
+                        pageData : {
+                            name : "ccc"
+                        }
+                    }
+                });
+            }
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/templates/providerSix/Body.tpl
+++ b/test/aria/pageEngine/pageEngine/site/templates/providerSix/Body.tpl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+  $classpath : "test.aria.pageEngine.pageEngine.site.templates.providerSix.Body",
+  $wlibs: {
+     "embed": "aria.embed.EmbedLib"
+  }
+}}
+
+{macro main ()}
+
+      <h1>Body Template Page Name: ${data.storage.pageData.name}</h1>
+
+{/macro}
+
+
+{/Template}

--- a/test/aria/pageEngine/pageEngine/site/templates/providerSix/MainLayout.tpl
+++ b/test/aria/pageEngine/pageEngine/site/templates/providerSix/MainLayout.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+{Template {
+  $classpath : "test.aria.pageEngine.pageEngine.site.templates.providerSix.MainLayout",
+  $wlibs: {
+     "embed": "aria.embed.EmbedLib"
+  }
+}}
+
+{macro main ()}
+
+      {@embed:Placeholder {
+          name : "body"
+      }/}
+
+{/macro}
+
+
+{/Template}


### PR DESCRIPTION
This commit aims to fix a problem when pageDefinition.animation is set to null. Now the pageEngine load the page content in the wrong div. With this commit the pageEngine loads the page content inside the same div when the animation is set to null.
