### PR TITLE
fix #759 EscapeOnModalAndNonModalTest fail in IE7

### DIFF
--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTemplate.tpl
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTemplate.tpl
@@ -22,7 +22,7 @@
 
         {foreach id inArray ids}
             {@aria:Dialog {
-                title : (data.modal[id_index] ? "modal" : "nonmodal"),
+                title : (id + ":" + (data.modal[id_index] ? "modal" : "nonmodal")),
                 contentMacro : {
                     id : id,
                     name : "dialogContent",

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
@@ -116,8 +116,8 @@ Aria.classDefinition({
 
         _assertFocus : function (id) {
             var field = this.getInputField(id);
-            this.assertEquals(field, aria.utils.Delegate.getFocus(), "Element with id " + id
-                    + " should be focused.");
+            var focused = Aria.$window.document.activeElement;
+            this.assertEquals(field, focused, "Element with id " + id + " should be focused.");
         }
     }
 });


### PR DESCRIPTION
Seems that `aria.utils.Delegate.getFocus()` sometimes doesn't track the focus properly in IE7, while it turns out that `document.activeElement` does the job well in all browsers.
