### PR TITLE
fix #749 enable VisualFocusTest in IE8

### DIFF
--- a/test/aria/templates/visualFocus/VisualFocusTestCase.js
+++ b/test/aria/templates/visualFocus/VisualFocusTestCase.js
@@ -110,7 +110,7 @@ Aria.classDefinition({
             }
         },
 
-        myVisualFocusTest : (aria.core.Browser.isIE6 || aria.core.Browser.isIE7 || aria.core.Browser.isIE8)
+        myVisualFocusTest : (aria.core.Browser.isIE7)
                 ? function () {
                     this.finishTest();
                 }


### PR DESCRIPTION
The test case is green in IE8, just mistakenly disabled. We don't run tests in IE6, hence removing that too.
