### PR TITLE
fix #661 disable touch Dialog tests in Firefox 3.6

### DIFF
--- a/test/aria/touch/widgets/dialog/closeOnClick/DialogTestCase.js
+++ b/test/aria/touch/widgets/dialog/closeOnClick/DialogTestCase.js
@@ -23,8 +23,12 @@ Aria.classDefinition({
         this.data = {
             dialogVisible : true
         };
-        var olderThanIe10 = aria.core.Browser.isIE && parseInt(aria.core.Browser.version, 10) < 10;
-        if (!olderThanIe10) {
+
+        var browserVersion = parseInt(aria.core.Browser.version, 10);
+        this.cssAnimationsNotSupported = (aria.core.Browser.isIE && browserVersion < 10)
+                || (aria.core.Browser.isFirefox && browserVersion < 4);
+
+        if (!this.cssAnimationsNotSupported) {
             this.setTestEnv({
                 template : "test.aria.touch.widgets.dialog.closeOnClick.DialogTestCaseTpl",
                 data : this.data
@@ -33,8 +37,7 @@ Aria.classDefinition({
     },
     $prototype : {
         runTemplateTest : function () {
-            var olderThanIe10 = aria.core.Browser.isIE && parseInt(aria.core.Browser.version, 10) < 10;
-            if (olderThanIe10) {
+            if (this.cssAnimationsNotSupported) {
                 this.end();
             } else {
                 this.synEvent.click(Aria.$window.document.body, {
@@ -45,7 +48,7 @@ Aria.classDefinition({
         },
 
         checkBindings : function () {
-            this.assertFalse(this.templateCtxt.data.dialogVisible, "The 'visible' binded data should be false");
+            this.assertFalse(this.templateCtxt.data.dialogVisible, "The 'visible' bound data should be false");
 
             this.notifyTemplateTestEnd();
         },
@@ -54,7 +57,7 @@ Aria.classDefinition({
             aria.core.Timer.addCallback({
                 fn : this.checkBindings,
                 scope : this,
-                delay : 5000
+                delay : 1000
             });
         }
 

--- a/test/aria/touch/widgets/dialog/events/DialogAnimationsTestCase.js
+++ b/test/aria/touch/widgets/dialog/events/DialogAnimationsTestCase.js
@@ -36,46 +36,51 @@ Aria.classDefinition({
          * Make sure the right events are thrown, even if there is only one animation set
          */
         testAsync_checkEvents : function () {
-            var olderThanIe10 = aria.core.Browser.isIE && parseInt(aria.core.Browser.version, 10) < 10;
-            if (!olderThanIe10) {
-                this.eventsFired = [];
-                var conf = {
-                    // Content
-                    section : this.mockSection,
-                    modal : true,
-                    absolutePosition : {
-                        top : 200,
-                        left : 500
-                    },
-                    animateIn : "slide right",
-                    animateOut : null
-                };
 
-                this.popup = new aria.popups.Popup();
-                var popup = this.popup;
-                popup.$on({
-                    "*" : function (evt) {
-                        this.eventsFired.push(evt.name);
-                    },
-                    scope : this
-                });
+            var browserVersion = parseInt(aria.core.Browser.version, 10);
+            var cssAnimationsNotSupported = (aria.core.Browser.isIE && browserVersion < 10)
+                    || (aria.core.Browser.isFirefox && browserVersion < 4);
 
-                this.assertEquals(this.eventsFired.length, 0);
-
-                popup.open(conf);
-
-                this.assertJsonEquals(["onBeforeOpen", "onPositioned"], this.eventsFired);
-                // reset
-                this.eventsFired = [];
-
-                aria.core.Timer.addCallback({
-                    fn : this.checkEventsArrayAfterOpen,
-                    scope : this,
-                    delay : 2000
-                });
-            } else {
+            if (cssAnimationsNotSupported) {
                 this.notifyTestEnd("testAsync_checkEvents");
+                return;
             }
+
+            this.eventsFired = [];
+            var conf = {
+                // Content
+                section : this.mockSection,
+                modal : true,
+                absolutePosition : {
+                    top : 200,
+                    left : 500
+                },
+                animateIn : "slide right",
+                animateOut : null
+            };
+
+            this.popup = new aria.popups.Popup();
+            var popup = this.popup;
+            popup.$on({
+                "*" : function (evt) {
+                    this.eventsFired.push(evt.name);
+                },
+                scope : this
+            });
+
+            this.assertEquals(this.eventsFired.length, 0);
+
+            popup.open(conf);
+
+            this.assertJsonEquals(["onBeforeOpen", "onPositioned"], this.eventsFired);
+            // reset
+            this.eventsFired = [];
+
+            aria.core.Timer.addCallback({
+                fn : this.checkEventsArrayAfterOpen,
+                scope : this,
+                delay : 400
+            });
         },
 
         checkEventsArrayAfterOpen : function () {

--- a/test/aria/touch/widgets/dialog/events/DialogEventsTestCase.js
+++ b/test/aria/touch/widgets/dialog/events/DialogEventsTestCase.js
@@ -36,46 +36,50 @@ Aria.classDefinition({
          * Make sure the right events are thrown
          */
         testAsync_checkEvents : function () {
-            var olderThanIe10 = aria.core.Browser.isIE && parseInt(aria.core.Browser.version, 10) < 10;
-            if (!olderThanIe10) {
-                this.eventsFired = [];
-                var conf = {
-                    // Content
-                    section : this.mockSection,
-                    modal : true,
-                    absolutePosition : {
-                        top : 200,
-                        left : 500
-                    },
-                    animateIn : "slide right",
-                    animateOut : "slide left"
-                };
+            var browserVersion = parseInt(aria.core.Browser.version, 10);
+            var cssAnimationsNotSupported = (aria.core.Browser.isIE && browserVersion < 10)
+                    || (aria.core.Browser.isFirefox && browserVersion < 4);
 
-                this.popup = new aria.popups.Popup();
-                var popup = this.popup;
-                popup.$on({
-                    "*" : function (evt) {
-                        this.eventsFired.push(evt.name);
-                    },
-                    scope : this
-                });
-
-                this.assertEquals(this.eventsFired.length, 0);
-
-                popup.open(conf);
-
-                this.assertJsonEquals(["onBeforeOpen", "onPositioned"], this.eventsFired);
-                // reset
-                this.eventsFired = [];
-
-                aria.core.Timer.addCallback({
-                    fn : this.checkEventsArrayAfterOpen,
-                    scope : this,
-                    delay : 2000
-                });
-            } else {
+            if (cssAnimationsNotSupported) {
                 this.notifyTestEnd("testAsync_checkEvents");
+                return;
             }
+
+            this.eventsFired = [];
+            var conf = {
+                // Content
+                section : this.mockSection,
+                modal : true,
+                absolutePosition : {
+                    top : 200,
+                    left : 500
+                },
+                animateIn : "slide right",
+                animateOut : "slide left"
+            };
+
+            this.popup = new aria.popups.Popup();
+            var popup = this.popup;
+            popup.$on({
+                "*" : function (evt) {
+                    this.eventsFired.push(evt.name);
+                },
+                scope : this
+            });
+
+            this.assertEquals(this.eventsFired.length, 0);
+
+            popup.open(conf);
+
+            this.assertJsonEquals(["onBeforeOpen", "onPositioned"], this.eventsFired);
+            // reset
+            this.eventsFired = [];
+
+            aria.core.Timer.addCallback({
+                fn : this.checkEventsArrayAfterOpen,
+                scope : this,
+                delay : 400
+            });
         },
 
         checkEventsArrayAfterOpen : function () {
@@ -87,7 +91,7 @@ Aria.classDefinition({
             aria.core.Timer.addCallback({
                 fn : this.checkEventsArrayAfterClose,
                 scope : this,
-                delay : 2000
+                delay : 400
             });
 
         },


### PR DESCRIPTION
By the way some refactor (early return) and lowered timers.

For nicer diff:
https://github.com/ariatemplates/ariatemplates/pull/662/files?w=1
