### PR TITLE
fix #672 DefaultAppender error display on Chrome

### DIFF
--- a/src/aria/core/log/DefaultAppender.js
+++ b/src/aria/core/log/DefaultAppender.js
@@ -101,8 +101,9 @@
              */
             error : function (className, msg, msgText, e) {
                 var message = this._formatClassName(className) + msg;
-                if (e) {
-                    console.error(message + "\n", e);
+                if (e && e.name && e.message) {
+                    var formattedErrorMessage = e.name + ": " + e.message;
+                    console.error(message + "\n", formattedErrorMessage);
                 } else {
                     console.error(message);
                 }

--- a/test/aria/core/DefaultAppenderTest.js
+++ b/test/aria/core/DefaultAppenderTest.js
@@ -14,7 +14,7 @@
  */
 
 /**
- * Test case for the logger
+ * Test case for the default appender when the the global console provides log, dir, warn, debug, info and error methods.
  */
 Aria.classDefinition({
     $classpath : "test.aria.core.DefaultAppenderTest",
@@ -60,8 +60,8 @@ Aria.classDefinition({
                     that._myTestWarn.call(that, args);
                 },
 
-                error : function (args) {
-                    that._myTestError.call(that, args);
+                error : function (message, originalErrorMessage) {
+                    that._myTestError.call(that, message, originalErrorMessage);
                 }
             };
 
@@ -94,8 +94,9 @@ Aria.classDefinition({
             this._storedWarnMessage = args;
         },
 
-        _myTestError : function (args) {
-            this._storedErrorMessage = args;
+        _myTestError : function (message, originalErrorMessage) {
+            this._storedErrorMessage = message;
+            this._storedOriginalErrorMessage = originalErrorMessage || null;
         },
 
         _onDefaultAppenderLoaded : function () {
@@ -117,9 +118,13 @@ Aria.classDefinition({
 
             aria.core.log.DefaultAppender.prototype.error(className, msg, msgText);
             this.assertTrue(this._storedErrorMessage == '[' + className + '] ' + msg);
+            this.assertTrue(this._storedOriginalErrorMessage == null);
 
-            aria.core.log.DefaultAppender.prototype.error(className, msg, msgText, true);
+            var errorMsg = "errorMsg", error = new Error(errorMsg);
+            aria.core.log.DefaultAppender.prototype.error(className, msg, msgText, error);
             this.assertTrue(this._storedErrorMessage == '[' + className + '] ' + msg + '\n');
+            this.assertTrue(this._storedOriginalErrorMessage == error.name + ": " + error.message);
+
 
             this.notifyTestEnd('testAsyncDefaultAppenderLogMessages');
         }

--- a/test/aria/core/DefaultAppenderTest2.js
+++ b/test/aria/core/DefaultAppenderTest2.js
@@ -14,7 +14,7 @@
  */
 
 /**
- * Test case for the logger
+ * Test case for the default appender when the the global console only provides log and error methods.
  */
 Aria.classDefinition({
     $classpath : "test.aria.core.DefaultAppenderTest2",
@@ -45,8 +45,8 @@ Aria.classDefinition({
                     that._myTestLog.call(that, args);
                 },
 
-                error : function (args) {
-                    that._myTestError.call(that, args);
+                error : function (message, originalErrorMessage) {
+                    that._myTestError.call(that, message, originalErrorMessage);
                 }
             };
 
@@ -63,8 +63,9 @@ Aria.classDefinition({
             this._storedLogMessage = args;
         },
 
-        _myTestError : function (args) {
-            this._storedErrorMessage = args;
+        _myTestError : function (message, originalErrorMessage) {
+            this._storedErrorMessage = message;
+            this._storedOriginalErrorMessage = originalErrorMessage || null;
         },
 
         _onDefaultAppenderLoaded : function () {
@@ -83,9 +84,12 @@ Aria.classDefinition({
 
             aria.core.log.DefaultAppender.prototype.error(className, msg, msgText);
             this.assertTrue(this._storedErrorMessage == '[' + className + '] ' + msg);
+            this.assertTrue(this._storedOriginalErrorMessage == null);
 
-            aria.core.log.DefaultAppender.prototype.error(className, msg, msgText, true);
+            var errorMsg = "errorMsg", error = new Error(errorMsg);
+            aria.core.log.DefaultAppender.prototype.error(className, msg, msgText, error);
             this.assertTrue(this._storedErrorMessage == '[' + className + '] ' + msg + '\n');
+            this.assertTrue(this._storedOriginalErrorMessage == error.name + ": " + error.message);
 
             this.notifyTestEnd('testAsyncDefaultAppenderLogMessages');
         }


### PR DESCRIPTION
Changed error method of aria.core.log.DefaultAppender to explicitly log
the name and message of the original js error, if provided.

Tests have been updated. NB : should probably be merged, the split between
the two TestCases is not clear.

Close #672
