### PR TITLE
fix #676 bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "grunt-verifylowercase": "0.2.0",
     "grunt-leading-indent": "0.1.0",
     "grunt": "git+https://github.com/divdavem/grunt.git#13da751bdfd291c25a47ca7669ae0778eb289b28",
-    "grunt-contrib-jshint": "0.6.0",
+    "grunt-contrib-jshint": "0.6.3",
     "attester": "1.2.0",
-    "express": "3.3.1",
-    "jade": "0.32.0",
+    "express": "3.3.5",
+    "jade": "0.34.1",
     "atpackager": "0.1.0",
     "mocha": "1.11.0"
   }


### PR DESCRIPTION
Build was failing due to jshint / contrib-jshint incompatibility.
