### PR TITLE
feat #652 Autocomplete Eventhandlers

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -906,6 +906,14 @@ Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "sclass of the list used in the dropdown. The default value for this property is taken from the skin."
                 },
+                "onclick" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the user  on the autocomplete."
+                },
+                "onfocus" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the user focusses the autocomplete"
+                },
                 "selectionKeys" : {
                     $type : "json:Array",
                     $description : "Keys defined for submitting a selected item from autocomplete dropdown, key codes and strings can be taken from aria.DomEven",

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -592,8 +592,8 @@ Aria.classDefinition({
         /**
          * Compare newValue with the one stored in _cfg[propertyName] Can be overrided to have a specific comparison
          * @param {String} propertyName
-         * @param {MultiTypes} newValue If transformation is used, this should be the widget value and not the data model
-         * value
+         * @param {MultiTypes} newValue If transformation is used, this should be the widget value and not the data
+         * model value
          * @private
          * @return {Boolean} true if values are considered as equals.
          */
@@ -833,6 +833,9 @@ Aria.classDefinition({
          */
         _dom_onclick : function () {
             this._autoselect();
+            if (!!this._cfg.onclick) {
+                this.evalCallback(this._cfg.onclick);
+            }
         },
 
         /**
@@ -844,6 +847,7 @@ Aria.classDefinition({
          */
         _dom_onfocus : function (event) {
             this._hasFocus = true;
+
             if (!this._keepFocus) {
                 var cfg = this._cfg;
 
@@ -878,6 +882,9 @@ Aria.classDefinition({
                 if (caretPosition) {
                     this.setCaretPosition(caretPosition.start, caretPosition.end);
                 }
+            }
+            if (!!this._cfg.onfocus) {
+                this.evalCallback(this._cfg.onfocus);
             }
         },
 

--- a/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
@@ -47,5 +47,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.helptext.test1.AutoCompleteHelptextTestCase");
         this.addTests("test.aria.widgets.form.autocomplete.helptext.test2.AutoCompleteHelptextTestCase");
         this.addTests("test.aria.widgets.form.autocomplete.autoedit.AutoEditInput");
+        this.addTests("test.aria.widgets.form.autocomplete.onfocus.AutocompleteOnFocusTest");
+        this.addTests("test.aria.widgets.form.autocomplete.onclick.AutocompleteOnClickTest");
     }
 });

--- a/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClick.tpl
+++ b/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClick.tpl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.autocomplete.onclick.AutocompleteOnClick",
+    $hasScript : true
+}}
+{macro main()}
+
+    {@aria:AutoComplete {
+        id: "ac",
+        resourcesHandler: this._airlinesHandler,
+        onclick:{fn:onclick},
+        bind : {
+            value : {
+                inside : data,
+                to : "value"
+            }
+        }
+    }/}
+{/macro}
+{/Template}

--- a/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClickScript.js
+++ b/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClickScript.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.onclick.AutocompleteOnClickScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        this.dateUtils = aria.utils.Date;
+        this._airlinesHandler = new aria.resources.handlers.LCResourcesHandler();
+        this._airlinesHandler.setSuggestions([{
+                    label : 'Air France',
+                    code : 'AF'
+                }, {
+                    label : 'Air Canada',
+                    code : 'AC'
+                }, {
+                    label : 'Finnair',
+                    code : '--'
+                }, {
+                    label : 'Quantas',
+                    code : '--'
+                }, {
+                    label : 'American Airlines',
+                    code : 'AA'
+                }, {
+                    label : 'Emirates',
+                    code : '--'
+                }]);
+    },
+    $destructor : function () {
+        this._airlinesHandler.$dispose();
+        this._airlinesHandler = null;
+    },
+    $prototype : {
+        onclick : function () {
+            this.data.refresh++;
+            this.$refresh();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClickTest.js
+++ b/test/aria/widgets/form/autocomplete/onclick/AutocompleteOnClickTest.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.onclick.AutocompleteOnClickTest",
+    $dependencies : ['aria.resources.handlers.LCResourcesHandler'],
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.autocomplete.onclick.AutocompleteOnClick",
+            data : {
+                refresh : 0,
+                value : null
+            }
+        });
+        this.defaultTestTimeout = 10000;
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.click(this.getInputField("ac"), {
+                fn : this.onAfterType,
+                scope : this
+            });
+        },
+
+        onAfterType : function () {
+            aria.core.Timer.addCallback({
+                fn : this.onAfterDelay,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        onAfterDelay : function () {
+            // Type something than [backspace] and [tab]
+            this.synEvent.type(this.getInputField("ac"), "[enter]", {
+                fn : this.onAfterEnter,
+                scope : this
+            });
+        },
+
+        onAfterEnter : function () {
+            // nothing to do, with just check no error occured
+            this.assertTrue(this.templateCtxt.data.refresh > 0, "onFocus is not happening in Autocomplete");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocus.tpl
+++ b/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocus.tpl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.autocomplete.onfocus.AutocompleteOnFocus",
+    $hasScript : true
+}}
+{macro main()}
+
+    {@aria:AutoComplete {
+        id: "ac",
+        resourcesHandler: this._airlinesHandler,
+        onfocus:{fn:onfocus},
+        bind : {
+            value : {
+                inside : data,
+                to : "value"
+            }
+        }
+    }/}
+{/macro}
+{/Template}

--- a/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocusScript.js
+++ b/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocusScript.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.onfocus.AutocompleteOnFocusScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        this.dateUtils = aria.utils.Date;
+        this._airlinesHandler = new aria.resources.handlers.LCResourcesHandler();
+        this._airlinesHandler.setSuggestions([{
+                    label : 'Air France',
+                    code : 'AF'
+                }, {
+                    label : 'Air Canada',
+                    code : 'AC'
+                }, {
+                    label : 'Finnair',
+                    code : '--'
+                }, {
+                    label : 'Quantas',
+                    code : '--'
+                }, {
+                    label : 'American Airlines',
+                    code : 'AA'
+                }, {
+                    label : 'Emirates',
+                    code : '--'
+                }]);
+    },
+    $destructor : function () {
+        this._airlinesHandler.$dispose();
+        this._airlinesHandler = null;
+    },
+    $prototype : {
+        onfocus : function () {
+            this.data.refresh++;
+            this.$refresh();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocusTest.js
+++ b/test/aria/widgets/form/autocomplete/onfocus/AutocompleteOnFocusTest.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.onfocus.AutocompleteOnFocusTest",
+    $dependencies : ['aria.resources.handlers.LCResourcesHandler'],
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.autocomplete.onfocus.AutocompleteOnFocus",
+            data : {
+                refresh : 0,
+                value : null
+            }
+        });
+        this.defaultTestTimeout = 10000;
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.templateCtxt.$focus("ac");
+
+            // Type something than [backspace] and [tab]
+            this.synEvent.type(this.getInputField("ac"), "AF", {
+                fn : this.onAfterType,
+                scope : this
+            });
+        },
+
+        onAfterType : function () {
+            aria.core.Timer.addCallback({
+                fn : this.onAfterDelay,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        onAfterDelay : function () {
+            // Type something than [backspace] and [tab]
+            this.synEvent.type(this.getInputField("ac"), "[enter]", {
+                fn : this.onAfterEnter,
+                scope : this
+            });
+        },
+
+        onAfterEnter : function () {
+            // nothing to do, with just check no error occured
+            this.assertTrue(this.templateCtxt.data.refresh > 0, "onFocus is not happening in Autocomplete");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});


### PR DESCRIPTION
Eventhandlers for onclick/onfocus are added for autocomplete widget.

The developer can use handlers for onclick/onfocus events in tpl files as shown below

{@aria:AutoComplete {
..........
onclick:{fn:clickHandler},
onfocus:{fn:focusHandler},
..........
}/}
