### PR TITLE
Refresh manager not resumed after an exception in a module controller

### DIFF
--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -154,13 +154,20 @@
         this.$callback(interc, info);
         if (!info.cancelDefault) {
             // call next wrapper or real method:
-            info.returnValue = __callWrapper.call(this, info.args, commonInfo, interceptorIndex + 1);
+            try {
+                info.returnValue = __callWrapper.call(this, info.args, commonInfo, interceptorIndex + 1);
+            } catch (e) {
+                info.exception = e;
+            }
             info.step = "CallEnd";
             delete info.cancelDefault; // no longer useful in CallEnd
             // call the interceptor, even if it was removed in the mean time (so
             // that CallEnd is always called when
             // CallBegin has been called):
             this.$callback(interc, info);
+            if ("exception" in info) {
+                throw info.exception;
+            }
         }
         return info.returnValue;
     };

--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -83,6 +83,8 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.statements.StatementsTestSuite");
         this.addTests("test.aria.templates.issue400.AlreadyCompiledTplTestCase");
 
+        this.addTests("test.aria.templates.issue727.RefreshManagerExceptionTestCase");
+
         this.addTests("test.aria.templates.tabsRefresh.TabsRefreshTestCase");
         this.addTests("test.aria.templates.macrolibs.MacrolibsTestCase");
         this.addTests("test.aria.templates.textTemplates.TextTemplatesTestCase");

--- a/test/aria/templates/issue727/IRefreshManagerExceptionModule.js
+++ b/test/aria/templates/issue727/IRefreshManagerExceptionModule.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.interfaceDefinition({
+    $classpath : "test.aria.templates.issue727.IRefreshManagerExceptionModule",
+    $extends : "aria.templates.IModuleCtrl",
+    $interface : {
+        callMethodWithException : "Function"
+    }
+});

--- a/test/aria/templates/issue727/RefreshManagerExceptionModule.js
+++ b/test/aria/templates/issue727/RefreshManagerExceptionModule.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.issue727.RefreshManagerExceptionModule",
+    $extends : "aria.templates.ModuleCtrl",
+    $implements : ["test.aria.templates.issue727.IRefreshManagerExceptionModule"],
+    $prototype : {
+        $publicInterfaceName : "test.aria.templates.issue727.IRefreshManagerExceptionModule",
+        _enableMethodEvents : true,
+        callMethodWithException : function (callback) {
+            callback();
+        }
+    }
+});

--- a/test/aria/templates/issue727/RefreshManagerExceptionTestCase.js
+++ b/test/aria/templates/issue727/RefreshManagerExceptionTestCase.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.issue727.RefreshManagerExceptionTestCase",
+    $dependencies : ["aria.templates.RefreshManager"],
+    $extends : "aria.jsunit.ModuleCtrlTestCase",
+    $prototype : {
+        $controller : "test.aria.templates.issue727.RefreshManagerExceptionModule",
+        testCallMethodWithException : function () {
+            var myException = new Error();
+            try {
+                var self = this;
+                this.assertFalse(aria.templates.RefreshManager.isStopped(), "The refresh manager should not be stopped from the beginning.");
+                this.$moduleCtrl.callMethodWithException(function () {
+                    self.assertTrue(aria.templates.RefreshManager.isStopped(), "The refresh manager should be stopped during the call of the module controller.");
+                    throw myException;
+                });
+                this.fail("callMethodWithException should raise an exception.");
+            } catch (e) {
+                this.assertEquals(e, myException);
+                this.assertFalse(aria.templates.RefreshManager.isStopped(), "The refresh manager should be resumed after an exception.");
+            }
+        }
+    }
+});


### PR DESCRIPTION
This is another pull request to fix #727, as the previous fix only fixed half of the issue (there were several calls to `aria.templates.RefreshManager.stop()`).

When an exception occured in a module controller method, the interceptor (which stopped the refresh manager when the call to the module controller begins) was not called to resume the refresh manager after the exception.
