### PR TITLE
Fix #730 Validation errors in page engine instances

### DIFF
--- a/src/aria/pageEngine/utils/PageConfigHelper.js
+++ b/src/aria/pageEngine/utils/PageConfigHelper.js
@@ -20,9 +20,28 @@ Aria.classDefinition({
     $classpath : "aria.pageEngine.utils.PageConfigHelper",
     $dependencies : ["aria.pageEngine.utils.PageEngineUtils", "aria.utils.Type", "aria.utils.Array"],
     $constructor : function (pageConfig) {
+        /**
+         * Page definition
+         * @type aria.pageEngine.CfgBeans:PageDefinition
+         * @protected
+         */
         this._pageConfig = pageConfig;
+
+        /**
+         * Page Engine utilities
+         * @type aria.pageEngine.utils.PageEngineUtils
+         * @protected
+         */
         this._utils = aria.pageEngine.utils.PageEngineUtils;
-        this._utils.addKeyAsProperty(this._pageConfig.pageComposition.modules, "refpath");
+
+        /**
+         * Copy of the list of modules from the page definition
+         * @type aria.pageEngine.CfgBeans:PageComposition.modules
+         * @protected
+         */
+        this._pageModules = aria.utils.Json.copy(this._pageConfig.pageComposition.modules) || {};
+
+        this._utils.addKeyAsProperty(this._pageModules, "refpath");
     },
     $prototype : {
 
@@ -89,7 +108,7 @@ Aria.classDefinition({
          * @private
          */
         _addPlaceholderDependencies : function (placeholder, dependencies, lazy) {
-            var modules = this._pageConfig.pageComposition.modules || {}, refpath, moduleDesc, typeUtils = aria.utils.Type;
+            var modules = this._pageModules, refpath, moduleDesc, typeUtils = aria.utils.Type;
             if (!typeUtils.isObject(placeholder)) {
                 return;
             }
@@ -122,7 +141,7 @@ Aria.classDefinition({
          * @return {Array} Contains objects of type {aria.templates.ModuleCtrl.SubModuleDefinition}
          */
         getPageModulesDescriptions : function (refpaths) {
-            var modules = this._pageConfig.pageComposition.modules || {};
+            var modules = this._pageModules;
             var filteredMods = [], i, len, currentDesc;
             if (refpaths) {
                 for (i = 0, len = refpaths.length; i < len; i++) {

--- a/test/aria/pageEngine/utils/PageConfigHelperTest.js
+++ b/test/aria/pageEngine/utils/PageConfigHelperTest.js
@@ -70,11 +70,13 @@ Aria.classDefinition({
             var pgh = new aria.pageEngine.utils.PageConfigHelper(this.pageDefOne.pageDef);
             var modules = pgh.getPageModulesDescriptions();
             var refpaths = ["modOne", "modTwo", "mod.modthree", "modFour", "modFive"];
-            var testVar = true;
+            var testVar = true, testRefPathShouldBeMissing = true;
             for (var i = 0, len = refpaths.length; i < len; i++) {
                 testVar = testVar && (this._getModuleWithRefpath(modules, refpaths[i]).refpath == refpaths[i]);
+                testRefPathShouldBeMissing = testRefPathShouldBeMissing && (!this.pageDefOne.pageDef.pageComposition.modules[refpaths[i]].refpath);
             }
             this.assertTrue(testVar, "Module definitions have not been decorated with refpaths");
+            this.assertTrue(testRefPathShouldBeMissing, "Original Module definitions have been decorated with refpaths");
 
             pgh.$dispose();
         },


### PR DESCRIPTION
We are now using a copy of the modules object, and injecting the `refpath` into the copy, thus resolving the issue caused during validation of the original modules object when it did contain the injected `refpath`, now it no longer does.
