### PR TITLE
Display issues for the aria tester on IE10

### DIFF
--- a/src/aria/tester/runner/view/BaseCSS.tpl.css
+++ b/src/aria/tester/runner/view/BaseCSS.tpl.css
@@ -65,7 +65,7 @@
     {macro gradient(r, g, b, from, to)}
         {if aria.core.Browser.isFirefox}
             background-image: -moz-linear-gradient(top, {call rgb(r,g,b,from)/}, {call rgb(r,g,b,to)/});
-        {elseif aria.core.Browser.isIE9/}
+        {elseif aria.core.Browser.isIE && aria.core.Browser.version >=9 /}
             background-image: linear-gradient(top, {call rgb(r,g,b,from)/}, {call rgb(r,g,b,to)/});
         {elseif aria.core.Browser.isChrome/}
             background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from({call rgb(r,g,b,from)/}), to({call rgb(r,g,b,to)/}));
@@ -73,11 +73,11 @@
             background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from({call rgb(r,g,b,from)/}), to({call rgb(r,g,b,to)/}));
         {/if}
     {/macro}
-    
+
     {macro gradientH(r, g, b, from, to)}
         {if aria.core.Browser.isFirefox}
             background-image: -moz-linear-gradient(left, {call rgb(r,g,b,from)/}, {call rgb(r,g,b,to)/});
-        {elseif aria.core.Browser.isIE9/}
+        {elseif aria.core.Browser.isIE && aria.core.Browser.version >=9 /}
             background-image: linear-gradient(left, {call rgb(r,g,b,from)/}, {call rgb(r,g,b,to)/});
         {elseif (aria.core.Browser.isChrome || aria.core.Browser.isSafari)/}
             background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, from({call rgb(r,g,b,from)/}), to({call rgb(r,g,b,to)/}));
@@ -87,7 +87,7 @@
         {if aria.core.Browser.isFirefox}
             box-shadow : ${textContent};
             -moz-box-shadow : ${textContent};
-        {elseif aria.core.Browser.isIE9/}
+        {elseif aria.core.Browser.isIE && aria.core.Browser.version >=9 /}
             box-shadow : ${textContent};
         {elseif aria.core.Browser.isChrome/}
             -webkit-box-shadow : ${textContent};
@@ -95,12 +95,12 @@
             -webkit-box-shadow : ${textContent};
         {/if}
     {/macro}
-    
+
     {macro borderRadius(textContent)}
         {if aria.core.Browser.isFirefox}
             border-radius : ${textContent};
             -moz-border-radius : ${textContent};
-        {elseif aria.core.Browser.isIE9/}
+        {elseif aria.core.Browser.isIE && aria.core.Browser.version >=9 /}
             border-radius : ${textContent};
         {elseif aria.core.Browser.isChrome/}
             -webkit-border-radius : ${textContent};
@@ -108,7 +108,7 @@
             -webkit-border-radius : ${textContent};
         {/if}
     {/macro}
-    
+
     {macro rgb(r,g,b,mod)}rgb(${Math.min(Math.max(r+mod,0),255)}, ${Math.min(Math.max(g+mod,0),255)}, ${Math.min(Math.max(b+mod,0),255)}){/macro}
 
 {/CSSTemplate}

--- a/src/aria/tester/runner/view/popup/PopupCSS.tpl.css
+++ b/src/aria/tester/runner/view/popup/PopupCSS.tpl.css
@@ -26,7 +26,7 @@
         position : fixed;
         top:0px;
         left:0px;
-        {if (aria.core.Browser.isIE && !aria.core.Browser.isIE9)}
+        {if (aria.core.Browser.isIE && aria.core.Browser.version < 9)}
             height : 100%;
             width : 100%;
             background:rgb(0,0,0);
@@ -41,16 +41,16 @@
     .popup {
         top:50%;
         left:50%;
-        
+
         background:white;
         border: 1px Solid #ddd;
-        
+
         {call borderRadius("8px")/}
-        {call shadow("0px 0 4px rgba(0,0,0,0.6)")/} 
-        
+        {call shadow("0px 0 4px rgba(0,0,0,0.6)")/}
+
         z-index:12001;
     }
-    
+
     h1 {
         margin-top : 7px;
         margin-bottom : 5px;
@@ -60,7 +60,7 @@
         font-size : 25px;
         font-family : Verdana;
         font-weight : normal;
-        
+
     }
     .separator {
         margin-left : 19px;
@@ -68,21 +68,21 @@
         background: rgb(200,200,200);
         {call gradientH(255, 255, 255, -10, -40)/}
     }
-    
+
     {var failedColor = "rgb(245,70,70)"/}
     .content {
         margin-left : 19px;
         overflow-y : scroll;
         color : ${failedColor};
     }
-    
+
     .buttonContainer {
-        float : right;   
+        float : right;
         margin-bottom: 5px;
         margin-right: 10px;
         margin-top: 5px;
     }
-    
+
     .popupButton {
         float:left;
         padding-top : 2px;


### PR DESCRIPTION
Replacing:
  `aria.core.Browser.isIE9`
by
  `aria.core.Browser.isIE && aria.core.Browser.version >=9`
and
  `aria.core.Browser.isIE && !aria.core.Browser.isIE9`
by
  `aria.core.Browser.isIE && aria.core.Browser.version < 9`
in CSS templates of the aria tester.
