### PR TITLE
Removing intermediate variable when calling Aria.classDefinition

### DIFF
--- a/src/aria/jsunit/JsCoverageObject.js
+++ b/src/aria/jsunit/JsCoverageObject.js
@@ -13,116 +13,110 @@
  * limitations under the License.
  */
 
-(function () {
-    /**
-     * Simple class to extract the information provided by the files instrumented by jscoverage-server.
-     *
-     * Documentation on JsCoverage available at http://siliconforks.com/jscoverage/manual.html
-     *
-     * This wrapper can be used to easily process raw JsCoverage data, and then make the data easier to use.
-     *
-     * @class aria.jsunit.JsCoverageObject description
-     * @extends aria.core.JsObject
-     */
-    var classDefinition = {
-        $classpath : 'aria.jsunit.JsCoverageObject',
-        $singleton : false,
-        $statics : {
-            sort : function (o1, o2) {
-                var filename1 = o1.filename.toLowerCase(), filename2 = o2.filename.toLowerCase();
-                if (filename1 > filename2) {
-                    return 1;
-                } else if (filename1 == filename2) {
-                    return 0;
-                }
-                return -1;
+/**
+ * Simple class to extract the information provided by the files instrumented by jscoverage-server. Documentation on
+ * JsCoverage available at http://siliconforks.com/jscoverage/manual.html This wrapper can be used to easily process raw
+ * JsCoverage data, and then make the data easier to use.
+ * @class aria.jsunit.JsCoverageObject description
+ * @extends aria.core.JsObject
+ */
+Aria.classDefinition({
+    $classpath : 'aria.jsunit.JsCoverageObject',
+    $singleton : false,
+    $statics : {
+        sort : function (o1, o2) {
+            var filename1 = o1.filename.toLowerCase(), filename2 = o2.filename.toLowerCase();
+            if (filename1 > filename2) {
+                return 1;
+            } else if (filename1 == filename2) {
+                return 0;
             }
-        },
-        $dependencies : [],
-        $constructor : function (conf) {
-            /**
-             * Filename (from the static root) "/aria-templates-dev/dev/aria/jsunit/JsCoverageObject.js"
-             * @type String
-             */
-            this.filename = conf.filename || "";
-
-            /**
-             * Pre-highlighted sourced. Highlight is done by JsCoverage
-             * @type String
-             */
-            this.source = conf.source || "";
-
-            /**
-             * Name of the class contained in the intrumented file (extracted from the source)
-             * "aria.jsunit.JsCoverageObject"
-             * @type String
-             */
-
-            this.classname = conf.classname || "";
-
-            /**
-             * Total number of monitored lines. JsCoverages leaves comments and blank lines out of the monitoring
-             * @type Number
-             */
-            this.linesCount = conf.linesCount || 0;
-
-            /**
-             * Total number of monitored lines that were executed
-             * @type Number
-             */
-            this.coveredLinesCount = conf.coveredLinesCount || 0;
-
-            /**
-             * Raw data used to initialize the jsCoverage object
-             * @protected
-             * @type Object
-             */
-            this._data = conf.data;
-
-            if (this._data) {
-                this.init(this._data);
-            }
-        },
-        $prototype : {
-            /**
-             * Instance initialization
-             * @param {Object} data
-             */
-            init : function (data) {
-                this.source = data.source;
-
-                var linesCount = 0;
-                var coveredLinesCount = 0;
-
-                for (var i in data) {
-                    if (i == "source") {
-                        continue;
-                    }
-                    linesCount++;
-                    if (data[i] > 0) {
-                        coveredLinesCount++;
-                    }
-                }
-                this.linesCount = linesCount;
-                this.coveredLinesCount = coveredLinesCount;
-            },
-
-            /**
-             * Strig representation
-             * @return {String}
-             */
-            toString : function () {
-                return (this.classname || this.filename) + " : " + this.getCoverage() + "%";
-            },
-
-            /**
-             * Retrieve the coverage (in %) of the file described by this JsCoverageData object Coverage in
-             * @return {Number}
-             */
-            getCoverage : function () {
-                return Math.floor((this.coveredLinesCount / this.linesCount) * 100);
-            }
+            return -1;
         }
-    };
-    Aria.classDefinition(classDefinition);
-})();
+    },
+    $dependencies : [],
+    $constructor : function (conf) {
+        /**
+         * Filename (from the static root) "/aria-templates-dev/dev/aria/jsunit/JsCoverageObject.js"
+         * @type String
+         */
+        this.filename = conf.filename || "";
+
+        /**
+         * Pre-highlighted sourced. Highlight is done by JsCoverage
+         * @type String
+         */
+        this.source = conf.source || "";
+
+        /**
+         * Name of the class contained in the intrumented file (extracted from the source)
+         * "aria.jsunit.JsCoverageObject"
+         * @type String
+         */
+
+        this.classname = conf.classname || "";
+
+        /**
+         * Total number of monitored lines. JsCoverages leaves comments and blank lines out of the monitoring
+         * @type Number
+         */
+        this.linesCount = conf.linesCount || 0;
+
+        /**
+         * Total number of monitored lines that were executed
+         * @type Number
+         */
+        this.coveredLinesCount = conf.coveredLinesCount || 0;
+
+        /**
+         * Raw data used to initialize the jsCoverage object
+         * @protected
+         * @type Object
+         */
+        this._data = conf.data;
+
+        if (this._data) {
+            this.init(this._data);
+        }
+    },
+    $prototype : {
+        /**
+         * Instance initialization
+         * @param {Object} data
+         */
+        init : function (data) {
+            this.source = data.source;
+
+            var linesCount = 0;
+            var coveredLinesCount = 0;
+
+            for (var i in data) {
+                if (i == "source") {
+                    continue;
+                }
+                linesCount++;
+                if (data[i] > 0) {
+                    coveredLinesCount++;
+                }
+            }
+            this.linesCount = linesCount;
+            this.coveredLinesCount = coveredLinesCount;
+        },
+
+        /**
+         * Strig representation
+         * @return {String}
+         */
+        toString : function () {
+            return (this.classname || this.filename) + " : " + this.getCoverage() + "%";
+        },
+
+        /**
+         * Retrieve the coverage (in %) of the file described by this JsCoverageData object Coverage in
+         * @return {Number}
+         */
+        getCoverage : function () {
+            return Math.floor((this.coveredLinesCount / this.linesCount) * 100);
+        }
+    }
+});

--- a/src/aria/jsunit/JsCoverageReport.js
+++ b/src/aria/jsunit/JsCoverageReport.js
@@ -13,110 +13,105 @@
  * limitations under the License.
  */
 
-(function () {
-    /**
-     * Generate an HTML report from the data contained in an instance of aria.jsunit.JsCoverage
-     */
-    var classDefinition = {
-        $classpath : "aria.jsunit.JsCoverageReport",
-        $singleton : false,
-        $constructor : function (conf) {
-            this.jsCoverage = conf.jsCoverage || {};
-            /**
-             * @private
-             * @type HTMLElement
-             */
-            this._reportContainer = null;
-        },
-        $prototype : {
-            /**
-             * @param {Boolean} toEmail : indicates if the output will be used in an email or not
-             * @return {String} HTML report as a string
-             */
-            getReport : function (toEmail) {
-                var coverage = parseInt(this.jsCoverage.getCoverage(), 10);
+/**
+ * Generate an HTML report from the data contained in an instance of aria.jsunit.JsCoverage
+ */
+Aria.classDefinition({
+    $classpath : "aria.jsunit.JsCoverageReport",
+    $singleton : false,
+    $constructor : function (conf) {
+        this.jsCoverage = conf.jsCoverage || {};
+        /**
+         * @private
+         * @type HTMLElement
+         */
+        this._reportContainer = null;
+    },
+    $prototype : {
+        /**
+         * @param {Boolean} toEmail : indicates if the output will be used in an email or not
+         * @return {String} HTML report as a string
+         */
+        getReport : function (toEmail) {
+            var coverage = parseInt(this.jsCoverage.getCoverage(), 10);
 
-                var linesCount = this.jsCoverage.getLinesCount();
-                var filesCount = this.jsCoverage.getFilesCount();
+            var linesCount = this.jsCoverage.getLinesCount();
+            var filesCount = this.jsCoverage.getFilesCount();
 
-                var baseUrl = this.jsCoverage.jsCoverageStore.getBaseReportsURL();
+            var baseUrl = this.jsCoverage.jsCoverageStore.getBaseReportsURL();
 
-                var coverageLink = "<a href='" + baseUrl + "jscoverage.html' target='_blank'>" + "Global Coverage"
-                        + "</a>";
+            var coverageLink = "<a href='" + baseUrl + "jscoverage.html' target='_blank'>" + "Global Coverage" + "</a>";
 
-                var markupArray = ["<h2>JsCoverage report</h2><br>",
-                        "<table style='border-collapse: collapse;font-size: small;'>", "<tbody>"];
+            var markupArray = ["<h2>JsCoverage report</h2><br>",
+                    "<table style='border-collapse: collapse;font-size: small;'>", "<tbody>"];
 
-                if (toEmail) {
-                    markupArray.push("<tr><td width='350px'><strong>" + coverageLink + "</strong> (on " + filesCount
-                            + " files and " + linesCount + " lines)</td>", "<td><strong>", coverage, "%<strong></td>", '<td width="100px"><table><tbody><tr>', '<td bgcolor="lime" width="'
-                            + coverage + 'px"/>', '<td bgcolor="red" width="' + (100 - coverage) + 'px"/>', '</tr></tbody></table></td></tr><br>');
-                } else {
-                    markupArray.push("<tr>", "<td><strong>" + coverageLink + "</strong> (on " + filesCount
-                            + " files and " + linesCount + " lines)</td>", '<td><strong>', coverage, '%</td>', '<td style="float: right;margin-right: 5px;">', '<div style="background-color: #E00000;border: 1px solid #000000;float: right;height: 10px;margin-top: 4px;overflow: hidden;width: 100px;">', '<div style="background-color: #00F000;height: 10px;width: '
-                            + coverage + 'px;"></div>', '</div>', '</td>', "</tr>");
-                }
-
-                markupArray.push("</tbody>", "</table>");
-
-                return markupArray.join("");
-            },
-
-            /**
-             * Create the DOM element displaying the actual JsCoverage report
-             * @private
-             */
-            _createJsCoverageReport : function () {
-                var document = Aria.$window.document;
-                var _reportContainer = document.createElement("div");
-
-                _reportContainer.id = "jsCoverageTableContainer";
-
-                _reportContainer.style.cssText = ["background-color: white", "border: 3px solid Grey", "top: 100px",
-                        "bottom: 100px", "left: 295px", "overflow-y: auto", "padding: 0 10px 10px",
-                        "position: absolute", "width: 600px", "z-index: 1"].join(";");
-
-                document.body.appendChild(_reportContainer);
-
-                this._reportContainer = _reportContainer;
-
-                this.refreshReport();
-            },
-
-            /**
-             * Make the JsCoverage report container visible This method might be called as soon as the test is
-             * completed. (necessary DOM elements will be created automatically if needed)
-             */
-            showReport : function () {
-                if (!this._reportContainer) {
-                    this._createJsCoverageReport();
-                }
-                this._reportContainer.style.display = "block";
-            },
-
-            /**
-             * Refresh the content of the report. To be called if anything changed in the JsCoverage instance
-             * represented by this reporter (such as filters)
-             */
-            refreshReport : function () {
-                if (!this._reportContainer) {
-                    this._createJsCoverageReport();
-                }
-                var jsCoverageReport = this.getReport();
-                this._reportContainer.innerHTML = jsCoverageReport;
-            },
-
-            /**
-             * Hide the JsCoverage report container
-             */
-            hideReport : function () {
-                if (!this._reportContainer) {
-                    this._createJsCoverageReport();
-                }
-                this._reportContainer.style.display = "none";
+            if (toEmail) {
+                markupArray.push("<tr><td width='350px'><strong>" + coverageLink + "</strong> (on " + filesCount
+                        + " files and " + linesCount + " lines)</td>", "<td><strong>", coverage, "%<strong></td>", '<td width="100px"><table><tbody><tr>', '<td bgcolor="lime" width="'
+                        + coverage + 'px"/>', '<td bgcolor="red" width="' + (100 - coverage) + 'px"/>', '</tr></tbody></table></td></tr><br>');
+            } else {
+                markupArray.push("<tr>", "<td><strong>" + coverageLink + "</strong> (on " + filesCount + " files and "
+                        + linesCount + " lines)</td>", '<td><strong>', coverage, '%</td>', '<td style="float: right;margin-right: 5px;">', '<div style="background-color: #E00000;border: 1px solid #000000;float: right;height: 10px;margin-top: 4px;overflow: hidden;width: 100px;">', '<div style="background-color: #00F000;height: 10px;width: '
+                        + coverage + 'px;"></div>', '</div>', '</td>', "</tr>");
             }
-        }
-    };
 
-    Aria.classDefinition(classDefinition);
-})();
+            markupArray.push("</tbody>", "</table>");
+
+            return markupArray.join("");
+        },
+
+        /**
+         * Create the DOM element displaying the actual JsCoverage report
+         * @private
+         */
+        _createJsCoverageReport : function () {
+            var document = Aria.$window.document;
+            var _reportContainer = document.createElement("div");
+
+            _reportContainer.id = "jsCoverageTableContainer";
+
+            _reportContainer.style.cssText = ["background-color: white", "border: 3px solid Grey", "top: 100px",
+                    "bottom: 100px", "left: 295px", "overflow-y: auto", "padding: 0 10px 10px", "position: absolute",
+                    "width: 600px", "z-index: 1"].join(";");
+
+            document.body.appendChild(_reportContainer);
+
+            this._reportContainer = _reportContainer;
+
+            this.refreshReport();
+        },
+
+        /**
+         * Make the JsCoverage report container visible This method might be called as soon as the test is completed.
+         * (necessary DOM elements will be created automatically if needed)
+         */
+        showReport : function () {
+            if (!this._reportContainer) {
+                this._createJsCoverageReport();
+            }
+            this._reportContainer.style.display = "block";
+        },
+
+        /**
+         * Refresh the content of the report. To be called if anything changed in the JsCoverage instance represented by
+         * this reporter (such as filters)
+         */
+        refreshReport : function () {
+            if (!this._reportContainer) {
+                this._createJsCoverageReport();
+            }
+            var jsCoverageReport = this.getReport();
+            this._reportContainer.innerHTML = jsCoverageReport;
+        },
+
+        /**
+         * Hide the JsCoverage report container
+         */
+        hideReport : function () {
+            if (!this._reportContainer) {
+                this._createJsCoverageReport();
+            }
+            this._reportContainer.style.display = "none";
+        }
+    }
+});

--- a/src/aria/tester/runner/utils/Hash.js
+++ b/src/aria/tester/runner/utils/Hash.js
@@ -13,84 +13,78 @@
  * limitations under the License.
  */
 
-(function () {
-    /**
-     * @class aria.tester.runner.utils.Hash
-     */
-    var classDefinition = {
-        $classpath : "aria.tester.runner.utils.Hash",
-        $singleton : true,
-        $constructor : function () {
-            this._hashParameters = {};
+Aria.classDefinition({
+    $classpath : "aria.tester.runner.utils.Hash",
+    $singleton : true,
+    $constructor : function () {
+        this._hashParameters = {};
+    },
+    $prototype : {
+        /**
+         * @private
+         */
+        _getHash : function () {
+            return Aria.$window.document.location.hash;
         },
-        $prototype : {
-            /**
-             * @private
-             */
-            _getHash : function () {
-                return Aria.$window.document.location.hash;
-            },
 
-            /**
-             * @private
-             */
-            _setHash : function (hash) {
-                Aria.$window.document.location.hash = hash;
-            },
+        /**
+         * @private
+         */
+        _setHash : function (hash) {
+            Aria.$window.document.location.hash = hash;
+        },
 
-            /**
-             *
-             */
-            getParameter : function (key) {
-                var hash = this._getHash();
+        /**
+         *
+         */
+        getParameter : function (key) {
+            var hash = this._getHash();
 
-                // remove initial #
-                hash = hash.substring(1);
+            // remove initial #
+            hash = hash.substring(1);
 
-                var keyvalues = hash.split("&");
-                for (var i = 0, l = keyvalues.length; i < l; i++) {
-                    var keyvalue = keyvalues[i];
-                    if (keyvalue.indexOf("=") != -1) {
-                        var split = keyvalue.split("=");
-                        if (key == split[0]) {
-                            return split[1];
-                        }
+            var keyvalues = hash.split("&");
+            for (var i = 0, l = keyvalues.length; i < l; i++) {
+                var keyvalue = keyvalues[i];
+                if (keyvalue.indexOf("=") != -1) {
+                    var split = keyvalue.split("=");
+                    if (key == split[0]) {
+                        return split[1];
                     }
                 }
-                return "";
-            },
-
-            setParameter : function (key, value) {
-                var hash = this._getHash();
-                var hashParam = [key, value].join("=");
-                // remove initial #
-                hash = hash.substring(1) || "";
-
-                var found = false;
-                var keyvalues = hash.split("&");
-                for (var i = 0, l = keyvalues.length; i < l; i++) {
-                    var keyvalue = keyvalues[i];
-                    if (keyvalue.indexOf("=") != -1) {
-                        var split = keyvalue.split("=");
-                        if (key == split[0]) {
-                            found = true;
-                            keyvalues[i] = hashParam;
-                        }
-                    }
-                }
-
-                if (!found) {
-                    if (keyvalues[keyvalues.length - 1] === "") {
-                        keyvalues[keyvalues.length - 1] = hashParam;
-                    } else {
-                        keyvalues.push(hashParam);
-                    }
-                }
-
-                hash = "#" + keyvalues.join("&");
-                this._setHash(hash);
             }
+            return "";
+        },
+
+        setParameter : function (key, value) {
+            var hash = this._getHash();
+            var hashParam = [key, value].join("=");
+            // remove initial #
+            hash = hash.substring(1) || "";
+
+            var found = false;
+            var keyvalues = hash.split("&");
+            for (var i = 0, l = keyvalues.length; i < l; i++) {
+                var keyvalue = keyvalues[i];
+                if (keyvalue.indexOf("=") != -1) {
+                    var split = keyvalue.split("=");
+                    if (key == split[0]) {
+                        found = true;
+                        keyvalues[i] = hashParam;
+                    }
+                }
+            }
+
+            if (!found) {
+                if (keyvalues[keyvalues.length - 1] === "") {
+                    keyvalues[keyvalues.length - 1] = hashParam;
+                } else {
+                    keyvalues.push(hashParam);
+                }
+            }
+
+            hash = "#" + keyvalues.join("&");
+            this._setHash(hash);
         }
-    };
-    Aria.classDefinition(classDefinition);
-})();
+    }
+});

--- a/src/aria/tester/runner/utils/TestUtils.js
+++ b/src/aria/tester/runner/utils/TestUtils.js
@@ -13,146 +13,143 @@
  * limitations under the License.
  */
 
-(function () {
-    /**
-     * Mutualize most of the test formatting and information extraction logic
-     */
-    var classDefinition = {
-        $classpath : "aria.tester.runner.utils.TestUtils",
-        $singleton : true,
-        $prototype : {
-            /**
-             *
-             */
-            getTestSuiteInfo : function (testSuite) {
-                var instance = testSuite.instance;
-                var suitesCount = instance.getAllSubTestSuites().length;
-                var casesCount = instance.getAllSubTestCases().length;
+/**
+ * Mutualize most of the test formatting and information extraction logic
+ */
+Aria.classDefinition({
+    $classpath : "aria.tester.runner.utils.TestUtils",
+    $singleton : true,
+    $prototype : {
+        /**
+         *
+         */
+        getTestSuiteInfo : function (testSuite) {
+            var instance = testSuite.instance;
+            var suitesCount = instance.getAllSubTestSuites().length;
+            var casesCount = instance.getAllSubTestCases().length;
 
-                return this._formatTestSuiteInfo(suitesCount, casesCount);
-            },
+            return this._formatTestSuiteInfo(suitesCount, casesCount);
+        },
 
-            /**
-             * Format information about a test suite for display purposes, with an abstraction on the testsuite. <br />
-             * (0,3) => '(3 test cases)' <br />
-             * (1,3) => '(1 test suite and 3 test cases)' <br />
-             * (2,0) => '(2 test suites)' <br />
-             * @param {Number} suitesCount The number of suites contained inside a given suite
-             * @param {Number} casesCount The number of cases contained inside a given suite
-             * @return {String} Formatted information
-             */
-            _formatTestSuiteInfo : function (suitesCount, casesCount) {
-                var testSuitesText = suitesCount ? suitesCount + " test suite" + (suitesCount > 1 ? "s" : "") : null;
+        /**
+         * Format information about a test suite for display purposes, with an abstraction on the testsuite. <br />
+         * (0,3) => '(3 test cases)' <br />
+         * (1,3) => '(1 test suite and 3 test cases)' <br />
+         * (2,0) => '(2 test suites)' <br />
+         * @param {Number} suitesCount The number of suites contained inside a given suite
+         * @param {Number} casesCount The number of cases contained inside a given suite
+         * @return {String} Formatted information
+         */
+        _formatTestSuiteInfo : function (suitesCount, casesCount) {
+            var testSuitesText = suitesCount ? suitesCount + " test suite" + (suitesCount > 1 ? "s" : "") : null;
 
-                var testCasesText = casesCount ? casesCount + " test case" + (casesCount > 1 ? "s" : "") : null;
+            var testCasesText = casesCount ? casesCount + " test case" + (casesCount > 1 ? "s" : "") : null;
 
-                if (casesCount && suitesCount) {
-                    return [testSuitesText, testCasesText].join(" and ");
-                } else if (casesCount || suitesCount) {
-                    return [testSuitesText, testCasesText].join("");
-                } else {
-                    return "no test available in this suite !";
-                }
-            },
-
-            /**
-             * Format the classpath of a given test case
-             * @param {Object} testCase : test preload wrapper {instance, classpath}
-             * @return {String} formatted name
-             */
-            formatTestCaseName : function (testCase, mini) {
-                var classpath = testCase.classpath;
-                var formattedClasspath = this._formatTestCaseClasspath(classpath, mini);
-                return formattedClasspath;
-            },
-
-            /**
-             * Apply display transformation to a given test case classpath
-             * @param {String} classpath
-             * @return {String} formatted classpath
-             * @private
-             */
-            _formatTestCaseClasspath : function (classpath, mini) {
-                var splitClasspath = classpath.split(".");
-                var lastElem = splitClasspath[splitClasspath.length - 1];
-                splitClasspath[splitClasspath.length - 1] = "<b>" + lastElem + "</b>";
-
-                if (mini) {
-                    return "<b>" + lastElem + "</b>";
-                } else {
-                    return splitClasspath.join(".");
-                }
-            },
-
-            formatTestErrorsCount : function (testCase) {
-                var errors = testCase.instance.getErrors();
-                var l = errors.length;
-                return (l + " error" + (l != 1 ? "s" : ""));
-            },
-
-            /**
-             * @param {Object}
-             */
-            formatTestSuiteName : function (testSuite) {
-                var classpath = testSuite.$classpath || testSuite.classpath;
-                var formattedClasspath = this._formatTestSuiteClasspath(classpath);
-                return formattedClasspath;
-            },
-
-            /**
-             *
-             */
-            _formatTestSuiteClasspath : function (classpath) {
-                var splitClasspath = classpath.split(".");
-                return splitClasspath[splitClasspath.length - 1].replace("TestSuite", "");
-            },
-
-            /**
-             * Retrieve all the selected tests (cases and suites) nested inside a given suite as a flat array
-             * @param {aria.jsunit.TestSuite} suite
-             * @return {Array}
-             */
-            getSubTestsAsArray : function (suite) {
-                var tests = [];
-                var subTests = suite.getSubTests();
-                for (var i = 0, l = subTests.length; i < l; i++) {
-                    var test = subTests[i];
-                    var instance = test.instance;
-                    if (instance && instance.$TestSuite) {
-                        if (instance.isSelected() !== -1 && !instance.isSkipped()) {
-                            var suiteSubTests = this.getSubTestsAsArray(instance);
-                            if (instance.getSubTests().length != instance.getSubTestSuites().length
-                                    && suiteSubTests.length !== 0) {
-                                tests.push(test);
-                            }
-                            tests = tests.concat(suiteSubTests);
-                        }
-                    } else {
-                        tests.push(test);
-                    }
-                }
-                return tests;
-            },
-
-            /**
-             * Retrieve the classpaths of all the unselected test suites nested inside a given suite
-             * @param {aria.jsunit.TestSuite} suite
-             * @return {Array}
-             */
-            getUnselectedSubSuites : function (suite) {
-                var unselectedSuites = [];
-                var subsuites = suite.getSubTestSuites();
-                for (var i = 0, l = subsuites.length; i < l; i++) {
-                    var subsuite = subsuites[i].instance;
-                    if (subsuite.isSelected() == -1) {
-                        unselectedSuites.push(subsuite.$classpath);
-                    } else if (subsuite.isSelected() === 0) {
-                        unselectedSuites = unselectedSuites.concat(this.getUnselectedSubSuites(subsuite));
-                    }
-                }
-                return unselectedSuites;
+            if (casesCount && suitesCount) {
+                return [testSuitesText, testCasesText].join(" and ");
+            } else if (casesCount || suitesCount) {
+                return [testSuitesText, testCasesText].join("");
+            } else {
+                return "no test available in this suite !";
             }
+        },
+
+        /**
+         * Format the classpath of a given test case
+         * @param {Object} testCase : test preload wrapper {instance, classpath}
+         * @return {String} formatted name
+         */
+        formatTestCaseName : function (testCase, mini) {
+            var classpath = testCase.classpath;
+            var formattedClasspath = this._formatTestCaseClasspath(classpath, mini);
+            return formattedClasspath;
+        },
+
+        /**
+         * Apply display transformation to a given test case classpath
+         * @param {String} classpath
+         * @return {String} formatted classpath
+         * @private
+         */
+        _formatTestCaseClasspath : function (classpath, mini) {
+            var splitClasspath = classpath.split(".");
+            var lastElem = splitClasspath[splitClasspath.length - 1];
+            splitClasspath[splitClasspath.length - 1] = "<b>" + lastElem + "</b>";
+
+            if (mini) {
+                return "<b>" + lastElem + "</b>";
+            } else {
+                return splitClasspath.join(".");
+            }
+        },
+
+        formatTestErrorsCount : function (testCase) {
+            var errors = testCase.instance.getErrors();
+            var l = errors.length;
+            return (l + " error" + (l != 1 ? "s" : ""));
+        },
+
+        /**
+         * @param {Object}
+         */
+        formatTestSuiteName : function (testSuite) {
+            var classpath = testSuite.$classpath || testSuite.classpath;
+            var formattedClasspath = this._formatTestSuiteClasspath(classpath);
+            return formattedClasspath;
+        },
+
+        /**
+         *
+         */
+        _formatTestSuiteClasspath : function (classpath) {
+            var splitClasspath = classpath.split(".");
+            return splitClasspath[splitClasspath.length - 1].replace("TestSuite", "");
+        },
+
+        /**
+         * Retrieve all the selected tests (cases and suites) nested inside a given suite as a flat array
+         * @param {aria.jsunit.TestSuite} suite
+         * @return {Array}
+         */
+        getSubTestsAsArray : function (suite) {
+            var tests = [];
+            var subTests = suite.getSubTests();
+            for (var i = 0, l = subTests.length; i < l; i++) {
+                var test = subTests[i];
+                var instance = test.instance;
+                if (instance && instance.$TestSuite) {
+                    if (instance.isSelected() !== -1 && !instance.isSkipped()) {
+                        var suiteSubTests = this.getSubTestsAsArray(instance);
+                        if (instance.getSubTests().length != instance.getSubTestSuites().length
+                                && suiteSubTests.length !== 0) {
+                            tests.push(test);
+                        }
+                        tests = tests.concat(suiteSubTests);
+                    }
+                } else {
+                    tests.push(test);
+                }
+            }
+            return tests;
+        },
+
+        /**
+         * Retrieve the classpaths of all the unselected test suites nested inside a given suite
+         * @param {aria.jsunit.TestSuite} suite
+         * @return {Array}
+         */
+        getUnselectedSubSuites : function (suite) {
+            var unselectedSuites = [];
+            var subsuites = suite.getSubTestSuites();
+            for (var i = 0, l = subsuites.length; i < l; i++) {
+                var subsuite = subsuites[i].instance;
+                if (subsuite.isSelected() == -1) {
+                    unselectedSuites.push(subsuite.$classpath);
+                } else if (subsuite.isSelected() === 0) {
+                    unselectedSuites = unselectedSuites.concat(this.getUnselectedSubSuites(subsuite));
+                }
+            }
+            return unselectedSuites;
         }
-    };
-    Aria.classDefinition(classDefinition);
-})();
+    }
+});

--- a/src/aria/tester/runner/view/filter/FilterScript.js
+++ b/src/aria/tester/runner/view/filter/FilterScript.js
@@ -13,20 +13,17 @@
  * limitations under the License.
  */
 
-(function () {
-    var tplScriptDefinition = {
-        $classpath : 'aria.tester.runner.view.filter.FilterScript',
-        $prototype : {
-            /**
-             * Callback triggered when the user clicks on the header button
-             */
-            onFilterLinkClick : function (evt, args) {
-                var type = evt.target.getData("type");
-                if (type) {
-                    this.$json.setValue(this.data.view.filter, "type", type);
-                }
+Aria.tplScriptDefinition({
+    $classpath : 'aria.tester.runner.view.filter.FilterScript',
+    $prototype : {
+        /**
+         * Callback triggered when the user clicks on the header button
+         */
+        onFilterLinkClick : function (evt, args) {
+            var type = evt.target.getData("type");
+            if (type) {
+                this.$json.setValue(this.data.view.filter, "type", type);
             }
         }
-    };
-    Aria.tplScriptDefinition(tplScriptDefinition);
-})();
+    }
+});

--- a/src/aria/tester/runner/view/header/HeaderScript.js
+++ b/src/aria/tester/runner/view/header/HeaderScript.js
@@ -13,90 +13,87 @@
  * limitations under the License.
  */
 
-(function () {
-    var tplScriptDefinition = {
-        $classpath : 'aria.tester.runner.view.header.HeaderScript',
-        $prototype : {
-            /**
-             * Callback triggered when the user clicks on the header button
-             */
-            _onStartTestsButtonClick : function () {
-                var state = this.data.flow.currentState;
-                var STATES = this.flowCtrl.STATES;
-                if (state == STATES.READY) {
-                    this.moduleCtrl.startCampaign();
-                } else if (state == STATES.ONGOING) {
-                    this.flowCtrl.navigate(STATES.PAUSING);
-                } else if (state == STATES.PAUSED) {
-                    this.flowCtrl.navigate(STATES.RESUMING);
-                } else if (state == STATES.FINISHED) {
-                    this.reload();
-                }
-            },
-
-            _onErrorCountClick : function (evt, args) {
-                this.flowCtrl.navigate(this.flowCtrl.STATES.REPORT);
-            },
-
-            isButtonDisabled : function () {
-                var state = this.data.flow.currentState;
-                return this.__isButtonDisabledForState(state);
-            },
-
-            __isButtonDisabledForState : function (state) {
-                var disabledStates = [];
-                disabledStates.push(this.flowCtrl.STATES.INIT);
-                disabledStates.push(this.flowCtrl.STATES.FAILURE);
-                disabledStates.push(this.flowCtrl.STATES.PAUSING);
-                disabledStates.push(this.flowCtrl.STATES.RESUMING);
-                disabledStates.push(this.flowCtrl.STATES.OPTIONS);
-
-                if (aria.utils.Array.indexOf(disabledStates, state) != -1) {
-                    return true;
-                }
-                return false;
-            },
-
-            /**
-             * For the current flow state, retrieve the label to use for the action button
-             * @return {String} The label to use for the action button
-             */
-            getButtonLabel : function () {
-                var state = this.data.flow.currentState;
-                return this.__getButtonLabelForState(state);
-            },
-
-            /**
-             * Given a state, retrieve the label to use for the action button
-             * @private
-             * @return {String} The label to use for the action button
-             */
-            __getButtonLabelForState : function (state) {
-                if (state == this.flowCtrl.STATES.READY || state == this.flowCtrl.STATES.OPTIONS) {
-                    return "Run";
-                } else if (state == this.flowCtrl.STATES.INIT || state == this.flowCtrl.STATES.FAILURE
-                        || state == this.flowCtrl.STATES.RESUMING) {
-                    return "Loading";
-                } else if (state == this.flowCtrl.STATES.FINISHED || state == this.flowCtrl.STATES.REPORT) {
-                    return "Reload";
-                } else if (state == this.flowCtrl.STATES.ONGOING) {
-                    return "Pause";
-                } else if (state == this.flowCtrl.STATES.PAUSING) {
-                    return "Pausing";
-                } else if (state == this.flowCtrl.STATES.PAUSED) {
-                    return "Resume";
-                } else {
-                    return "#" + state + "#";
-                }
-            },
-
-            /**
-             *
-             */
-            reload : function () {
-                this.moduleCtrl.reload();
+Aria.tplScriptDefinition({
+    $classpath : 'aria.tester.runner.view.header.HeaderScript',
+    $prototype : {
+        /**
+         * Callback triggered when the user clicks on the header button
+         */
+        _onStartTestsButtonClick : function () {
+            var state = this.data.flow.currentState;
+            var STATES = this.flowCtrl.STATES;
+            if (state == STATES.READY) {
+                this.moduleCtrl.startCampaign();
+            } else if (state == STATES.ONGOING) {
+                this.flowCtrl.navigate(STATES.PAUSING);
+            } else if (state == STATES.PAUSED) {
+                this.flowCtrl.navigate(STATES.RESUMING);
+            } else if (state == STATES.FINISHED) {
+                this.reload();
             }
+        },
+
+        _onErrorCountClick : function (evt, args) {
+            this.flowCtrl.navigate(this.flowCtrl.STATES.REPORT);
+        },
+
+        isButtonDisabled : function () {
+            var state = this.data.flow.currentState;
+            return this.__isButtonDisabledForState(state);
+        },
+
+        __isButtonDisabledForState : function (state) {
+            var disabledStates = [];
+            disabledStates.push(this.flowCtrl.STATES.INIT);
+            disabledStates.push(this.flowCtrl.STATES.FAILURE);
+            disabledStates.push(this.flowCtrl.STATES.PAUSING);
+            disabledStates.push(this.flowCtrl.STATES.RESUMING);
+            disabledStates.push(this.flowCtrl.STATES.OPTIONS);
+
+            if (aria.utils.Array.indexOf(disabledStates, state) != -1) {
+                return true;
+            }
+            return false;
+        },
+
+        /**
+         * For the current flow state, retrieve the label to use for the action button
+         * @return {String} The label to use for the action button
+         */
+        getButtonLabel : function () {
+            var state = this.data.flow.currentState;
+            return this.__getButtonLabelForState(state);
+        },
+
+        /**
+         * Given a state, retrieve the label to use for the action button
+         * @private
+         * @return {String} The label to use for the action button
+         */
+        __getButtonLabelForState : function (state) {
+            if (state == this.flowCtrl.STATES.READY || state == this.flowCtrl.STATES.OPTIONS) {
+                return "Run";
+            } else if (state == this.flowCtrl.STATES.INIT || state == this.flowCtrl.STATES.FAILURE
+                    || state == this.flowCtrl.STATES.RESUMING) {
+                return "Loading";
+            } else if (state == this.flowCtrl.STATES.FINISHED || state == this.flowCtrl.STATES.REPORT) {
+                return "Reload";
+            } else if (state == this.flowCtrl.STATES.ONGOING) {
+                return "Pause";
+            } else if (state == this.flowCtrl.STATES.PAUSING) {
+                return "Pausing";
+            } else if (state == this.flowCtrl.STATES.PAUSED) {
+                return "Resume";
+            } else {
+                return "#" + state + "#";
+            }
+        },
+
+        /**
+         *
+         */
+        reload : function () {
+            this.moduleCtrl.reload();
         }
-    };
-    Aria.tplScriptDefinition(tplScriptDefinition);
-})();
+    }
+});


### PR DESCRIPTION
Some files are using an intermediate variable before calling `Aria.classDefinition` or `Aria.tplScriptDefinition`.
This is useless, and can prevent some automatic tools from working on those files.
This commit removes the intermediate variable, which makes Aria Templates files more consistent.
