### PR TITLE
feat #745 enable `getComputedStyle` for IE9+

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -841,10 +841,10 @@ Aria.classDefinition({
          */
         getStyle : function (element, property) {
             var browser = aria.core.Browser;
-            if (browser.isIE) {
-                var isIE8orLess = browser.isIE8 || browser.isIE7 || browser.isIE6;
+            var isIE8orLess = browser.isIE8 || browser.isIE7 || browser.isIE6;
+            if (isIE8orLess) {
                 this.getStyle = function (element, property) {
-                    if (isIE8orLess && property == 'opacity') {// IE<=8 opacity uses filter
+                    if (property == 'opacity') {// IE<=8 opacity uses filter
                         var val = 100;
                         try { // will error if no DXImageTransform
                             val = element.filters['DXImageTransform.Microsoft.Alpha'].opacity;


### PR DESCRIPTION
I haven't tested this, but I hope this should be fine.
[CanIUse](http://caniuse.com/getcomputedstyle) doesn't report any issues with IE9/IE10 regarding this method.

I think we can postpone testing until the release testing.
