### PR TITLE
fix #669 add ko_KR, zh_CN, tw_CN, ar_SA locales

### DIFF
--- a/build/config/locales.json
+++ b/build/config/locales.json
@@ -1,3 +1,3 @@
-["cn_CN", "da_DK", "en_GB", "en_US", "es_ES", "fi_FI", "fr_FR", "is_IS", "it_IT", "ja_JP", "ko_KO", "nl_NL", "no_NO",
-        "pl_PL", "pt_BR", "pt_PT", "ru_RU", "sp_AR", "sv_SE", "th_TH", "tr_TR", "tw_TW", "de_DE", "tk_TK", "ca_ES",
+["cn_CN", "zh_CN", "da_DK", "en_GB", "en_US", "es_ES", "fi_FI", "fr_FR", "is_IS", "it_IT", "ja_JP", "ko_KO", "ko_KR", "nl_NL", "no_NO",
+        "pl_PL", "pt_BR", "pt_PT", "ru_RU", "sp_AR", "ar_SA", "sv_SE", "th_TH", "tr_TR", "tw_TW", "zh_TW", "de_DE", "tk_TK", "ca_ES",
         "el_GR", "fo_FO", "he_IL", "hi_IN", "hu_HU"]

--- a/src/aria/core/ResClassLoader.js
+++ b/src/aria/core/ResClassLoader.js
@@ -31,6 +31,16 @@ Aria.classDefinition({
     $statics : {
         REGEXP : /Aria\.resourcesDefinition\(/,
 
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-669 */
+        DEPRECATED_LOCALES : {
+            "sp_AR" : "ar_SA",
+            "ko_KO" : "ko_KR",
+            "cn_CN" : "zh_CN",
+            "tw_TW" : "zh_TW"
+        },
+        DEPRECATED_LOCALES_WARNING : "The locale %1 is deprecated and will be removed soon, please use %2 locale instead.",
+        /* BACKWARD-COMPATIBILITY-END GH-669 */
+
         // ERROR MESSAGES:
         RESOURCE_NOT_FOUND : "Error: the resource file '%1' for '%2' locale was not found",
         RESOURCE_NOT_RESOLVED : "Error: No resource file for '%1' could be found"
@@ -119,6 +129,13 @@ Aria.classDefinition({
             var devMode = aria.core.environment.Environment.isDevMode();
             // Get the locale
             var resLocale = aria.core.ResMgr.currentLocale;
+
+            /* BACKWARD-COMPATIBILITY-BEGIN GH-669 */
+            if (resLocale in this.DEPRECATED_LOCALES) {
+                var newLocale = this.DEPRECATED_LOCALES[resLocale];
+                this.$logWarn(this.DEPRECATED_LOCALES_WARNING, [resLocale, newLocale]);
+            }
+            /* BACKWARD-COMPATIBILITY-END GH-669 */
 
             // Build the callback for the asynchronous method
             var callback = {

--- a/src/aria/resources/CalendarRes_ar_SA.js
+++ b/src/aria/resources/CalendarRes_ar_SA.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for calendar ar_SA
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.CalendarRes',
+    $resources : {
+        today : "\u0627\u0644\u064a\u0648\u0645",
+        selectedDate : "\u0627\u0644\u062a\u0627\u0631\u064a\u062e \u0627\u0644\u0645\u062d\u062f\u062f"
+    }
+});

--- a/src/aria/resources/CalendarRes_ko_KR.js
+++ b/src/aria/resources/CalendarRes_ko_KR.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for calendar ko_KR
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.CalendarRes',
+    $resources : {
+        today : "\uc624\ub298",
+        selectedDate : "\uc120\ud0dd\ud55c \ub0a0\uc9dc"
+    }
+});

--- a/src/aria/resources/CalendarRes_zh_CN.js
+++ b/src/aria/resources/CalendarRes_zh_CN.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for calendar zh_CN
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.CalendarRes',
+    $resources : {
+        today : "\u4eca\u5929",
+        selectedDate : "\u6240\u9009\u65e5\u671f"
+    }
+});

--- a/src/aria/resources/CalendarRes_zh_TW.js
+++ b/src/aria/resources/CalendarRes_zh_TW.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for calendar zh_TW
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.CalendarRes',
+    $resources : {
+        today : "\u4eca\u5929",
+        selectedDate : "\u9078\u64c7\u7684\u65e5\u671f"
+    }
+});

