### PR TITLE
Typo and parameter issue in error message in BindableWidget

### DIFF
--- a/src/aria/widgetLibs/BindableWidget.js
+++ b/src/aria/widgetLibs/BindableWidget.js
@@ -23,7 +23,7 @@ Aria.classDefinition({
     $classpath : "aria.widgetLibs.BindableWidget",
     $extends : "aria.widgetLibs.BaseWidget",
     $statics : {
-        INVALID_BEAN : "Invalid propety '%1' in widget's '%2' configuration."
+        INVALID_BEAN : "%1Invalid property '%2' in widget's '%3' configuration."
     },
     $dependencies : ["aria.utils.Json", "aria.utils.Type"],
     /**


### PR DESCRIPTION
This pull request fixes a typo and parameter issue in error message in `BindableWidget`.
