### PR TITLE
feat #682 add 'macro' to @aria:Dialog as an alias to 'contentMacro'

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1667,6 +1667,10 @@ Aria.beanDefinitions({
                             $type : "common:BindingRef"
                         },
                         "contentMacro" : {
+                            $type : "common:BindingRef",
+                            $description : "Deprecated in favor of 'macro' property."
+                        },
+                        "macro" : {
                             $type : "common:BindingRef"
                         },
                         "title" : {
@@ -1699,7 +1703,11 @@ Aria.beanDefinitions({
                 },
                 "contentMacro" : {
                     $type : "templates:MacroCfg",
-                    $description : "The macro that will be used as dialog content, Browser will freeze if it does not find this property  as part of widget or bindable property"
+                    $description : "[DEPRECATED in favor of 'macro'] The macro that will be used as dialog content. Browser will freeze if it does not find this property as part of widget or bindable property."
+                },
+                "macro" : {
+                    $type : "templates:MacroCfg",
+                    $description : "Required. The macro that will be used as dialog content. Browser will freeze if it does not find this property as part of widget or bindable property."
                 },
                 "icon" : {
                     $type : "json:String",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -135,7 +135,11 @@ Aria.classDefinition({
     },
     $statics : {
         CONTAINER_USAGE_DEPRECATED : "%1The usage as a container {@aria:Dialog}{/@aria:Dialog} is deprecated; use the {@aria:Dialog /} syntax instead.",
-        MISSING_CONTENT_MACRO : "Missing contentMacro in Dialog configuration."
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+        INCONSISTENT_MACRO_CONTENTMACRO_USAGE : "%1Please consistently use either 'macro' or 'contentMacro' in cfg and cfg.bind in the Dialog configuration and do not mix them.",
+        CONTENTMACRO_DEPRECATED : "%1The 'contentMacro' property in Dialog configuration has been deprecated in favor of 'macro'.",
+        /* BACKWARD-COMPATIBILITY-END GH-687 */
+        MISSING_CONTENT_MACRO : "%1Missing 'macro' in Dialog configuration."
     },
     $prototype : {
 
@@ -163,6 +167,38 @@ Aria.classDefinition({
                 this._setMaximizedHeightAndWidth(viewport);
             }
         },
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+        /**
+         * Register listeners for the bindings associated to this widget
+         * @protected
+         */
+        _registerBindings : function () {
+            // Make 'macro' behave like an alias for 'contentMacro' for consistency with other widgets
+            // Handle this before registering the bindings, not to have improper/duplicate bindings defined.
+            // Store things inside "macro" internally instead of "contentMacro" for future-proofness
+            var cfg = this._cfg;
+            var bindCfg = cfg.bind;
+            var logWarning = false;
+
+            // Note that bound and not-bound property are not mutually exclusive;
+            // i.e. there can be both .macro and .bind.macro defined at the same time.
+            if (cfg.contentMacro && !cfg.macro) {
+                cfg.macro = cfg.contentMacro;
+                logWarning = true;
+                delete cfg.contentMacro;
+            }
+
+            if (bindCfg && bindCfg.contentMacro && !bindCfg.macro) {
+                bindCfg.macro = bindCfg.contentMacro;
+                logWarning = true;
+                delete bindCfg.contentMacro;
+            }
+            if (logWarning) {
+                this.$logWarn(this.CONTENTMACRO_DEPRECATED);
+            }
+            this.$Container._registerBindings.call(this);
+        },
+        /* BACKWARD-COMPATIBILITY-BEGIN END-687 */
 
         /**
          * Check that a contentMacro is specified or bound to the dataModel
@@ -170,9 +206,17 @@ Aria.classDefinition({
          * @protected
          */
         _checkCfgConsistency : function (cfg) {
-            if (!("contentMacro" in cfg) && !("bind" in cfg && "contentMacro" in cfg.bind)) {
+            // Note also some related operations are done beforehand, in _registerBindings
+            if (!("macro" in cfg) && !("bind" in cfg && "macro" in cfg.bind)) {
                 this.$logError(this.MISSING_CONTENT_MACRO);
             }
+            /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+            // They shouldn't be here anymore; if defined, they should've been replaced with "macro" in
+            // _registerBindings. If they're still present, it means the user mixes "macro" and "contentMacro" usage
+            if (("contentMacro" in cfg) || ("bind" in cfg && "contentMacro" in cfg.bind)) {
+                this.$logError(this.INCONSISTENT_MACRO_CONTENTMACRO_USAGE);
+            }
+            /* BACKWARD-COMPATIBILITY-END GH-687 */
             var appEnvDialogSettings = aria.widgets.environment.WidgetSettings.getWidgetSettings().dialog;
             if (!("movable" in cfg)) {
                 cfg.movable = appEnvDialogSettings.movable;
@@ -285,8 +329,8 @@ Aria.classDefinition({
                         }]
             });
 
-            if (this._cfg.contentMacro) {
-                out.callMacro(this._cfg.contentMacro);
+            if (this._cfg.macro) {
+                out.callMacro(this._cfg.macro);
             }
 
             out.endSection();
@@ -386,8 +430,8 @@ Aria.classDefinition({
                 if (this._titleDomElt) {
                     this._titleDomElt.innerHTML = newValue;
                 }
-            } else if (propertyName === "contentMacro") {
-                this._cfg.contentMacro = newValue;
+            } else if (propertyName === "macro") {
+                this._cfg.macro = newValue;
                 if (this._popup) {
                     if (!this._popup.isOpen) {
                         this.open();

--- a/test/aria/widgets/container/dialog/macroContentMacro/MacroContentMacroTestCase.js
+++ b/test/aria/widgets/container/dialog/macroContentMacro/MacroContentMacroTestCase.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.macroContentMacro.MacroContentMacroTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            dialogEnabled : {
+                /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+                ContentMacro : false,
+                BindContentMacro : false,
+                ContentMacroBindContentMacro : false,
+                mixed1 : false,
+                mixed2 : false,
+                mixed3 : false,
+                mixed4 : false,
+                /* BACKWARD-COMPATIBILITY-END GH-687 */
+                Macro : false,
+                BindMacro : false,
+                MacroBindMacro : false
+            }
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.macroContentMacro.MacroContentMacroTpl",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            // Little subtlety in the two test methods below:
+            // MacroBindMacro is enabled before BindMacro in order to set the data model value
+            // If enabled in the reverse order, then BindMacro would have had a binding to null.
+
+            this._testMacro();
+            /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+            this._testContentMacro();
+            this._testMixedUsageLogsError();
+            /* BACKWARD-COMPATIBILITY-END GH-687 */
+            this.notifyTemplateTestEnd();
+        },
+
+        _testMacro : function () {
+            this.__enableDialogAndCheckHtml("Macro", "Macro1Content");
+            this.__enableDialogAndCheckHtml("MacroBindMacro", "Macro1Content");
+            this.__enableDialogAndCheckHtml("BindMacro", "Macro1Content");
+
+            // let's now change the data model value; dialogs with bindings should notice the change
+            aria.utils.Json.setValue(this.data, "dialogMacroName", "macro2");
+
+            // only check the two dialogs with bindings
+            this.__assertDialogInnerHtmlMatches("BindMacro", "Macro2Content");
+            this.__assertDialogInnerHtmlMatches("MacroBindMacro", "Macro2Content");
+
+            this.assertLogsEmpty();
+
+            // set back to old value
+            aria.utils.Json.setValue(this.data, "dialogMacroName", "macro1");
+        },
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+        _testContentMacro : function () {
+            var deprecatedMsg = aria.widgets.container.Dialog.CONTENTMACRO_DEPRECATED;
+
+            this.__enableDialogAndCheckHtml("ContentMacro", "Macro1Content");
+            this.assertErrorInLogs(deprecatedMsg);
+
+            this.__enableDialogAndCheckHtml("ContentMacroBindContentMacro", "Macro1Content");
+            this.assertErrorInLogs(deprecatedMsg);
+
+            this.__enableDialogAndCheckHtml("BindContentMacro", "Macro1Content");
+            this.assertErrorInLogs(deprecatedMsg);
+
+            // let's now change the data model value; dialogs with bindings should notice the change
+            aria.utils.Json.setValue(this.data, "dialogMacroName", "macro2");
+
+            // only check the two dialogs with bindings
+            this.__assertDialogInnerHtmlMatches("BindMacro", "Macro2Content");
+            this.__assertDialogInnerHtmlMatches("MacroBindMacro", "Macro2Content");
+
+            this.assertLogsEmpty();
+        },
+        _testMixedUsageLogsError : function () {
+            // enable the mixed dialogs one-by-one, and check the errors are logged for each
+            var errorMsg = aria.widgets.container.Dialog.INCONSISTENT_MACRO_CONTENTMACRO_USAGE;
+
+            this.__enableDialog("mixed1");
+            this.assertErrorInLogs(errorMsg);
+
+            this.__enableDialog("mixed2");
+            this.assertErrorInLogs(errorMsg);
+
+            this.__enableDialog("mixed3");
+            this.assertErrorInLogs(errorMsg);
+
+            this.__enableDialog("mixed4");
+            this.assertErrorInLogs(errorMsg);
+        },
+        /* BACKWARD-COMPATIBILITY-END GH-687 */
+
+        __enableDialog : function (dialogId) {
+            aria.utils.Json.setValue(this.data.dialogEnabled, dialogId, true);
+        },
+
+        __enableDialogAndCheckHtml : function (dialogId, expectedHtml) {
+            this.__enableDialog(dialogId);
+            this.__assertDialogInnerHtmlMatches(dialogId, expectedHtml);
+        },
+
+        __assertDialogInnerHtmlMatches : function (dialogId, expected) {
+            var dialogInstance = this.getWidgetInstance(dialogId);
+            var match = dialogInstance._domElt.innerHTML.match(expected);
+            this.assertTrue(match != null, "Expected to find " + expected + " in dialog " + dialogId);
+        }
+
+    }
+});

--- a/test/aria/widgets/container/dialog/macroContentMacro/MacroContentMacroTpl.tpl
+++ b/test/aria/widgets/container/dialog/macroContentMacro/MacroContentMacroTpl.tpl
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath:"test.aria.widgets.container.dialog.macroContentMacro.MacroContentMacroTpl"
+}}
+    {macro main()}
+
+        {call writeGoodDialogs() /}
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+        {call writeDeprecatedDialogs() /}
+        {call writeMixedDialogSection(1) /}
+        {call writeMixedDialogSection(2) /}
+        {call writeMixedDialogSection(3) /}
+        {call writeMixedDialogSection(4) /}
+        /* BACKWARD-COMPATIBILITY-END GH-687 */
+    {/macro}
+
+    {macro writeSectionWithDialog(macroId)}
+        {section {
+            macro: macroId,
+            bindRefreshTo : [{
+                to: macroId,
+                inside: data.dialogEnabled
+            }]
+        } /}
+    {/macro}
+
+    {macro writeGoodDialogs()}
+        {call writeSectionWithDialog("Macro") /}
+        {call writeSectionWithDialog("BindMacro") /}
+        {call writeSectionWithDialog("MacroBindMacro") /}
+    {/macro}
+
+    {macro Macro()}
+        {if data.dialogEnabled.Macro}
+            {@aria:Dialog {
+                id: "Macro",
+                visible : true,
+                macro: "macro1"
+            }/}
+        {/if}
+    {/macro}
+    {macro BindMacro()}
+        {if data.dialogEnabled.BindMacro}
+            {@aria:Dialog {
+                id: "BindMacro",
+                visible : true,
+                bind: {
+                    macro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+    {macro MacroBindMacro()}
+        {if data.dialogEnabled.MacroBindMacro}
+            {@aria:Dialog {
+                id: "MacroBindMacro",
+                visible : true,
+                macro: "macro1",
+                bind: {
+                    macro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    /* BACKWARD-COMPATIBILITY-BEGIN GH-687 */
+    {macro writeDeprecatedDialogs()}
+        {call writeSectionWithDialog("ContentMacro") /}
+        {call writeSectionWithDialog("BindContentMacro") /}
+        {call writeSectionWithDialog("ContentMacroBindContentMacro") /}
+    {/macro}
+
+    {macro ContentMacro()}
+        {if data.dialogEnabled.ContentMacro}
+            {@aria:Dialog {
+                id: "ContentMacro",
+                visible : true,
+                contentMacro: "macro1"
+            }/}
+        {/if}
+    {/macro}
+
+    {macro BindContentMacro()}
+        {if data.dialogEnabled.BindContentMacro}
+            {@aria:Dialog {
+                id: "BindContentMacro",
+                visible : true,
+                bind: {
+                    contentMacro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro ContentMacroBindContentMacro()}
+        {if data.dialogEnabled.ContentMacroBindContentMacro}
+            {@aria:Dialog {
+                id: "ContentMacroBindContentMacro",
+                visible : true,
+                contentMacro: "macro1",
+                bind: {
+                    contentMacro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro mixedDialog1()}
+        {if data.dialogEnabled.mixed1}
+            {@aria:Dialog {
+                visible : true,
+                contentMacro: "macro1",
+                bind: {
+                    macro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro mixedDialog2()}
+        {if data.dialogEnabled.mixed2}
+            {@aria:Dialog {
+                visible : true,
+                macro: "macro1",
+                bind: {
+                    contentMacro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro mixedDialog3()}
+        {if data.dialogEnabled.mixed3}
+            {@aria:Dialog {
+                visible : true,
+                macro: "whatever",
+                contentMacro: "whatever",
+                bind: {
+                    contentMacro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro mixedDialog4()}
+        {if data.dialogEnabled.mixed4}
+            {@aria:Dialog {
+                visible : true,
+                contentMacro: "macro1",
+                bind: {
+                    contentMacro : {
+                        to: "thisWillBeDiscarded", // macro now takes precedence
+                        inside: data
+                    },
+                    macro : {
+                        to: "dialogMacroName",
+                        inside: data
+                    }
+                }
+            }/}
+        {/if}
+    {/macro}
+
+    {macro writeMixedDialogSection(n)}
+        {section {
+            macro: "mixedDialog"+n,
+            bindRefreshTo : [{
+                to: "mixed"+n,
+                inside: data.dialogEnabled
+            }]
+        } /}
+    {/macro}
+    /* BACKWARD-COMPATIBILITY-END GH-687 */
+
+    {macro macro1()}
+        Macro1Content
+    {/macro}
+
+    {macro macro2()}
+        Macro2Content
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
To make API more consistent, let `macro` in `@aria:Dialog` be a synonym for `contentMacro`. `contentMacro` still takes precedence.