--- a/src/aria/resources/DateRes_ar_SA.js
+++ b/src/aria/resources/DateRes_ar_SA.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates ar_SA
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "الأحد",
+            "الاثنين",
+            "الثلاثاء",
+            "الأربعاء",
+            "الخميس",
+            "الجمعة",
+            "السبت"
+        ],
+        // a false value for the following items mean: use substring
+        // to generate the short versions of days or months
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "يناير",
+            "فبراير",
+            "مار س",
+            "أبريل",
+            "مايو",
+            "يونيو",
+            "يوليو",
+            "أغسطس",
+            "سبتمبر",
+            "أكتوبر",
+            "نوفمبر",
+            "ديسمبر"
+        ]
+    }
+});

--- a/src/aria/resources/DateRes_ko_KR.js
+++ b/src/aria/resources/DateRes_ko_KR.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates ko_KR
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "일요일",
+            "월요일",
+            "화요일",
+            "수요일",
+            "목요일",
+            "금요일",
+            "토요일"
+        ],
+        // a false value for the following items mean: use substring
+        // to generate the short versions of days or months
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "1월",
+            "2월",
+            "3월",
+            "4월",
+            "5월",
+            "6월",
+            "7월",
+            "8월",
+            "9월",
+            "10월",
+            "11월",
+            "12월"
+        ]
+    }
+});
+

--- a/src/aria/resources/DateRes_zh_CN.js
+++ b/src/aria/resources/DateRes_zh_CN.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates zh_CN
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "星期日",
+            "星期一",
+            "星期二",
+            "星期三",
+            "星期四",
+            "星期五",
+            "星期六"
+        ],
+        // a false value for the following items mean: use substring
+        // to generate the short versions of days or months
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "一月",
+            "二月",
+            "三月",
+            "四月",
+            "五月",
+            "六月",
+            "七月",
+            "八月",
+            "九月",
+            "十月",
+            "十一月",
+            "十二月"
+        ]
+    }
+});

--- a/src/aria/resources/DateRes_zh_TW.js
+++ b/src/aria/resources/DateRes_zh_TW.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates zh-TW
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "星期日",
+            "星期一",
+            "星期二",
+            "星期三",
+            "星期四",
+            "星期五",
+            "星期六"
+        ],
+        // a false value for the following items mean: use substring
+        // to generate the short versions of days or months
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "一月",
+            "二月",
+            "三月",
+            "四月",
+            "五月",
+            "六月",
+            "七月",
+            "八月",
+            "九月",
+            "十月",
+            "十一月",
+            "十二月"
+        ]
+    }
+});

--- a/src/aria/resources/multiselect/FooterRes_ar_SA.js
+++ b/src/aria/resources/multiselect/FooterRes_ar_SA.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for multiselect footer ar_SA (Arabic)
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.multiselect.FooterRes',
+    $resources : {
+        selectAll : "\u062a\u062d\u062f\u064a\u062f\u0020\u0627\u0644\u0643\u0644",
+        deselectAll : "\u0623\u0644\u063a\u064a\u0020\u0623\u062e\u062a\u064a\u0627\u0631\u0020\u0627\u0644\u0643\u0644",
+        close : "\u0623\u063a\u0644\u0627\u0642"
+    }
+});

--- a/src/aria/resources/multiselect/FooterRes_ko_KR.js
+++ b/src/aria/resources/multiselect/FooterRes_ko_KR.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for multiselect footer ko_KR (Korean)
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.multiselect.FooterRes',
+    $resources : {
+        selectAll : "\ubaa8\ub450\u0020\uc120\ud0dd",
+        deselectAll : "\ubaa8\ub450\u0020\uc120\ud0dd\u0020\ucde8\uc18c",
+        close : "\ub2eb\uae30"
+    }
+});

--- a/src/aria/resources/multiselect/FooterRes_zh_CN.js
+++ b/src/aria/resources/multiselect/FooterRes_zh_CN.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for multiselect footer zh_CN (Chinese)
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.multiselect.FooterRes',
+    $resources : {
+        selectAll : "\u5168\u9009",
+        deselectAll : "\u53d6\u6d88\u5168\u9009",
+        close : "\u5173\u95ed"
+    }
+});

--- a/src/aria/resources/multiselect/FooterRes_zh_TW.js
+++ b/src/aria/resources/multiselect/FooterRes_zh_TW.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria resource object for multiselect footer zh_TW
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.multiselect.FooterRes',
+    $resources : {
+        selectAll : "\u5168\u90e8\u9078\u64c7",
+        deselectAll : "\u5168\u90e8\u53d6\u6d88\u9078\u64c7",
+        close : "\u95dc\u9589"
+    }
+});


### PR DESCRIPTION
`ko_KO` doesn't make sense; proper country code is `KR` for South Korea and `KP` for Nort Korea: http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
