### PR TITLE
fix aria.utils.json.JsonSerializer wrongly escaped the keys in some cases

### DIFF
--- a/test/aria/utils/json/JsonSerializer.js
+++ b/test/aria/utils/json/JsonSerializer.js
@@ -439,6 +439,20 @@ Aria.classDefinition({
             };
             var result = this.jsonSerializer.serialize(testObj);
             this.assertJsonStringEquals(result, "{\"b\":1}");
+        },
+
+        /**
+         * Test some special cases
+         */
+        testSpecialCases : function () {
+            // Special chars in key
+            var testObj = {"/?\\": "test"};
+            var output = this.jsonSerializer.serialize(testObj, {
+                reversible : true,
+                keepMetadata : false
+            });
+            this.assertJsonEquals(testObj, this.jsonSerializer.parse(output));
         }
+
     }
 });


### PR DESCRIPTION
For example :

jsonSerializer.serialize({"\", "something"}, {reversible : true})

outputs : 

{"\", "something"} which is wrong.
