### PR TITLE
refactor Remove dead code

### DIFF
--- a/build/config/jshint.json
+++ b/build/config/jshint.json
@@ -16,7 +16,7 @@
     "quotmark" : false,
     "regexp" : false,
     "undef" : true,
-    "unused" : false,
+    "unused" : "vars",
     "strict" : false,
     "trailing" : true,
     "maxparams" : 6,

--- a/build/grunt-config/config-checkStyle.js
+++ b/build/grunt-config/config-checkStyle.js
@@ -43,6 +43,7 @@ module.exports = function (grunt) {
                         '!test/aria/templates/reloadResources/ExternalResourceErr.js']
             },
             options : {
+                "unused" : false,
                 "globals" : {
                     "aria": false,
                     "Aria": false,

--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -211,7 +211,7 @@
             Aria.$logError(Aria.NULL_CLASSPATH);
             return false;
         }
-        var classpathParts = path.split('.'), nbParts = classpathParts.length, part;
+        var classpathParts = path.split('.'), nbParts = classpathParts.length;
         for (var index = 0; index < nbParts - 1; index++) {
             if (!__checkPackageName(classpathParts[index], context)) {
                 return false;
@@ -1445,7 +1445,6 @@
         object.Aria = Aria;
         var global = Aria.$global;
         var classes = Aria.$classes;
-        var copiedClasses = {};
         for (var i = 0, l = classes.length; i < l; i++) {
             var classRef = classes[i];
             if (classRef) {

--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -399,8 +399,6 @@ Aria.classDefinition({
          * @private
          */
         _afterRequestFilters : function (unused, req) {
-            var reqId = req.id;
-
             this.$raiseEvent({
                 name : "request",
                 req : req
@@ -451,7 +449,8 @@ Aria.classDefinition({
             this.nbRequests++;
             req.id = this.nbRequests;
 
-            var reqMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "OPTIONS", "CONNECT", "PATCH", "COPY", "PROPFIND", "MKCOL", "PROPPATCH", "MOVE", "LOCK", "UNLOCK", "BIND", "UNBIND", "REBIND"];
+            var reqMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "OPTIONS", "CONNECT", "PATCH", "COPY",
+                    "PROPFIND", "MKCOL", "PROPPATCH", "MOVE", "LOCK", "UNLOCK", "BIND", "UNBIND", "REBIND"];
             // Assign a request timeout in order of importance:
             // # req.timeout - User specified timeout
             // # req.callback.timeout - Timeout of the callback function (might be set by filters)
@@ -533,8 +532,6 @@ Aria.classDefinition({
          * @private
          */
         _prepareTransport : function (request) {
-            var reqId = request.id;
-
             var transport;
             if (request.jsonp) {
                 transport = this.__jsonp;
@@ -615,7 +612,7 @@ Aria.classDefinition({
         _asyncRequest : function (arg) {
             var request = arg.req;
             var reqId = request.id;
-            var method = request.method;
+            // var method = request.method;
             var transport = arg.transport.instance || Aria.getClassRef(arg.transport.classpath);
 
             var transportCallback = {

--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -51,7 +51,7 @@
         var arr = callbacksMap[name];
 
         if (arr) {
-            var length = arr.length, removeThis = false, newList = null, cb;
+            var length = arr.length, removeThis = false, cb;
             for (var i = 0; i < length; i++) {
                 cb = arr[i];
 
@@ -238,7 +238,6 @@
     var __interceptObject = function (interfaceMethods, interceptor, allInterceptors) {
         var interceptedMethods = allInterceptors || {};
         // for a class object, intercept specific methods
-        var interceptorMethodBegin, interceptorMethodCallBack, interceptorMethodEnd;
         for (var m in interfaceMethods) {
             if (interfaceMethods.hasOwnProperty(m) && __hasBeenIntercepted(m, interceptor)) {
                 (interceptedMethods[m] || (interceptedMethods[m] = [])).push({

--- a/src/aria/core/JsonTypesCheck.js
+++ b/src/aria/core/JsonTypesCheck.js
@@ -574,7 +574,6 @@
      */
     var fastNormalizers = {
         emptyObject : function (obj) {
-            var beanProperties = this.$properties;
             if (!obj) {
                 return this.$getDefault();
             }

--- a/src/aria/core/ResClassLoader.js
+++ b/src/aria/core/ResClassLoader.js
@@ -174,7 +174,6 @@ Aria.classDefinition({
                 serverResource : false,
                 full : null
             };
-            var asynch = false;
 
             // process server resource set
             if (refClasspath.match(/\.Res$/)) {

--- a/src/aria/core/TplClassLoader.js
+++ b/src/aria/core/TplClassLoader.js
@@ -43,7 +43,7 @@
 
     var __loadTemplate3 = function (res, args) {
         // Step 3: init the template context and show the template
-        var cfg = args.cfg, cb = args.cb;
+        var cfg = args.cfg;
 
         var tplCtxt = new aria.templates.TemplateCtxt();
         if (res.moduleCtrlPrivate && cfg.moduleCtrl.autoDispose) {
@@ -399,7 +399,6 @@
              * @param {aria.templates.CfgBeans:Div} div The div given to Aria.loadTemplate.
              */
             disposeTemplate : function (div) {
-                var templateCtxt;
                 if (typeof(div) == "string") {
                     div = aria.utils.Dom.getElementById(div);
                 }

--- a/src/aria/core/transport/JsonP.js
+++ b/src/aria/core/transport/JsonP.js
@@ -119,7 +119,7 @@ Aria.classDefinition({
          * @protected
          */
         _onJsonPLoad : function (request, callback, json) {
-            var reqId = request.id;
+            // var reqId = request.id;
 
             delete this[request.evalCb];
 

--- a/src/aria/embed/controllers/MapController.js
+++ b/src/aria/embed/controllers/MapController.js
@@ -90,7 +90,7 @@
              */
             _createMap : function (container, cfg) {
                 var createMapConfig = aria.utils.Json.copy(cfg);
-                var provider = createMapConfig.provider;
+                // var provider = createMapConfig.provider;
                 delete createMapConfig.loadingIndicator;
                 var domElement = Aria.$window.document.createElement("div");
                 createMapConfig.domElement = domElement;

--- a/src/aria/jsunit/RobotJavaApplet.js
+++ b/src/aria/jsunit/RobotJavaApplet.js
@@ -260,7 +260,8 @@ Aria.classDefinition({
                 // Resolve the url depending on the base tag
                 var baseTags = document.getElementsByTagName('head')[0].getElementsByTagName("base");
                 if (baseTags && baseTags[0] && !this.absoluteUrlRegExp.test(jnlp)) {
-                    var baseUrl = baseTags[0].getAttribute("href").replace(/[^\/.]+\.[^\/.]+$/, "").replace(/\/$/, "") + "/";
+                    var baseUrl = baseTags[0].getAttribute("href").replace(/[^\/.]+\.[^\/.]+$/, "").replace(/\/$/, "")
+                            + "/";
                     jnlp = baseUrl + jnlp;
                 }
 
@@ -340,7 +341,7 @@ Aria.classDefinition({
         _updateAppletPosition : function (cb) {
             // keep the applet at position 0,0 (even when the window is scrolled)
             var applet = this.applet;
-            var document = applet.ownerDocument;
+            // var document = applet.ownerDocument;
             var scrollPos = aria.utils.Dom._getDocumentScroll();
             applet.style.left = scrollPos.scrollLeft + "px";
             applet.style.top = scrollPos.scrollTop + "px";

--- a/src/aria/jsunit/SonarReport.js
+++ b/src/aria/jsunit/SonarReport.js
@@ -76,7 +76,7 @@ Aria.classDefinition({
 
             var subTests = this.__getTestCaseSubTests(testCase);
 
-            var errors = testCase.getErrors();
+            // var errors = testCase.getErrors();
             reportBuffer.push(["<testsuite", "name='" + this.__getTestSuiteName(testCase) + "'",
                     "errors='" + testCase.getExecutionErrors().length + "'",
                     "failures='" + testCase.getFailures().length + "'", "tests='" + subTests.length + "'",

--- a/src/aria/jsunit/SynEvents.js
+++ b/src/aria/jsunit/SynEvents.js
@@ -93,7 +93,7 @@ Aria.classDefinition({
                 this.$callback(args.cb);
             } else {
                 var callParams = array[curIdx];
-                var cb = args.curIdx++;
+                args.curIdx++;
                 if (!aria.utils.Type.isArray(callParams)) {
                     this.$logError("Not an array");
                     return;

--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -403,7 +403,7 @@ Aria.classDefinition({
             if (recursive && !oElm) {
                 var subTplCtxts = [];
                 this.__retrieveDirectSubTemplates(tplCtxt, subTplCtxts);
-                var content = tplCtxt._mainSection._content;
+                // var content = tplCtxt._mainSection._content;
                 for (var i = 0, sz = subTplCtxts.length; i < sz; i++) {
                     oElm = this.getElementById(id, true, subTplCtxts[i], domUtility);
                     if (oElm) {
@@ -682,8 +682,8 @@ Aria.classDefinition({
          * @private
          */
         __afterType : function () {
-            var id = arguments[1][0], text = arguments[1][1], callback = arguments[1][2], blur = arguments[1][3];
-
+            var id = arguments[1][0], callback = arguments[1][2], blur = arguments[1][3];
+            // text = arguments[1][1]
             if (blur === false) {
                 this.$callback(callback);
             } else {
@@ -827,7 +827,8 @@ Aria.classDefinition({
                 },
                 onerror : {
                     fn : function (args) {
-                        // FIXME Doing this because onerror is not an aria.core.CfgBean.Callback so I can't use apply:true
+                        // FIXME Doing this because onerror is not an aria.core.CfgBean.Callback so I can't use
+                        // apply:true
                         this._iframeLoadError(args, "onerror callback of Aria.load(aria.jsunit.TemplateTestCase)");
                     },
                     scope : this,

--- a/src/aria/jsunit/TestSuite.js
+++ b/src/aria/jsunit/TestSuite.js
@@ -389,7 +389,8 @@ Aria.classDefinition({
          * @param {Object} params
          */
         __onDownloadTaskError : function (args) {
-            var task = args.task, test = args.test, sequencer = args.sequencer;
+            var test = args.test;
+            // var task = args.task, sequencer = args.sequencer;
 
             var errorMessage = "Loading of " + test.classpath + " failed";
 

--- a/src/aria/jsunit/TestWrapper.js
+++ b/src/aria/jsunit/TestWrapper.js
@@ -94,7 +94,7 @@ Aria.classDefinition({
          */
         _loadTestComplete : function () {
             var Aria = this._subWindow.Aria;
-            var aria = this._subWindow.aria;
+            // var aria = this._subWindow.aria;
             this._testInstance = Aria.getClassInstance(this.$classpath);
             this._testInstance.$on({
                 '*' : this._testEvent,

--- a/src/aria/jsunit/TestacularReport.js
+++ b/src/aria/jsunit/TestacularReport.js
@@ -59,7 +59,7 @@ Aria.classDefinition({
         _onChange : function (evt) {
             var changeType = evt.changeType;
             var testEngine = this._testEngine;
-            var testacular = this._testacular;
+            // var testacular = this._testacular;
             var currentTest = testEngine.getCurrentTest();
 
             // immediately report any failures or errors

--- a/src/aria/jsunit/UITestCase.js
+++ b/src/aria/jsunit/UITestCase.js
@@ -80,45 +80,6 @@ Aria.classDefinition({
          */
         getUITestResult : function () {
             return this.screenCapture.getResponse();
-        },
-
-        /**
-         * Captures the header. Obsolete
-         * @private
-         * @deprecated
-         */
-        __captureHeader : function () {
-            this.screenCapture.capture("HomePage_Header", {
-                x : 0,
-                y : 0,
-                width : 1280,
-                height : 65,
-                threshold : 0
-            }, this.responseCallbackMethod, this);
-        },
-
-        /**
-         * Captures the menu. Obsolete
-         * @private
-         * @deprecated
-         */
-        __captureMenu : function () {
-            this.screenCapture.capture("HomePage_Menu", {
-                x : 0,
-                y : 0,
-                width : 320,
-                height : 500,
-                threshold : 0
-            }, this.responseCallbackMethod, this);
-        },
-
-        /**
-         * Obsolete
-         * @deprecated
-         */
-        responseCallbackMethod : function () {
-            var result = this.screenCapture.getResponse(this.responseCallbackMethod, this);
-            // alert('responseCallbackMethod CODE:'+result.code+ " REASON:"+result.reason);
         }
     }
 });

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -415,8 +415,9 @@ Aria.classDefinition({
          */
         _onresponse : function (res, args) {
             // callback args preparation
-            var cb = args.cb, requestObject = args.requestObject, actionQueuing = args.actionQueuing;
-            var id = args.id, session = args.session, requestHandler = args.requestHandler, senderObject = args.senderObject;
+            var requestObject = args.requestObject, actionQueuing = args.actionQueuing;
+            var id = args.id, senderObject = args.senderObject;
+            // var cb = args.cb, session = args.session, requestHandler = args.requestHandler
 
             // starts right now for next item in action queuing
             if (actionQueuing) {
@@ -450,8 +451,7 @@ Aria.classDefinition({
          * @protected
          */
         _processOnResponse : function (args) {
-
-            var cb = args.cb;
+            // var cb = args.cb;
             var res = args.res;
 
             var handler = args.requestHandler;

--- a/src/aria/pageEngine/utils/SiteConfigHelper.js
+++ b/src/aria/pageEngine/utils/SiteConfigHelper.js
@@ -117,7 +117,7 @@ Aria.classDefinition({
         },
 
         disposeContentProcessorsInstances : function () {
-            var processors = {}, typeUtils = aria.utils.Type;
+            var typeUtils = aria.utils.Type;
             var instances = this._contentProcessorsInstances;
             for (var cp in instances) {
                 if (instances.hasOwnProperty(cp)) {

--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -964,7 +964,7 @@ Aria.classDefinition({
             // section in DOM");
             aria.utils.Dom.replaceHTML(this.domElement, section.html);
 
-            var sectionDomElement = this.domElement.firstChild;
+            // var sectionDomElement = this.domElement.firstChild;
 
             // Maybe the initWidget should be done after displaying the popup ?
             section.initWidgets();

--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -407,8 +407,6 @@
                 domEvent.target;
 
                 // Close first popup on the stack that can be closed
-                var scrollPrevented = false;
-                var popupsToClose = [];
                 for (var i = this.openedPopups.length - 1; i >= 0; i--) {
                     var popup = /** @type aria.popups.Popup */
                     this.openedPopups[i];

--- a/src/aria/resources/handlers/LCResourcesHandler.js
+++ b/src/aria/resources/handlers/LCResourcesHandler.js
@@ -133,7 +133,7 @@
                     var codeSuggestions = [], labelSuggestions = [], labelSuggestionsMultiWord = [];
                     var nbSuggestions = this._suggestions.length, textEntryLength = textEntry.length;
                     var multiWord = this._labelMatchAtWordBoundaries;
-                    var returnedSuggestion, index, suggestion;
+                    var index, suggestion;
 
                     for (index = 0; index < nbSuggestions; index++) {
                         suggestion = this._suggestions[index];

--- a/src/aria/templates/CSSClassGenerator.js
+++ b/src/aria/templates/CSSClassGenerator.js
@@ -47,7 +47,7 @@ Aria.classDefinition({
          * @protected
          */
         _writeClassInit : function (out) {
-            var tplParam = out.templateParam;
+            // var tplParam = out.templateParam;
             out.enterBlock("classInit");
             this._writeMapInheritance(out, "__$csslibs", out.templateParam.$csslibs, "{}");
             this._writeValueInheritance(out, "__$prefix", out.templateParam.$prefix, "true");

--- a/src/aria/templates/CSSMgr.js
+++ b/src/aria/templates/CSSMgr.js
@@ -356,7 +356,6 @@ Aria.classDefinition({
 
             // Do something only if this CSS class is not yet loaded
             var usage = this.__cssUsage[cssClasspath];
-            var styleTagToUpdate = [];
             if (usage && usage.length) {
                 usage.push(tplClasspath);
                 this.__pathsLoaded.push(cssClasspath);
@@ -528,7 +527,7 @@ Aria.classDefinition({
             }
 
             var sorted = this.__sortPaths();
-            var loaded = this.__textLoaded;
+            // var loaded = this.__textLoaded;
             var totalSelectors = 0;
             var styleBuilders = {};
             var utilsArray = aria.utils.Array;

--- a/src/aria/templates/ModuleCtrlFactory.js
+++ b/src/aria/templates/ModuleCtrlFactory.js
@@ -510,7 +510,6 @@
             toBeLoaded : subModulesDescArrayLength,
             customModules : customModules
         };
-        var subRecursionCheck = null;
         var typeUtils = aria.utils.Type;
         for (var i = 0; i < subModulesDescArrayLength; i++) {
             var subModuleDesc = subModulesDescArray[i];

--- a/src/aria/templates/NavigationManager.js
+++ b/src/aria/templates/NavigationManager.js
@@ -106,7 +106,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} event
          */
         handleNavigation : function (keyMap, tableNav, event, keyMapOnly) {
-            var done;
             if (event.type == "keyup" || event.type == "keydown") {
                 // handle table navigation if not already done
                 if (!event[this._tableNavMarker] && event.type == "keydown") {

--- a/src/aria/templates/RefreshManager.js
+++ b/src/aria/templates/RefreshManager.js
@@ -106,8 +106,8 @@ Aria.classDefinition({
 
         /**
          * Queue a refresh. It'll be execute on resume.
-         * @param {aria.core.CfgBeans:Callback} cb A callback to aria.templates.TemplateCtxt.$refresh (in the case of a template
-         * or section refresh) or to aria.widgets.Widget._notifyDataChangeCB in the case of a Widget refresh
+         * @param {aria.core.CfgBeans:Callback} cb A callback to aria.templates.TemplateCtxt.$refresh (in the case of a
+         * template or section refresh) or to aria.widgets.Widget._notifyDataChangeCB in the case of a Widget refresh
          * @param {Object} element A TemplateContext, in the case of a Template or Section refresh, or a Widget in the
          * case of a widget refresh
          */
@@ -131,8 +131,8 @@ Aria.classDefinition({
         },
 
         /**
-         * Internal function to execute callbacks in the queue. It is different from JsObject.$callback
-         * because the order of parameters is different if the scope is a Widget
+         * Internal function to execute callbacks in the queue. It is different from JsObject.$callback because the
+         * order of parameters is different if the scope is a Widget
          * @param {aria.core.CfgBeans:Callback} cb Callback to be executed
          * @private
          */
@@ -194,7 +194,7 @@ Aria.classDefinition({
             this.updateHierarchies();
 
             this._updatedNodes.length = 0;
-            var hierarchiesLength = this._hierarchies.length, freeCallbacks = [];
+            var hierarchiesLength = this._hierarchies.length;
 
             // 2-color the tree
             for (var rootIdx = 0; rootIdx < hierarchiesLength; rootIdx++) {
@@ -413,7 +413,6 @@ Aria.classDefinition({
          * @private
          */
         _fillNode : function (node) {
-            var content = [];
             var nodeEntry = {
                 type : null,
                 elem : node,
@@ -475,7 +474,7 @@ Aria.classDefinition({
             } else if (node.idMap != null) {
                 // 3-------it's a section
                 nodeEntry.type = "section";
-                var sectionContent = node._content;
+                // var sectionContent = node._content;
                 this._addContent(nodeEntry, node._content);
             }
 

--- a/src/aria/templates/Section.js
+++ b/src/aria/templates/Section.js
@@ -43,7 +43,7 @@
          * @param {aria.templates.CfgBeans:SectionCfg} configuration of this section (id, type, ...).
          */
         $constructor : function (tplCtxt, cfg, options) {
-            var binding, bindings, id, type, processing;
+            var binding, bindings, id, type;
 
             /**
              * Array of objects which are either a section (recognizable through its _type property = TYPE_SECTION) or

--- a/src/aria/templates/TmlClassGenerator.js
+++ b/src/aria/templates/TmlClassGenerator.js
@@ -60,7 +60,7 @@ Aria.classDefinition({
          * @protected
          */
         _writeClassInit : function (out) {
-            var tplParam = out.templateParam;
+            // var tplParam = out.templateParam;
             out.enterBlock("classInit");
             this._writeMapInheritance(out, "__$macrolibs", out.templateParam.$macrolibs, "{}");
             out.leaveBlock();

--- a/src/aria/templates/TxtClassGenerator.js
+++ b/src/aria/templates/TxtClassGenerator.js
@@ -71,7 +71,7 @@ Aria.classDefinition({
          * @protected
          */
         _writeClassInit : function (out) {
-            var tplParam = out.templateParam;
+            // var tplParam = out.templateParam;
             out.enterBlock("classInit");
             out.writeln(out.templateParam.$classpath, ".processTextTemplate = aria.templates.TextTemplate.processTextTemplate;");
             out.leaveBlock();

--- a/src/aria/tester/runner/view/popup/report/ReportScript.js
+++ b/src/aria/tester/runner/view/popup/report/ReportScript.js
@@ -23,7 +23,6 @@ Aria.tplScriptDefinition({
         getTestsWithErrors : function () {
             var __testUtils = aria.tester.runner.utils.TestUtils;
             var rootSuite = this.data.campaign.testsTree[0];
-            var testInstance = null;
             var failedTests = [];
             var subTests = [];
 

--- a/src/aria/tester/runner/view/report/ReportScript.js
+++ b/src/aria/tester/runner/view/report/ReportScript.js
@@ -142,7 +142,6 @@ Aria.tplScriptDefinition({
         },
 
         formatTestInfo : function (testCase) {
-            var __testUtils = aria.tester.runner.utils.TestUtils;
             var assertCount = testCase.instance._totalAssertCount;
             var assertReport = assertCount + " asserts";
 

--- a/src/aria/tools/inspector/InspectorModule.js
+++ b/src/aria/tools/inspector/InspectorModule.js
@@ -249,7 +249,7 @@ Aria.classDefinition({
                 var moduleCtrlFactory = this.bridge.getAriaPackage().templates.ModuleCtrlFactory;
                 this.$assert(190, !!templateCtxt);
                 this.$assert(191, !!moduleCtrlFactory);
-                var data = templateCtxt.data;
+                // var data = templateCtxt.data;
                 var moduleCtrl = templateCtxt.moduleCtrl;
 
                 if (moduleCtrl) {
@@ -375,7 +375,7 @@ Aria.classDefinition({
             // replace in this scope Aria and aria
             var oSelf = this;
             var doIt = function () {
-                var Aria = oSelf.bridge.getAria(), aria = oSelf.bridge.getAriaPackage();
+                // var Aria = oSelf.bridge.getAria(), aria = oSelf.bridge.getAriaPackage();
 
                 // ... and call for reload
                 templateCtxt.$reload(tplSource, {

--- a/src/aria/utils/Bridge.js
+++ b/src/aria/utils/Bridge.js
@@ -217,7 +217,7 @@ Aria.classDefinition({
         moduleStart : function () {
 
             // start working in subwindow
-            var Aria = this._subWindow.Aria, aria = this._subWindow.aria;
+            var Aria = this._subWindow.Aria; // , aria = this._subWindow.aria;
 
             clearInterval(this._bridgeAttachedInterval);
 
@@ -247,7 +247,8 @@ Aria.classDefinition({
         _templatesReady : function () {
 
             // continue working in subwindow
-            var Aria = this._subWindow.Aria, aria = this._subWindow.aria;
+            // var Aria = this._subWindow.Aria;
+            var aria = this._subWindow.aria;
 
             // creates module instance first to be able to dispose it when window close
             aria.templates.ModuleCtrlFactory.createModuleCtrl({
@@ -270,7 +271,7 @@ Aria.classDefinition({
         _moduleLoaded : function (moduleCtrlObject) {
 
             // finish working in subwindow
-            var Aria = this._subWindow.Aria, aria = this._subWindow.aria;
+            var Aria = this._subWindow.Aria; // , aria = this._subWindow.aria;
             var moduleCtrl = moduleCtrlObject.moduleCtrlPrivate;
             Aria.loadTemplate({
                 classpath : this._config.displayClasspath,

--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -40,7 +40,7 @@ Aria.classDefinition({
          */
         this._environment = aria.utils.environment.Date;
 
-        var res = this.dateRes, env = this._environment, utilString = aria.utils.String, utilRes = this.res;
+        var res = this.dateRes, utilString = aria.utils.String, utilRes = this.res;
 
         /**
          * IATA Months for interpretation
@@ -1442,7 +1442,8 @@ Aria.classDefinition({
         /**
          * Format a date from a given pattern
          * @param {Date} date
-         * @param {String} pattern. See http://www.ariatemplates.com/usermanual/latest/localization_and_resources#Date_and_Time
+         * @param {String} pattern. See
+         * http://www.ariatemplates.com/usermanual/latest/localization_and_resources#Date_and_Time
          * @param {Boolean} utcTime if true, display UTC date/time instead of local
          * @return {String}
          */
@@ -1472,7 +1473,7 @@ Aria.classDefinition({
          */
         _getFormatFunction : function (pattern) {
 
-            var workPattern = pattern, currentChar, previousChar, inLitteral, litteral = [], quoteJustInserted = false, patternOccurency = 0, fnParts = [], patternFn, utilType = aria.utils.Type, formatFunction;
+            var workPattern = pattern, currentChar, previousChar, inLitteral, litteral = [], quoteJustInserted = false, patternOccurency = 0, fnParts = [], formatFunction;
 
             // retrieve from cache
             if (this._formatCache[pattern]) {

--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -471,7 +471,7 @@ Aria.classDefinition({
                 this.__stackCache = {};
             }
 
-            var depth = this.depth, stack = [], cacheStack, expandoValue, target, widget, bubble, callbackDef;
+            var depth = this.depth, stack = [], cacheStack, expandoValue, target;
             var stopper = Aria.$window.document.body;
 
             evt = this.__wrapEvent(evt);
@@ -508,7 +508,7 @@ Aria.classDefinition({
                 depth--;
             }
 
-            var utilsArray = aria.utils.Array, callback, delegateConfig;
+            var callback, delegateConfig;
 
             // will be used to track changes
             var nested = false;

--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1063,7 +1063,7 @@ Aria.classDefinition({
         scrollIntoView : function (element, alignTop) {
             var document = element.ownerDocument;
             var origin = element, originRect = origin.getBoundingClientRect();
-            var parent, hasScroll = false, docElementOk = false;
+            var hasScroll = false;
             var documentScroll = this.getDocumentScrollElement(document);
 
             while (element) {

--- a/src/aria/utils/Event.js
+++ b/src/aria/utils/Event.js
@@ -376,7 +376,7 @@
              * @return {Boolean} true if the unbind was successful, false otherwise.
              */
             removeListener : function (element, event, callback) {
-                var i, len, li;
+                var i, li;
 
                 if ('mousewheel' == event) {
                     if (this.UA.isIE) {

--- a/src/aria/utils/FrameATLoader.js
+++ b/src/aria/utils/FrameATLoader.js
@@ -181,7 +181,6 @@ Aria.classDefinition({
          */
         _loadATInFrameCb4 : function (res, args) {
             var window = args.frame.contentWindow || args.frame;
-            var document = window.document;
             window.Aria.rootFolderPath = Aria.rootFolderPath;
             var rootMap = window.aria.utils.Json.copy(aria.core.DownloadMgr._rootMap);
             window.aria.core.DownloadMgr.updateRootMap(rootMap);

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -216,7 +216,7 @@
             // mark this node has being visited
             node[jsonUtils.TEMP_REC_MARKER] = true;
 
-            for (var index = 0, parentDesc, parentListener; parentDesc = parents[index]; index++) {
+            for (var index = 0, parentDesc; parentDesc = parents[index]; index++) {
                 listeners = __retrieveListeners(parentDesc.parent, parentDesc.property, true, listeners);
             }
             // at the end, clean recursive markup (only first call will have recursive set to null)
@@ -286,30 +286,6 @@
             change.dataHolder = container;
             change.dataName = property;
             __callListeners(listeners, change, listenerToExclude);
-        }
-    };
-
-    /**
-     * Copy for an element in the object / array
-     * @private
-     * @param {Object} elem
-     * @param {Object} target
-     * @param {String} key
-     * @param {Boolean} rec
-     * @param {Boolean} keepValidators
-     */
-    var __elemCopy = function (elem, target, key, rec, keepValidators) {
-        if (typeUtils.isObject(elem) || typeUtils.isArray(elem)) {
-            if (rec) {
-                target[key] = aria.utils.Json.copy(elem, true, null, keepValidators);
-            } else {
-                target[key] = elem;
-            }
-        } else if (typeUtils.isDate(elem)) {
-            target[key] = new Date(elem.getTime());
-        } else {
-            // may be a string, number, boolean, or something else: function ...
-            target[key] = elem;
         }
     };
 
@@ -746,7 +722,7 @@
              */
             copy : function (obj, rec, filters, keepMeta) {
                 rec = (rec !== false);
-                var container = false, res, elem;
+                var container = false, res;
                 if (typeUtils.isArray(obj)) {
                     res = [];
                     container = true;
@@ -797,7 +773,6 @@
              */
             load : function (str, ctxt, errMsg) {
                 // TODO setup complete sandbox variables - e.g. through closure
-                var window = null, document = null, frames = null;
                 var res = null;
                 try {
                     str = ('' + str).replace(/^\s/, ''); // remove first spaces
@@ -807,7 +782,6 @@
                     if (!errMsg) {
                         errMsg = this.INVALID_JSON_CONTENT;
                     }
-                    var cp = 'unspecified';
                     if (ctxt && ctxt.$classpath) {
                         ctxt = ctxt.$classpath;
                     }

--- a/src/aria/utils/Mouse.js
+++ b/src/aria/utils/Mouse.js
@@ -366,7 +366,7 @@
                 this._dragStartPosition = null;
                 disconnectMouseEvents(this);
 
-                var element = this._activeDrag, event;
+                var element = this._activeDrag;
                 if (element) {
                     element.end();
                 }

--- a/src/aria/utils/Path.js
+++ b/src/aria/utils/Path.js
@@ -52,7 +52,7 @@ Aria.classDefinition({
                 return;
             }
 
-            var container = inside, param, content, next;
+            var container = inside, param, next;
             for (var i = 0, len = path.length; i < len; i += 1) {
                 param = path[i];
 
@@ -212,7 +212,7 @@ Aria.classDefinition({
                 return;
             }
 
-            var obj = container, param, content;
+            var obj = container, param;
             for (var i = 0, len = path.length; i < len; i += 1) {
                 param = path[i];
 

--- a/src/aria/utils/ProfilingDisplayScript.js
+++ b/src/aria/utils/ProfilingDisplayScript.js
@@ -57,7 +57,7 @@ Aria.tplScriptDefinition({
         },
 
         isTimeRangeListVisible : function (list) {
-            for (var i = 1, l = list.length; i < list.length; i++) {
+            for (var i = 1, l = list.length; i < l; i++) {
                 if (this.isTimeRangeVisible(list[i].start, list[i].length)) {
                     return true;
                 }

--- a/src/aria/utils/SynEvents.js
+++ b/src/aria/utils/SynEvents.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* jshint unused : false */
 
 (function () {
     var _isInDom = function (element) {

--- a/src/aria/utils/css/Units.js
+++ b/src/aria/utils/css/Units.js
@@ -113,13 +113,13 @@
 
             __px2Em : function (value, elem, property) {
                 var el = (property == "fontSize") ? elem.parentNode : elem;
-                var fontSize = this.__getFontSizeInPixels(elem);
+                var fontSize = this.__getFontSizeInPixels(el);
                 return value / fontSize;
             },
 
             __em2Px : function (value, elem, property) {
                 var el = (property == "fontSize") ? elem.parentNode : elem;
-                var fontSize = this.__getFontSizeInPixels(elem);
+                var fontSize = this.__getFontSizeInPixels(el);
                 return value * fontSize;
             },
 
@@ -263,7 +263,6 @@
                 // in contrary to W3C browsers which normalize that to pixels in getComputedStyle. However,
                 // `offsetWidth` is always unit-less, which means pixels.
 
-                var cs = element.currentStyle;
                 var left = "Left", right = "Right", top = "Top", bottom = "Bottom";
                 if (property == "width") {
                     var padLeft = this.__getPadding(element, left);

--- a/src/aria/utils/json/JsonSerializer.js
+++ b/src/aria/utils/json/JsonSerializer.js
@@ -39,10 +39,8 @@ Aria.classDefinition({
                     return this.valueOf();
                 };
 
-                var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g, escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g, gap, indent, meta = { // table
-                    // of
-                    // character
-                    // substitutions
+                var escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g, gap, indent, meta = {
+                    // table of character substitutions
                     '\b' : '\\b',
                     '\t' : '\\t',
                     '\n' : '\\n',
@@ -261,7 +259,6 @@ Aria.classDefinition({
                     var dateToJSON = Date.prototype.toJSON;
                     var regexpToJSON = RegExp.prototype.toJSON;
                     var functionToJSON = Function.prototype.toJSON;
-                    var self = this;
                     try {
                         Date.prototype.toJSON = function () {
                             return aria.utils.Date.format(this, options.serializedDatePattern);

--- a/src/aria/utils/overlay/CloneOverlay.js
+++ b/src/aria/utils/overlay/CloneOverlay.js
@@ -53,9 +53,6 @@ Aria.classDefinition({
          * @override
          */
         _createOverlay : function (params) {
-
-            var overlay = this.$Overlay._createOverlay(params);
-
             var clone = this.__clone;
             var opacity = ("opacity" in params) ? params.opacity : 0.5;
             aria.utils.Dom.setOpacity(clone, opacity);

--- a/src/aria/widgets/Text.js
+++ b/src/aria/widgets/Text.js
@@ -78,7 +78,6 @@ Aria.classDefinition({
          * @protected
          */
         _widgetMarkup : function (out) {
-            var cfg = this._cfg;
             var textContent = this._cfg.text;
             // String cast
             if (textContent !== null) {

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -187,7 +187,7 @@ Aria.classDefinition({
          * @param {Array} bindings List of bindings
          */
         _initBindings : function (bindings) {
-            var bnd, inside, to, bindValue, transform, jsonUtils = aria.utils.Json;
+            var bnd, inside, to, bindValue, transform;
             for (var bindedProperty in bindings) {
                 if (bindings.hasOwnProperty(bindedProperty)) {
                     bnd = bindings[bindedProperty];

--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -151,7 +151,7 @@ Aria.classDefinition({
 
             if (actingDom) {
                 this._actingDom = actingDom;
-                var domElt = this.getDom();
+                // var domElt = this.getDom();
 
                 this._initializeFocusableElement();
 

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -239,7 +239,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} domEvt
          */
         _dom_onfocus : function (domEvt) {
-            var cfg = this._cfg;
             this._hasFocus = true;
             this._updateState();
         },
@@ -250,7 +249,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} domEvt
          */
         _dom_onblur : function (domEvt) {
-            var cfg = this._cfg;
             this._hasFocus = false;
             this._updateState();
         },

--- a/src/aria/widgets/controllers/MultiSelectController.js
+++ b/src/aria/widgets/controllers/MultiSelectController.js
@@ -224,7 +224,6 @@ Aria.classDefinition({
         checkValue : function (value) {
             var report = new aria.widgets.controllers.reports.DropDownControllerReport();
             var dataModel = this._dataModel;
-            var options = this._options;
             if (value === null) {
                 report.ok = true;
                 dataModel.value = null;

--- a/src/aria/widgets/errorlist/ErrorListTemplateScript.js
+++ b/src/aria/widgets/errorlist/ErrorListTemplateScript.js
@@ -75,7 +75,7 @@ Aria.tplScriptDefinition({
 
             if (evt.name == "messagesChanged") {
                 if (evt.domRef) {
-                    var domConfig = aria.utils.Dom.scrollIntoView(evt.domRef);
+                    aria.utils.Dom.scrollIntoView(evt.domRef);
                 }
                 this.$refresh();
             }

--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -178,7 +178,7 @@ Aria.classDefinition({
          */
         _initInputMarkup : function (elt) {
             this._initializeFocusableElement();
-            var focusElt = this._getFocusableElement();
+            this._getFocusableElement();
             this._label = null;
             var labels = this.getDom().getElementsByTagName("label");
             if (labels.length > 0) {

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -180,7 +180,7 @@ Aria.classDefinition({
          * @protected
          */
         _renderDropdownContent : function (out) {
-            var cfg = this._cfg, skinObj = this._skinObj;
+            var cfg = this._cfg;
             var wrapperDiv = cfg.popupWidth && cfg.popupWidth > -1 && aria.core.Browser.isIE6;
             if (wrapperDiv) {
                 out.write('<div style="width: ' + cfg.popupWidth + 'px;">');

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -189,7 +189,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} event
          */
         _dom_onkeydown : function (event) {
-            var cfg = this._cfg;
             if (event.isSpecialKey) {
                 this._handleKey(event);
             }
@@ -201,7 +200,6 @@ Aria.classDefinition({
          * @param {aria.DomEvent} event
          */
         _dom_onkeypress : function (event) {
-            var cfg = this._cfg;
             if (!event.isSpecialKey) {
                 this._handleKey(event);
             }

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -900,7 +900,7 @@ Aria.classDefinition({
                 return;
             }
             if (!this._keepFocus) {
-                var cfg = this._cfg, htc = this._skinObj.helpText;
+                var cfg = this._cfg; // , htc = this._skinObj.helpText;
                 this._hasFocus = false;
                 // reinitialize for next time (autoselect feature)
                 this._firstFocus = true;

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -147,10 +147,9 @@ Aria.classDefinition({
          * DOM callback function called on key press
          */
         _dom_onkeypress : function (event) {
-            var cfg = this._cfg;
             if (this._subTplModuleCtrl) {
                 if (!event.isSpecialKey && event.charCode != event.KC_SPACE) {
-                    var returns = this.sendKey(event.charCode, event.keyCode);
+                    this.sendKey(event.charCode, event.keyCode);
                 }
             }
         },
@@ -159,11 +158,10 @@ Aria.classDefinition({
          * DOM callback function called on key down
          */
         _dom_onkeydown : function (event) {
-            var cfg = this._cfg;
             // event.cancelBubble = true;
             if (this._subTplModuleCtrl) {
                 if (event.isSpecialKey) {
-                    var returns = this.sendKey(event.charCode, event.keyCode);
+                    this.sendKey(event.charCode, event.keyCode);
                 }
             }
             if (event.keyCode != event.KC_TAB) {
@@ -196,7 +194,7 @@ Aria.classDefinition({
             // by each of the updates below that needs a refresh
             var refreshNeeded = false;
             var moduleCtrl = this._subTplModuleCtrl;
-            var data = this._subTplCtxt.data;
+            // var data = this._subTplCtxt.data;
             if (key == "selectedValues") {
                 moduleCtrl.setSelectedValues(newValue);
             } else if (key == "selectedIndex") {

--- a/src/aria/widgets/frames/SimpleFrame.js
+++ b/src/aria/widgets/frames/SimpleFrame.js
@@ -43,8 +43,8 @@ Aria.classDefinition({
          */
         writeMarkupBegin : function (out) {
             var cfg = this._cfg;
-            var cssPrefix = this._cssPrefix;
-            var state = cfg.stateObject;
+            // var cssPrefix = this._cssPrefix;
+            // var state = cfg.stateObject;
             var sizeInfo = {
                 style : cfg.block ? 'display:block;' : '',
                 className : "xSimpleFrame " + this._cssPrefix + "frame " + cfg.cssClass

--- a/src/aria/widgets/frames/SimpleHTMLFrame.js
+++ b/src/aria/widgets/frames/SimpleHTMLFrame.js
@@ -30,7 +30,7 @@ Aria.classDefinition({
          * @protected
          */
         _computeSize : function () {
-            var cfg = this._cfg, state = cfg.stateObject;
+            var cfg = this._cfg; // , state = cfg.stateObject;
             // The following line was removed (set as a comment) because the borderSize property was not passed by the
             // skinning system, and as a consequence the hard-coded default was always used.
             // var border = (state.borderSize > 0) ? (state.borderSize) * 2 : 4;

--- a/src/aria/widgets/frames/TableFrame.js
+++ b/src/aria/widgets/frames/TableFrame.js
@@ -91,7 +91,7 @@ Aria.classDefinition({
          * @param {aria.templates.MarkupWriter} out
          */
         writeMarkupBegin : function (out) {
-            var cfg = this._cfg, cssPrefix = this._cssPrefix, state = cfg.stateObject;
+            var cfg = this._cfg, cssPrefix = this._cssPrefix; // , state = cfg.stateObject;
             var frameContainerClass = (cfg.block !== true) ? ' ' : 'class="xBlock"';
             var sizeInfo = {
                 style : '',
@@ -119,7 +119,7 @@ Aria.classDefinition({
          * @param {aria.templates.MarkupWriter} out
          */
         writeMarkupEnd : function (out) {
-            var cfg = this._cfg, sclass = cfg.sclass, cssPrefix = this._cssPrefix;
+            var cfg = this._cfg, cssPrefix = this._cssPrefix; // sclass = cfg.sclass
             out.write(['</span></td>', '<td class="', cssPrefix, 'rs ', cssPrefix, 'bkgC"></td>', '</tr>', '<tr>',
                     '<td class="', cssPrefix, 'blc ', cssPrefix, 'bkgA"></td>', '<td class="', cssPrefix, 'bs ',
                     cssPrefix, 'bkgB">', this.__addFrameIcon(cfg, cssPrefix, 'bottom'), '</td>', '<td class="',

--- a/test/node/npm_start.js
+++ b/test/node/npm_start.js
@@ -14,7 +14,6 @@
  */
 
 var spawn = require("child_process").spawn;
-var exec = require('child_process').exec;
 var path = require("path");
 var assert = require("assert");
 var http = require("http");


### PR DESCRIPTION
Remove variables that are created but never used (in some cases, remove the variable entirely; in some case, just call the method without storing the result).

Add JSHint build-time check (for `src` files only) for declared but unused vars.

Also, fixes a minor issue that landed in
https://github.com/ariatemplates/ariatemplates/commit/107507a30d0407e46bcbf6dea3cf31ee28c43928#commitcomment-4166998

---

Code review note:
In some cases, instead of removing the lines, I've commented them out -- usually in case of storing locally `args.something.something`, perhaps this will be useful in the future to know of existence of some param. But I can remove that also.
