### PR TITLE
Fix some randomly failing tests

### DIFF
--- a/test/aria/html/radioButton/IEbug/RadioButtonTestCase.js
+++ b/test/aria/html/radioButton/IEbug/RadioButtonTestCase.js
@@ -18,7 +18,7 @@ Aria.classDefinition({
     $extends : "aria.jsunit.RobotTestCase",
     $dependencies : ["aria.utils.Dom", "aria.html.RadioButton"],
     $constructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
+        this.$RobotTestCase.constructor.call(this);
         this.setTestEnv({
             data : {
                 selectedValue : ""

--- a/test/aria/touch/widgets/dialog/events/DialogAnimationsTestCase.js
+++ b/test/aria/touch/widgets/dialog/events/DialogAnimationsTestCase.js
@@ -76,11 +76,20 @@ Aria.classDefinition({
             // reset
             this.eventsFired = [];
 
-            aria.core.Timer.addCallback({
-                fn : this.checkEventsArrayAfterOpen,
-                scope : this,
-                delay : 400
+            this.waitFor({
+                condition : {
+                    fn : this.checkEventFired,
+                    scope : this
+                },
+                callback : {
+                    fn : this.checkEventsArrayAfterOpen,
+                    scope : this
+                }
             });
+        },
+
+        checkEventFired : function () {
+            return this.eventsFired.length > 0;
         },
 
         checkEventsArrayAfterOpen : function () {

--- a/test/aria/widgets/container/tooltip/TooltipTestCase.js
+++ b/test/aria/widgets/container/tooltip/TooltipTestCase.js
@@ -30,26 +30,36 @@ Aria.classDefinition({
         runTemplateTest : function () {
             var tooltipDiv = this.testWindow.aria.utils.Dom.getElementById("mouseOverMe");
 
-            this.testWindow.aria.jsunit.SynEvents.move({
+            this.synEvent.move({
                 to : tooltipDiv,
                 duration : 500
             }, {
                 x : 0,
                 y : 0
             }, {
-                fn : function () {
-                    // Wait for the tooltip to appear
-                    aria.core.Timer.addCallback({
-                        fn : this._afterMove,
-                        scope : this,
-                        delay : 100
-                    });
-                },
+                fn : this._afterMove,
                 scope : this
             });
         },
 
         _afterMove : function () {
+            this.waitFor({
+                condition : {
+                    fn : this._checkTooltip,
+                    scope : this
+                },
+                callback : {
+                    fn : this._afterShowTooltip,
+                    scope : this
+                }
+            });
+        },
+
+        _checkTooltip : function () {
+            return this.testWindow.aria.utils.Dom.getElementById("testMe") != null;
+        },
+
+        _afterShowTooltip : function () {
             var DomUtil = this.testWindow.aria.utils.Dom;
 
             var tooltipAnchor = DomUtil.getElementById("mouseOverMe");


### PR DESCRIPTION
`test.aria.touch.widgets.dialog.events.DialogAnimationsTestCase` and `test.aria.widgets.container.tooltip.TooltipTestCase` are randomly failing because of timeouts (which are too small).
This pull request replaces the timeouts with calls to `waitFor`. It partially fixes #725.
