### PR TITLE
Dialog widget movable property

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1663,6 +1663,9 @@ Aria.beanDefinitions({
                         "visible" : {
                             $type : "common:BindingRef"
                         },
+                        "movable" : {
+                            $type : "common:BindingRef"
+                        },
                         "contentMacro" : {
                             $type : "common:BindingRef"
                         },

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -368,6 +368,15 @@ Aria.classDefinition({
                 } else {
                     this.close();
                 }
+            } else if (propertyName === "movable") {
+                this._cfg.movable = newValue;
+                if (this._popup && this._popup.isOpen) {
+                    if (newValue) {
+                        this._loadAndCreateDraggable();
+                    } else {
+                        this._destroyDraggable();
+                    }
+                }
             } else if (propertyName === "title") {
                 this._cfg.title = newValue;
                 if (this._titleDomElt) {
@@ -1022,7 +1031,7 @@ Aria.classDefinition({
          * @protected
          */
         _destroyDraggable : function () {
-            if (!this._cfg.movable || !this._draggable) {
+            if (!this._draggable) {
                 return;
             }
 

--- a/test/aria/widgets/container/dialog/MovableDialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/MovableDialogTestSuite.js
@@ -26,6 +26,7 @@ Aria.classDefinition({
                 "test.aria.widgets.container.dialog.bindPosition.DialogInViewportTestCase",
                 "test.aria.widgets.container.dialog.movable.test1.MovableDialogTestCase",
                 "test.aria.widgets.container.dialog.movable.test2.MovableDialogTestCaseTwo",
-                "test.aria.widgets.container.dialog.movable.test3.MovableDialogTestCaseThree"];
+                "test.aria.widgets.container.dialog.movable.test3.MovableDialogTestCaseThree",
+                "test.aria.widgets.container.dialog.movable.test4.MovableDialogTestCaseFour"];
     }
 });

--- a/test/aria/widgets/container/dialog/movable/test4/MovableDialogTemplateFour.tpl
+++ b/test/aria/widgets/container/dialog/movable/test4/MovableDialogTemplateFour.tpl
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.container.dialog.movable.test4.MovableDialogTemplateFour"
+}}
+
+    {var modal = false /}
+
+    {macro main()}
+        {var dataModel = data["firstDialog"] /}
+        {@aria:Dialog {
+            id : "firstDialog",
+            contentMacro : {
+                name : "displayDialogContent",
+                args : ["one"]
+            },
+            icon : "std:info",
+            width : 500,
+            maxHeight : 500,
+            visible : true,
+            modal : false,
+            movable : false,
+            bind : {
+                "movable" : {inside:data, to:"movableDialog"},
+                "visible" : {inside:data, to:"visibleDialog"}
+            }
+        }/}
+    {/macro}
+
+    {macro displayDialogContent()}
+        {var dataModel = data["firstDialog"] /}
+
+          {@aria:Text {
+            text : "movable : "
+          }/}
+
+          {@aria:Text {
+            id : "dialogText",
+            bind : {
+              text : {inside:data, to:"movableDialog"}
+            }
+          }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/movable/test4/MovableDialogTestCaseFour.js
+++ b/test/aria/widgets/container/dialog/movable/test4/MovableDialogTestCaseFour.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.movable.test4.MovableDialogTestCaseFour",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Json", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+
+         this.data = {
+            firstDialog : {
+                visible : true,
+                movable : false,
+                xpos : 0,
+                ypos : 0
+            }
+        };
+
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.movable.test4.MovableDialogTemplateFour",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.assertTrue(this.data.movableDialog === false, "Dialog movable property isn't equal to false");
+
+            aria.core.Timer.addCallback({
+                fn : this._activateMovable,
+                scope : this,
+                delay : 500
+            });
+        },
+
+        _activateMovable : function () {
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.dialogPos = {
+                x : handleGeometry.x,
+                y : handleGeometry.y
+            };
+
+            var from = {
+                x : handleGeometry.x + handleGeometry.width / 2,
+                y : handleGeometry.y + handleGeometry.height / 2
+            };
+            var options = {
+                duration : 2000,
+                to : {
+                    x : from.x + 150,
+                    y : from.y + 150
+                }
+            };
+
+            this.assertTrue(this.data.movableDialog === false, "Dialog movable property isn't equal to false");
+            this.synEvent.execute([["drag", options, from]], {
+                fn : this._afterDrag,
+                scope : this
+            });
+        },
+
+        _afterDrag : function () {
+            var self = this;
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.assertTrue(this.dialogPos.x === handleGeometry.x, "The Dialog has been moved");
+            this.assertTrue(this.dialogPos.y === handleGeometry.y, "The Dialog has been moved");
+
+            aria.utils.Json.setValue(this.data, "movableDialog", !this.data.movableDialog);
+
+            this.assertTrue(this.data.movableDialog === true, "Dialog movable property isn't equal to true");
+
+            aria.core.Timer.addCallback({
+                fn : this._secondDrag,
+                scope : this,
+                delay : 1000
+            });
+        },
+
+        _secondDrag : function () {
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+            this.dialogPos = {
+                x : handleGeometry.x,
+                y : handleGeometry.y
+            };
+
+            var from = {
+                x : handleGeometry.x + handleGeometry.width / 2,
+                y : handleGeometry.y + handleGeometry.height / 2
+            };
+            var options = {
+                duration : 2000,
+                to : {
+                    x : from.x + 150,
+                    y : from.y + 150
+                }
+            };
+
+            this.synEvent.execute([["drag", options, from]], {
+                fn : this._afterSecondDrag,
+                scope : this
+            });
+        },
+
+        _afterSecondDrag : function () {
+            var self = this;
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.assertTrue(this.dialogPos.x !== handleGeometry.x, "The Dialog is not movable");
+            this.assertTrue(this.dialogPos.y !== handleGeometry.y, "The Dialog is not movable");
+
+            aria.utils.Json.setValue(this.data, "movableDialog", !this.data.movableDialog);
+
+            this.assertTrue(this.data.movableDialog === false, "Dialog movable property isn't equal to false");
+
+             aria.core.Timer.addCallback({
+                fn : this._thirdDrag,
+                scope : this,
+                delay : 1000
+            });
+        },
+
+        _thirdDrag : function () {
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.dialogPos = {
+                x : handleGeometry.x,
+                y : handleGeometry.y
+            };
+
+            var from = {
+                x : handleGeometry.x + handleGeometry.width / 2,
+                y : handleGeometry.y + handleGeometry.height / 2
+            };
+            var options = {
+                duration : 2000,
+                to : {
+                    x : from.x + 150,
+                    y : from.y + 150
+                }
+            };
+
+            this.synEvent.execute([["drag", options, from]], {
+                fn : this._afterThirdDrag,
+                scope : this
+            });
+        },
+
+        _afterThirdDrag : function () {
+            var self = this;
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.assertTrue(this.dialogPos.x === handleGeometry.x, "The Dialog has been moved");
+            this.assertTrue(this.dialogPos.y === handleGeometry.y, "The Dialog has been moved");
+
+            aria.utils.Json.setValue(this.data, "visibleDialog", false);
+
+            this.assertTrue(this.data.movableDialog === false, "Dialog movable property isn't equal to false");
+            aria.utils.Json.setValue(this.data, "movableDialog", !this.data.movableDialog);
+            this.assertTrue(this.data.movableDialog === true, "Dialog movable property isn't equal to true");
+
+            this.assertTrue(this.data.visibleDialog === false, "Dialog movable property isn't equal to false");
+            aria.utils.Json.setValue(this.data, "visibleDialog", true);
+            this.assertTrue(this.data.visibleDialog === true, "Dialog movable property isn't equal to true");
+
+            this.end();
+        },
+
+        _getHandle : function (dialogId) {
+            return this.getWidgetInstance(dialogId)._titleBarDomElt;
+        },
+
+        _getCloseIcon : function (dialogId) {
+            var elements = this.getWidgetInstance(dialogId)._titleBarDomElt.children;
+            return (elements.length > 1) ? elements[1] : null;
+        }
+    }
+});


### PR DESCRIPTION
This commit add the possibility to bind the movable property of a dialog widget to the data model
