### PR TITLE
refactor some positioning/viewport calculations

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -694,8 +694,8 @@ Aria.classDefinition({
             }
 
             var position = {
-                top : offsetTop,
-                left : offsetLeft,
+                top : Math.round(offsetTop),
+                left : Math.round(offsetLeft),
                 scrollTop : scrollTop,
                 scrollLeft : scrollLeft
             };

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -140,7 +140,7 @@ Aria.classDefinition({
 
             var domElt = this._domElt;
             var maximized = this._cfg.maximized;
-            var viewport = aria.utils.Dom._getViewportSize();
+            var viewport = event.viewportNewSize;
             if (domElt) {
                 // Remove width and height, they will be recalculated later, to have the content size well calculated
                 domElt.style.width = "";
@@ -860,8 +860,10 @@ Aria.classDefinition({
         _setBodyOverflow : function (newValue) {
             Aria.$window.document.documentElement.style.overflow = newValue;
             // need to explicitly raise viewportResized so that maxwidth/maxheight constraints are recalculated
-            this._onViewportResized();
             var viewportSize = aria.utils.Dom._getViewportSize();
+            this._onViewportResized({
+                viewportNewSize : viewportSize
+            });
             return viewportSize;
         },
 


### PR DESCRIPTION
1) don't recalculate the viewport size in `onViewportResized` in Dialog, take it from event data
2) round to full pixels in `utils.Dom.calculatePosition` (`getBoundingClientRect` returns floats)
