### PR TITLE
Fixes #765 Now possible to set the option value to an empty string.

### DIFF
--- a/src/aria/html/Select.js
+++ b/src/aria/html/Select.js
@@ -86,7 +86,7 @@ Aria.classDefinition({
                             attributes : option.attributes,
                             // value is optional, so we set the default value to label(mandatory) if it's not
                             // defined
-                            value : option.value || option.label
+                            value : option.value == null ? option.label : option.value
                         };
                     }
 


### PR DESCRIPTION
The issue occurs when adding an empty string as an option value, previously the value would be set to be the same as the label, now with the fix below it is set to be the empty string value that was intended.
