### PR TITLE
test.aria.widgets.icon.IconTest failing on IE10

### DIFF
--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -21,7 +21,6 @@ Aria.beanDefinitions({
     $description : "Definition of the JSON beans used to set application variables",
     $namespaces : {
         "json" : "aria.core.JsonTypes",
-        "dom" : "aria.utils.DomBeans",
         "animation" : "aria.utils.css.AnimationsBean"
     },
     $beans : {
@@ -185,22 +184,22 @@ Aria.beanDefinitions({
             $description : "Configuration object to describe the absolute positionning of the popup",
             $properties : {
                 "top" : {
-                    $type : "json:Integer",
+                    $type : "json:Float",
                     $description : "Top value of the AbsolutePosition object",
                     $default : null
                 },
                 "bottom" : {
-                    $type : "json:Integer",
+                    $type : "json:Float",
                     $description : "Bottom value of the AbsolutePosition object",
                     $default : null
                 },
                 "right" : {
-                    $type : "json:Integer",
+                    $type : "json:Float",
                     $description : "Right value of the AbsolutePosition object",
                     $default : null
                 },
                 "left" : {
-                    $type : "json:Integer",
+                    $type : "json:Float",
                     $description : "Left value of the AbsolutePosition object",
                     $default : null
                 }


### PR DESCRIPTION
This pull request fixes `test.aria.widgets.icon.IconTest` which started failing in d483056c6edf8064781d069101fdca40b874ac15 because the type of `absolutePosition.top` in the popup configuration changed from `json:Float` to `json:Integer` (when the config bean was moved from `aria.utils.DomBeans` to `aria.popups.Beans`).
This PR restores `json:Float` in `aria.popups.Beans.AbsolutePositionConfig`.
