### PR TITLE
Fixing regression in debug tools: "reload with source" button no longer appears

### DIFF
--- a/src/aria/tools/inspector/TemplateInspectorScript.js
+++ b/src/aria/tools/inspector/TemplateInspectorScript.js
@@ -126,10 +126,7 @@ Aria.tplScriptDefinition({
             if (this.data.initialSource) {
                 aria.utils.Json.setValue(this.data, "initialSource", false);
                 this.$refresh({
-                    filterSection : "controls",
-                    macro : {
-                        name : "displayControls"
-                    }
+                    section : "controls"
                 });
             }
             this.data.tplSrcEdit = event.target.getValue();


### PR DESCRIPTION
This pull request fixes a regression introduced in Aria Templates 1.4.10 by commit 222411636510b08270641db78fd9a8463d078f8b: when typing in the text area in the debug tools to change the template, the "Reload with source" button no longer appears.
