### PR TITLE
fix #728 Headers should not be shared between request handler instances

### DIFF
--- a/src/aria/modules/requestHandler/JSONRequestHandler.js
+++ b/src/aria/modules/requestHandler/JSONRequestHandler.js
@@ -23,20 +23,23 @@ Aria.classDefinition({
     $statics : {
         PARSING_ERROR : "Response text could not be evaluated as JSON."
     },
+    $constructor : function () {
+        this.$RequestHandler.constructor.call(this);
+
+        /**
+         * Request Headers to be used
+         * @type Object
+         */
+        this.headers = {
+            "Content-Type" : "application/json"
+        };
+    },
     $prototype : {
         /**
          * Expect JSON as response type
          * @type String
          */
         expectedResponseType : "json",
-
-        /**
-         * Request Headers to be used
-         * @type Object
-         */
-        headers : {
-            "Content-Type" : "application/json"
-        },
 
         /**
          * Handles the response from the server, and call the associated callback

--- a/src/aria/modules/requestHandler/RequestHandler.js
+++ b/src/aria/modules/requestHandler/RequestHandler.js
@@ -47,19 +47,19 @@ Aria.classDefinition({
                 scope : this
             }
         });
+
+        /**
+         * Request Headers to be used
+         * @type Object
+         */
+        this.headers = {
+            "Content-Type" : "application/x-www-form-urlencoded; charset=UTF-8"
+        };
     },
     $destructor : function () {
         this._requestJsonSerializer = null;
     },
     $prototype : {
-        /**
-         * Request Headers to be used
-         * @type Object
-         */
-        headers : {
-            "Content-Type" : "application/x-www-form-urlencoded; charset=UTF-8"
-        },
-
         /**
          * Handles the response from the server, and call the associated callback
          * @param {aria.modules.RequestBeans:SuccessResponse} successResponse

--- a/test/aria/modules/requestHandler/JSONRequestHandlerTest.js
+++ b/test/aria/modules/requestHandler/JSONRequestHandlerTest.js
@@ -101,6 +101,23 @@ Aria.classDefinition({
             handler.$dispose();
 
             this.notifyTestEnd("testAsyncJsonResponseJSON");
+        },
+
+        /**
+         * Test that each instance gets independant headers
+         */
+        testEachInstanceGetsIndependantHeaders : function () {
+            var i1 = new aria.modules.requestHandler.JSONRequestHandler();
+            i1.getRequestHeaders()['foo'] = 'bar1';
+
+            var i2 = new aria.modules.requestHandler.JSONRequestHandler();
+            i2.getRequestHeaders()['foo'] = 'bar2';
+
+            this.assertEquals(i1.getRequestHeaders()['foo'], 'bar1');
+            this.assertEquals(i2.getRequestHeaders()['foo'], 'bar2');
+
+            i1.$dispose();
+            i2.$dispose();		
         }
     }
 });

--- a/test/aria/modules/requestHandler/RequestHandlerTest.js
+++ b/test/aria/modules/requestHandler/RequestHandlerTest.js
@@ -113,6 +113,23 @@ Aria.classDefinition({
             this.assertTrue(valid);
             this.assertTrue(request.postHeader === "text/plain");
             handler.$dispose();
+        },
+
+        /**
+         * Test that each instance gets independant headers
+         */
+        testEachInstanceGetsIndependantHeaders : function () {
+            var i1 = new aria.modules.requestHandler.RequestHandler();
+            i1.getRequestHeaders()['foo'] = 'bar1';
+
+            var i2 = new aria.modules.requestHandler.RequestHandler();
+            i2.getRequestHeaders()['foo'] = 'bar2';
+
+            this.assertEquals(i1.getRequestHeaders()['foo'], 'bar1');
+            this.assertEquals(i2.getRequestHeaders()['foo'], 'bar2');
+			
+            i1.$dispose();
+            i2.$dispose();
         }
     }
 });

--- a/test/aria/modules/requestHandler/issue459/MockRequestHandler.js
+++ b/test/aria/modules/requestHandler/issue459/MockRequestHandler.js
@@ -17,9 +17,12 @@ Aria.classDefinition({
     $classpath : "test.aria.modules.requestHandler.issue459.MockRequestHandler",
     $implements : ["aria.modules.requestHandler.IRequestHandler"],
     $extends : "aria.modules.requestHandler.RequestHandler",
-    $prototype : {
-        headers : {
+    $constructor : function () {
+        this.$RequestHandler.constructor.call(this);
+        this.headers = {
             "Content-Type" : "mockHeaders"
-        }
+        };
+    },
+    $prototype : {
     }
 });


### PR DESCRIPTION
`RequestHandler` and `JSONRequestHandler` used to rely on implicitly static fields for headers. Since the addition of `RequestHandler#getHeaders()`, it was possible to modify those headers, corrupting the whole application.
