### PR TITLE
fix #702 PageEngine: can't use custom animation for page transition

### DIFF
--- a/src/aria/pageEngine/CfgBeans.js
+++ b/src/aria/pageEngine/CfgBeans.js
@@ -21,7 +21,8 @@ Aria.beanDefinitions({
     $description : "Definition of the beans used in aria.pageEngine",
     $namespaces : {
         "json" : "aria.core.JsonTypes",
-        "core" : "aria.core.CfgBeans"
+        "core" : "aria.core.CfgBeans",
+        "animation" : "aria.utils.css.AnimationsBean"
     },
     $beans : {
         "ExtendedCallback" : {
@@ -299,18 +300,14 @@ Aria.beanDefinitions({
             $description : "Animation applied to the coming page and/or to the leaving page",
             $properties : {
                 "animateOut" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the leaving page",
-                    $sample : "slide left",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade", "fade reverse",
-                            "pop", "pop reverse", "flip", "flip reverse"]
+                    $sample : "slide left"
                 },
                 "animateIn" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the coming page",
                     $sample : "slide left",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade", "fade reverse",
-                            "pop", "pop reverse", "flip", "flip reverse"],
                     $mandatory : true
                 },
                 "type" : {

--- a/src/aria/pageEngine/utils/AnimationsManager.js
+++ b/src/aria/pageEngine/utils/AnimationsManager.js
@@ -181,6 +181,10 @@ Aria.classDefinition({
                     reverse = true;
                 }
                     break;
+                default : {
+                    name = pageTransitionName;
+                    reverse = false;
+                }
             }
             return {
                 name : name,

--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -21,7 +21,8 @@ Aria.beanDefinitions({
     $description : "Definition of the JSON beans used to set application variables",
     $namespaces : {
         "json" : "aria.core.JsonTypes",
-        "dom" : "aria.utils.DomBeans"
+        "dom" : "aria.utils.DomBeans",
+        "animation" : "aria.utils.css.AnimationsBean"
     },
     $beans : {
         "PopupConf" : {
@@ -122,18 +123,14 @@ Aria.beanDefinitions({
                     $default : -1
                 },
                 "animateOut" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the opening popup",
-                    $sample : "slide left",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade in", "fade out", "pop",
-                            "pop reverse", "flip", "flip reverse"]
+                    $sample : "slide left"
                 },
                 "animateIn" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the closing popup",
-                    $sample : "slide right",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade in", "fade out", "pop",
-                            "pop reverse", "flip", "flip reverse"]
+                    $sample : "slide left"
                 }
             }
         },

--- a/src/aria/touch/widgets/DialogCfgBeans.js
+++ b/src/aria/touch/widgets/DialogCfgBeans.js
@@ -21,7 +21,8 @@ Aria.beanDefinitions({
         "common" : "aria.widgetLibs.CommonBeans",
         "base" : "aria.html.beans.ElementCfg",
         "dom" : "aria.utils.DomBeans",
-        "templates" : "aria.templates.CfgBeans"
+        "templates" : "aria.templates.CfgBeans",
+        "animation" : "aria.utils.css.AnimationsBean"
     },
     $beans : {
         "DialogCfg" : {
@@ -125,18 +126,14 @@ Aria.beanDefinitions({
                     $default : -1
                 },
                 "animateOut" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the opening popup",
-                    $sample : "slide left",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade in", "fade out", "pop",
-                            "pop reverse", "flip", "flip reverse"]
+                    $sample : "slide left"
                 },
                 "animateIn" : {
-                    $type : "json:Enum",
+                    $type : "animation:AnimationName",
                     $description : "Animation to apply to the closing popup",
-                    $sample : "slide left",
-                    $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade in", "fade out", "pop",
-                            "pop reverse", "flip", "flip reverse"]
+                    $sample : "slide left"
                 },
                 "htmlContent" : {
                     $type : "json:String",

--- a/src/aria/utils/css/AnimationsBean.js
+++ b/src/aria/utils/css/AnimationsBean.js
@@ -45,6 +45,20 @@ Aria.beanDefinitions({
                     $description : "className to apply to the element animate out and to remove from the element animate in"
                 }
             }
+        },
+        "AnimationName" : {
+            $type : "json:MultiTypes",
+            $description : "The name of the animation",
+            $sample : "slide left",
+            $contentTypes : [{
+                $type : "json:Enum",
+                $description : "Predefined framework animation",
+                $enumValues : ["slide left", "slide right", "slide up", "slide down", "fade", "fade reverse",
+                    "pop", "pop reverse", "flip", "flip reverse"]
+            }, {
+                $type : "json:String",
+                $description : "Custom animation"
+            }]
         }
     }
 });


### PR DESCRIPTION
Solved the undefined issue for custom animations
