### PR TITLE
Multiple modal dialogs not closing on ESCAPE

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -49,7 +49,8 @@ Aria.classDefinition({
             properties : {
                 position : "Position chosen if any. If empty, no position in viewset was found."
             }
-        }
+        },
+        onEscape : "Raised when the ESCAPE key is pressed when the popup is modal and it is the last one opened."
     },
     $statics : {
         ANCHOR_BOTTOM : "bottom",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -501,26 +501,15 @@ Aria.classDefinition({
                 "onAfterOpen" : this._onAfterPopupOpen,
                 scope : this
             });
+            popup.$on({
+                "onEscape" : this.actionClose,
+                scope : this
+            });
             if (cfg.closeOnMouseClick) {
                 popup.$on({
                     "onMouseClickClose" : this._onMouseClickClose,
                     scope : this
                 });
-            }
-
-            // global navigation is disable is the case of a modal dialog
-            if (this._cfg.modal) {
-                var navManager = aria.templates.NavigationManager;
-                navManager.addGlobalKeyMap({
-                    key : "ESCAPE",
-                    modal : true,
-                    callback : {
-                        fn : this.actionClose,
-                        scope : this
-                    }
-                });
-
-                navManager.setModalBehaviour(true);
             }
 
             popup.open({
@@ -658,19 +647,6 @@ Aria.classDefinition({
                 this._popup.$dispose();
                 this._popup = null;
 
-                // restore globalKeyMap
-                if (cfg.modal) {
-                    var navManager = aria.templates.NavigationManager;
-                    navManager.removeGlobalKeyMap({
-                        key : "ESCAPE",
-                        modal : true,
-                        callback : {
-                            fn : this.actionClose,
-                            scope : this
-                        }
-                    });
-                    navManager.setModalBehaviour(false);
-                }
                 aria.templates.Layout.$removeListeners({
                     "viewportResized" : this._onViewportResized,
                     scope : this

--- a/test/aria/widgets/container/dialog/DialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/DialogTestSuite.js
@@ -32,6 +32,8 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.container.dialog.checkStyle.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.escKey.DialogTemplateTestCase");
+        this.addTests("test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalTest");
+        this.addTests("test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalAndNonModalTest");
         this.addTests("test.aria.widgets.container.dialog.indicators.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.keymap.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.missingMacro.DialogTestCase");

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalAndNonModalTest.js
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalAndNonModalTest.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalAndNonModalTest",
+    $extends : "test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalTest",
+    $constructor : function () {
+        this.$EscapeOnModalTest.constructor.call(this);
+        this._data.modal = [true, false, true];
+    },
+    $prototype : {
+
+        _afterFirstEscape : function () {
+            this._assertDialogVisibility("one");
+            this._assertDialogVisibility("two");
+            this._assertDialogVisibility("three", false);
+            this._assertFocus("two");
+
+            aria.utils.FireDomEvent.fireEvent("keydown", this.getInputField("two"), {
+                keyCode : aria.DomEvent['KC_ESCAPE']
+            });
+
+            aria.core.Timer.addCallback({
+                fn : this._afterSecondEscape,
+                scope : this,
+                delay : 50
+            });
+        }
+
+    }
+});

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTemplate.tpl
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTemplate.tpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalTemplate"
+}}
+    {macro main()}
+
+		{var ids = ["one", "two", "three"] /}
+
+		{foreach id inArray ids}
+	        {@aria:Dialog {
+	            title : (data.modal[id_index] ? "modal" : "nonmodal"),
+	            contentMacro : {
+	            	id : id,
+	            	name : "dialogContent",
+	            	args : [id]
+	            },
+	            modal : data.modal[id_index],
+	            bind : {
+	                visible : {
+	                    to : id,
+	                    inside : data
+	                }
+	            },
+	            center : false,
+	            xpos : 50*id_index,
+	            ypos : 50*id_index
+	        }/}
+		{/foreach}
+    {/macro}
+
+    {macro dialogContent(id)}
+        <div>
+            {@aria:TextField {
+                id : id
+            }/}
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.FireDomEvent", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this._data = {
+            one : false,
+            two : false,
+            three : false,
+            modal : [true, true, true]
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.escKey.multipleDialogs.EscapeOnModalTemplate",
+            data : this._data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var json = aria.utils.Json;
+
+            json.setValue(this._data, "one", true);
+            json.setValue(this._data, "two", true);
+            json.setValue(this._data, "three", true);
+            aria.core.Timer.addCallback({
+                fn : this._afterOpen,
+                scope : this,
+                delay : 50
+            });
+        },
+
+        _afterOpen : function () {
+            this._assertDialogVisibility("one");
+            this._assertDialogVisibility("two");
+            this._assertDialogVisibility("three");
+
+            aria.utils.FireDomEvent.fireEvent('click', Aria.$window.document.body, {
+                keyCode : aria.DomEvent['KC_ESCAPE']
+            });
+            aria.utils.FireDomEvent.fireEvent('keydown', Aria.$window.document.body, {
+                keyCode : aria.DomEvent['KC_ESCAPE']
+            });
+
+            aria.core.Timer.addCallback({
+                fn : this._afterFirstEscape,
+                scope : this,
+                delay : 50
+            });
+        },
+
+        _afterFirstEscape : function () {
+            this._assertDialogVisibility("one");
+            this._assertDialogVisibility("two");
+            this._assertDialogVisibility("three", false);
+            this._assertFocus("two");
+
+            aria.utils.FireDomEvent.fireEvent('keydown', Aria.$window.document.body, {
+                keyCode : aria.DomEvent['KC_ESCAPE']
+            });
+
+            aria.core.Timer.addCallback({
+                fn : this._afterSecondEscape,
+                scope : this,
+                delay : 50
+            });
+        },
+
+        _afterSecondEscape : function () {
+            this._assertDialogVisibility("one");
+            this._assertDialogVisibility("two", false);
+            this._assertDialogVisibility("three", false);
+            this._assertFocus("one");
+
+            aria.utils.FireDomEvent.fireEvent('keydown', Aria.$window.document.body, {
+                keyCode : aria.DomEvent['KC_ESCAPE']
+            });
+
+            aria.core.Timer.addCallback({
+                fn : this._afterThirdEscape,
+                scope : this,
+                delay : 50
+            });
+        },
+
+        _afterThirdEscape : function () {
+            this._assertDialogVisibility("one", false);
+            this._assertDialogVisibility("two", false);
+            this._assertDialogVisibility("three", false);
+
+            this.notifyTemplateTestEnd();
+        },
+
+        _assertDialogVisibility : function (id, open) {
+            open = open === false ? false : true;
+            this.assertEquals(this._data[id], open, "Dialog " + id + " should " + (open ? "" : "not ") + "be open");
+            var realId = this.templateCtxt.$getId(id);
+            var field = aria.utils.Dom.getElementById(realId);
+            this.assertEquals(!!field, open, "Dialog " + id + " should " + (open ? "" : "not ") + "be open");
+        },
+
+        _assertFocus : function (id) {
+            var field = this.getInputField(id);
+            this.assertEquals(field, aria.utils.Delegate.getFocus(), "Element with id " + id
+                    + " should be focused.");
+        }
+    }
+});


### PR DESCRIPTION
When two modal dialogs were open (the one on top of the other), the top one would close on ESCAPE. A second press of the ESCAPE key would not close the second.

Also, when closing a modal dialog, the focus should be given to the dialog below it, if there is one.
