### PR TITLE
feat #714 custom padding for the `pad` modifier

### DIFF
--- a/src/aria/templates/Modifiers.js
+++ b/src/aria/templates/Modifiers.js
@@ -115,25 +115,29 @@
         },
         "pad" : {
             /**
-             * Pad the string with non-breaking spaces
+             * Pad the string with the provided padding character(s) or non-breaking spaces
              * @name aria.templates.Modifiers.pad
              * @param {String} str the entry
              * @param {Integer} sz the targetted size for the result string
              * @param {Boolean} begin tells if the padding must be added at the beginning (true) or at the end (false)
              * of the string - Default is false
+             * @param {String} padStr the HTML string to be used for padding. Default is '&nbsp;'. Note that if this
+             * string has javascript length > 1, it will still be used in its entirety for padding, the same number of
+             * times as if it was one-character only. This might be useful mainly for passing HTML entities.
              * @return {String}
              */
-            fn : function (str, sz, begin) {
+            fn : function (str, sz, begin, padStr) {
                 str = '' + str; // force cast to string
+                padStr = padStr || '&nbsp;'; // empty padding string doesn't make sense
                 var lgth = str.length;
                 if (lgth < sz) {
                     var beg = (begin === true);
-                    var a = [], diff = sz - lgth, sp = '&nbsp;';
+                    var a = [], diff = sz - lgth;
                     if (!beg) {
                         a.push(str);
                     }
                     for (var i = 0; diff > i; i++) {
-                        a.push(sp);
+                        a.push(padStr);
                     }
                     if (beg) {
                         a.push(str);

--- a/test/aria/templates/ModifiersTest.js
+++ b/test/aria/templates/ModifiersTest.js
@@ -84,6 +84,35 @@ Aria.classDefinition({
                     "escapeForHTML"]) === "&lt;div id=&#x27;id&#x27; class=&quot;class&quot;&gt;&#x2F;&lt;&#x2F;div&gt;", "Default with escape failed.");
         },
 
+        testPad : function () {
+            var callModifier = aria.templates.Modifiers.callModifier;
+
+            // basic functionality
+            this.assertEquals(callModifier("pad", ["a", 3]), "a&nbsp;&nbsp;");
+            this.assertEquals(callModifier("pad", ["a", 3, false]), "a&nbsp;&nbsp;");
+            this.assertEquals(callModifier("pad", ["a", 3, true]), "&nbsp;&nbsp;a");
+            this.assertEquals(callModifier("pad", ["abc", 3, true]), "abc");
+
+            // does nothing when the input is too long
+            this.assertEquals(callModifier("pad", ["abcdef", 3, true]), "abcdef");
+
+            // does nothing when the length is negative
+            this.assertEquals(callModifier("pad", ["abcdef", -2]), "abcdef");
+
+            // test alternative padding string
+            this.assertEquals(callModifier("pad", ["a", 2, false, ' ']), "a ");
+            this.assertEquals(callModifier("pad", ["7", 3, true, '0']), "007");
+
+            // when the padding string is empty, default to '&nbsp;' also
+            this.assertEquals(callModifier("pad", ["foo", 6, true, '']), "&nbsp;&nbsp;&nbsp;foo");
+
+            // when the padding string param is longer than one character, it should be used in its entirety
+            // the main use case is to be able to pass HTML entites
+            this.assertEquals(callModifier("pad", ["foo", 5, false, '&mdash;']), "foo&mdash;&mdash;");
+            // the following is not of a much use probably, but let's not overengineer this function too much
+            this.assertEquals(callModifier("pad", ["foo", 5, false, 'abc']), "fooabcabc");
+        },
+
         /**
          * Unit test the highlight modifiers. Highlight puts &lt;strong&gt; tags around the initial part of the words
          */


### PR DESCRIPTION
Now the `pad` modifier accepts third parameter which is the padding string. By default it's `&nbsp;` if not provided.

See #714
