### PR TITLE
fix #690 Adds shortnames for days in Russian

### DIFF
--- a/src/aria/resources/DateRes_ru_RU.js
+++ b/src/aria/resources/DateRes_ru_RU.js
@@ -31,7 +31,15 @@ Aria.resourcesDefinition({
         ],
         // a false value for the following items mean: use substring
         // to generate the short versions of days or months
-        dayShort : false,
+        dayShort : [
+            "Вс",
+            "Пн",
+            "Вт",
+            "Ср",
+            "Чт",
+            "Пт",
+            "Cб"
+        ],
         monthShort : false,
         month : [
             "Январь",


### PR DESCRIPTION
Values added: ["Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Cб"]
