### PR TITLE
fix #666 History Manager state not updated when replacing page

### DIFF
--- a/src/aria/pageEngine/utils/HistoryManager.js
+++ b/src/aria/pageEngine/utils/HistoryManager.js
@@ -88,12 +88,10 @@ Aria.classDefinition({
             var url = pageRequest.url;
             if (aria.utils.Type.isString(url)) {
                 this._addInCache(url, pageRequest.pageId);
-                if (this.getUrl() != url) {
-                    if (pageRequest.replace) {
-                        this._history.replaceState(pageRequest.data, pageRequest.title, url);
-                    } else {
-                        this._history.pushState(pageRequest.data, pageRequest.title, url);
-                    }
+                if (pageRequest.replace) {
+                    this._history.replaceState(pageRequest.data, pageRequest.title, url);
+                } else {
+                    this._history.pushState(pageRequest.data, pageRequest.title, url);
                 }
             }
         },

--- a/test/aria/pageEngine/utils/BaseNavigationManagerTest.js
+++ b/test/aria/pageEngine/utils/BaseNavigationManagerTest.js
@@ -77,10 +77,14 @@ Aria.classDefinition({
             this._testCacheEntry("", "bbb");
 
             aria.core.Timer.addCallback({
-                fn : this._firstTestAfterSecondUpdate,
+                fn : this._firstTestAfterUpdateWithOnlyData,
                 scope : this,
                 delay : 100
             });
+        },
+
+        _firstTestAfterUpdateWithOnlyData : function () {
+            this._firstTestAfterSecondUpdate();
         },
 
         _firstTestAfterSecondUpdate : function () {

--- a/test/aria/pageEngine/utils/HistoryManagerTest.js
+++ b/test/aria/pageEngine/utils/HistoryManagerTest.js
@@ -24,6 +24,24 @@ Aria.classDefinition({
 
         _getNavManagerInstance : function (cb, options) {
             return new this._testWindow.aria.pageEngine.utils.HistoryManager(cb, options);
+        },
+
+        _firstTestAfterUpdateWithOnlyData : function () {
+            this._update({
+                pageId : "bbb",
+                title : "bbb_title",
+                url : "",
+                data : { test : "test"},
+                replace : true
+            });
+
+            this.assertEquals(this._navManager._history.state.test, "test", "History' state has not been updated");
+
+            aria.core.Timer.addCallback({
+                fn : this._firstTestAfterSecondUpdate,
+                scope : this,
+                delay : 100
+            });
         }
 
     }


### PR DESCRIPTION
Updated HistoryManager to remove the URL check + added a UT.
