### PR TITLE
fix #718 Touch:Dialog widget and domReference attribute

### DIFF
--- a/src/aria/touch/widgets/Dialog.js
+++ b/src/aria/touch/widgets/Dialog.js
@@ -171,11 +171,19 @@ Aria.classDefinition({
             });
 
             // default the position to 0,0 if nothing is defined
-            if (cfg.domReference === null && cfg.absolutePosition === null && cfg.center === false) {
+            if (cfg.domReference === null && cfg.referenceId === null && cfg.absolutePosition === null && cfg.center === false) {
                 cfg.absolutePosition = {
                     top : 0,
                     left : 0
                 };
+            }
+            
+            var domReference = null;
+            if (cfg.domReference) {
+                domReference = cfg.domReference;
+            }
+            else if (cfg.referenceId) {
+                domReference = aria.utils.Dom.getElementById(this._context.$getId(cfg.referenceId));
             }
 
             popup.open({
@@ -183,7 +191,7 @@ Aria.classDefinition({
                 keepSection : true,
                 modal : cfg.modal,
                 maskCssClass : cfg.maskCssClass,
-                domReference : cfg.domReference,
+                domReference : domReference,
                 absolutePosition : cfg.absolutePosition,
                 center : cfg.center,
                 maximized : cfg.maximized,

--- a/src/aria/touch/widgets/DialogCfgBeans.js
+++ b/src/aria/touch/widgets/DialogCfgBeans.js
@@ -53,7 +53,12 @@ Aria.beanDefinitions({
                 },
                 "domReference" : {
                     $type : "json:ObjectRef",
-                    $description : "{HTMLElement} The DOM reference which will be used as the reference position for the tooltip",
+                    $description : "{HTMLElement} The DOM reference which will be used as the reference position for the tooltip. Takes priority over referenceId if defined.",
+                    $default : null
+                },
+                "referenceId" : {
+                    $type : "json:String",
+                    $description : "The id of the reference which will be used for position of the tooltip the tooltip.",
                     $default : null
                 },
                 "absolutePosition" : {


### PR DESCRIPTION
Fixed by introducing a new attribute in the Dialog widget.
