### PR TITLE
fix #746 non existent skinClass configured for a widget now defaults correctly to 'std'

### DIFF
--- a/src/aria/widgets/AriaSkinInterface.js
+++ b/src/aria/widgets/AriaSkinInterface.js
@@ -286,6 +286,22 @@ Aria.classDefinition({
             }
 
             return rule.join("");
+        },
+
+        /**
+         * Returns if the given skinClass exists for the given widgetName.
+         * @param {String} widgetName name of the widget (in fact, the skinnable class, which may not correspond exactly
+         * to widgets)
+         * @param {String} skinClass
+         * @return {Boolean} indicator if the skinClass is defined and can be used
+         */
+        checkSkinClassExists : function (widgetName, skinClass) {
+
+            var skinClasses = this.getSkinClasses(widgetName);
+            if(skinClasses) {
+                return skinClasses[skinClass] !== undefined;
+            }
+            return false;
         }
     }
 });

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -115,6 +115,13 @@ Aria.classDefinition({
 
         this._cfgOk = aria.core.JsonValidator.validateCfg(this._cfgBean || this._cfgPackage + "." + this.$class + "Cfg", cfg);
 
+        //Check if the defined skinClass exists for this widget, if not set it to 'std'
+        if(this._skinnableClass) {
+            if(!aria.widgets.AriaSkinInterface.checkSkinClassExists(this._skinnableClass, cfg.sclass)) {
+                cfg.sclass = 'std';
+            }
+        }
+
         var bindings = cfg.bind;
         if (bindings) {
             this._initBindings(bindings);
@@ -181,6 +188,13 @@ Aria.classDefinition({
          * @type Boolean
          */
         _directInit : false,
+
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : null,
 
         /**
          * Initialize the binding description.

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -73,15 +73,6 @@ Aria.classDefinition({
          */
         this.currTarget = null;
 
-        if (!this._skinnableClass) {
-            /**
-             * Skinnable class to use for this widget.
-             * @type String
-             * @protected
-             */
-            this._skinnableClass = "Button";
-        }
-
         /**
          * Skin configutation for simpleHTML
          * @type Object
@@ -116,6 +107,12 @@ Aria.classDefinition({
         this.$ActionWidget.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Button",
 
         /**
          * Internal method to update the state of the widget

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -43,6 +43,13 @@ Aria.classDefinition({
     },
     $prototype : {
         /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Link",
+
+        /**
          * Generate the internal widget markup
          * @param {aria.templates.MarkupWriter} out Markup Writer
          * @protected

--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -33,7 +33,7 @@ Aria.classDefinition({
     $constructor : function (cfg, ctxt, lineNumber) {
         this.$ActionWidget.constructor.apply(this, arguments);
 
-        this._setSkinObj("SortIndicator");
+        this._setSkinObj(this._skinnableClass);
         this._setInputType();
         this._setIconPrefix();
 
@@ -140,6 +140,13 @@ Aria.classDefinition({
          * @type Boolean
          */
         _customTabIndexProvided : true,
+
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "SortIndicator",
 
         /**
          * Called when a new instance is initialized

--- a/src/aria/widgets/calendar/Calendar.js
+++ b/src/aria/widgets/calendar/Calendar.js
@@ -27,7 +27,7 @@ Aria.classDefinition({
     $constructor : function (cfg, ctxt) {
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
         var sclass = this._cfg.sclass;
-        var skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Calendar", sclass);
+        var skinObj = aria.widgets.AriaSkinInterface.getSkinObject(this._skinnableClass, sclass);
         this._hasFocus = false;
         this._initTemplate({
             defaultTemplate : skinObj.defaultTemplate,
@@ -63,6 +63,12 @@ Aria.classDefinition({
     },
 
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Calendar",
 
         /**
          * React to the events coming from the module controller.

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -31,7 +31,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt) {
         this.$Container.constructor.apply(this, arguments);
-        this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Dialog", cfg.sclass);
+        this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject(this._skinnableClass, cfg.sclass);
 
         /**
          * Will contain the popup object.
@@ -142,6 +142,12 @@ Aria.classDefinition({
         MISSING_CONTENT_MACRO : "%1Missing 'macro' in Dialog configuration."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass :"Dialog",
 
         /**
          * Manage the viewport resize event
@@ -261,7 +267,7 @@ Aria.classDefinition({
          */
         __writeTitlebarButton : function (out, delegateId, cssClassPostfix, skinIcon) {
             var cfg = this._cfg;
-            out.write(['<span class="xDialog_', cssClassPostfix, ' xDialog_', cfg.sclass, '_', cssClassPostfix, '" ',
+            out.write(['<span class="x', this._skinnableClass,'_', cssClassPostfix, ' x', this._skinnableClass,'_', cfg.sclass, '_', cssClassPostfix, '" ',
                     aria.utils.Delegate.getMarkup(delegateId), '>'].join(''));
             var button = new aria.widgets.Icon({
                 icon : this._skinObj[skinIcon]
@@ -340,13 +346,13 @@ Aria.classDefinition({
             if (cfg.resizable && this._handlesArr) {
                 var handles = this._handlesArr;
                 for (var i = 0, ii = handles.length; i < ii; i++) {
-                    out.write(['<span class="xDialog_resizable xDialog_' + handles[i] + '">', '</span>'].join(''));
+                    out.write(['<span class="x', this._skinnableClass,'_resizable xDialog_' + handles[i] + '">', '</span>'].join(''));
                 }
             }
 
-            out.write(['<div class="xDialog_titleBar xDialog_', cfg.sclass, '_titleBar">'].join(''));
+            out.write(['<div class="xDialog_titleBar x', this._skinnableClass,'_', cfg.sclass, '_titleBar">'].join(''));
             if (cfg.icon) {
-                out.write(['<span class="xDialog_icon xDialog_', cfg.sclass, '_icon">'].join(''));
+                out.write(['<span class="xDialog_icon x', this._skinnableClass,'_', cfg.sclass, '_icon">'].join(''));
                 var icon = new aria.widgets.Icon({
                     icon : cfg.icon
                 }, this._context, this._lineNumber);
@@ -354,7 +360,7 @@ Aria.classDefinition({
                 icon.writeMarkup(out);
                 out.write('</span>');
             }
-            out.write(['<span class="xDialog_title xDialog_', cfg.sclass, '_title">',
+            out.write(['<span class="x', this._skinnableClass,'_title x', this._skinnableClass,'_', cfg.sclass, '_title">',
                     aria.utils.String.escapeHTML(cfg.title), '</span>'].join(''));
 
             // buttons are floated to the right, so close should be first in the markup

--- a/src/aria/widgets/container/Div.js
+++ b/src/aria/widgets/container/Div.js
@@ -33,7 +33,7 @@ Aria.classDefinition({
         if (!this._frame) {
             /* this._frame could be overriden in sub-classes */
             this._frame = aria.widgets.frames.FrameFactory.createFrame({
-                skinnableClass : "Div",
+                skinnableClass : this._skinnableClass,
                 sclass : cfg.sclass,
                 state : "normal",
                 width : cfg.width,
@@ -58,6 +58,12 @@ Aria.classDefinition({
         this.$Container.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Div",
 
         /**
          * A method called when we initialize the object.

--- a/src/aria/widgets/container/Fieldset.js
+++ b/src/aria/widgets/container/Fieldset.js
@@ -33,7 +33,7 @@ Aria.classDefinition({
         if (!this._frame) {
             /* this._frame could be overriden in sub-classes */
             this._frame = aria.widgets.frames.FrameFactory.createFrame({
-                skinnableClass : "Fieldset",
+                skinnableClass : this._skinnableClass,
                 sclass : cfg.sclass,
                 state : "normal",
                 width : cfg.width,
@@ -57,6 +57,12 @@ Aria.classDefinition({
         INPUT_ATTRIBUTE : "_ariaInput"
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Fieldset",
         /**
          * A method called when we initialize the object.
          * @protected

--- a/src/aria/widgets/container/Splitter.js
+++ b/src/aria/widgets/container/Splitter.js
@@ -29,7 +29,7 @@ Aria.classDefinition({
     $constructor : function (cfg, ctxt) {
         this.$Container.constructor.apply(this, arguments);
 
-        this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject("Splitter", cfg.sclass);
+        this._skinObj = aria.widgets.AriaSkinInterface.getSkinObject(this._skinnableClass, cfg.sclass);
 
         /**
          * Contains the dom element of first splitter panel
@@ -117,6 +117,13 @@ Aria.classDefinition({
         this.$Container.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Splitter",
+
         /**
          * OVERRIDE initWidget
          */

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -28,7 +28,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt) {
         this.$Container.constructor.apply(this, arguments);
-        this._setSkinObj("Tab");
+        this._setSkinObj(this._skinnableClass);
 
         /**
          * Whether the mouse is over the Tab or not
@@ -56,7 +56,7 @@ Aria.classDefinition({
             state : this._state,
             width : cfg.width,
             sclass : cfg.sclass,
-            skinnableClass : "Tab",
+            skinnableClass : this._skinnableClass,
             printOptions : cfg.printOptions,
             id : Aria.testMode ? this._domId + "_" + cfg.tabId : undefined
         });
@@ -79,6 +79,12 @@ Aria.classDefinition({
         this.$Container.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Tab",
 
         /**
          * Called when a new instance is initialized

--- a/src/aria/widgets/container/TabPanel.js
+++ b/src/aria/widgets/container/TabPanel.js
@@ -28,14 +28,14 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt) {
         this.$Container.constructor.apply(this, arguments);
-        this._setSkinObj("TabPanel");
+        this._setSkinObj(this._skinnableClass);
 
         this._frame = aria.widgets.frames.FrameFactory.createFrame({
             height : cfg.height,
             state : "normal",
             width : cfg.width,
             sclass : cfg.sclass,
-            skinnableClass : "TabPanel",
+            skinnableClass : this._skinnableClass,
             printOptions : cfg.printOptions,
             block : cfg.block
         });
@@ -64,6 +64,12 @@ Aria.classDefinition({
         CONTAINER_USAGE_DEPRECATED : "%1The usage as a container {@aria:TabPanel}{/@aria:TabPanel} is deprecated; use the {@aria:TabPanel /} syntax instead."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "TabPanel",
 
         /**
          * Called when a new instance is initialized

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -33,7 +33,7 @@ Aria.classDefinition({
     },
     $constructor : function (cfg, ctxt) {
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
-        var skinObj = aria.widgets.AriaSkinInterface.getSkinObject("ErrorList", this._cfg.sclass);
+        var skinObj = aria.widgets.AriaSkinInterface.getSkinObject(this._skinnableClass, this._cfg.sclass);
         var divCfg = aria.utils.Json.copy(cfg, true, ['width', 'minWidth', 'maxWidth', 'height', 'minHeight', 'block',
                 'maxHeight']);
         divCfg.sclass = skinObj.divsclass;
@@ -58,6 +58,13 @@ Aria.classDefinition({
         this.$TemplateBasedWidget.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @type String
+         * @protected
+         */
+        _skinnableClass : "ErrorList",
+
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             this._inOnBoundPropertyChange = true;
             try {

--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -31,15 +31,6 @@ Aria.classDefinition({
      * @param {Number} controller the data controller object
      */
     $constructor : function (cfg, ctxt, lineNumber, controller) {
-        if (!this._skinnableClass) {
-            /**
-             * Skinnable class to use for this widget.
-             * @protected
-             * @type String
-             */
-            this._skinnableClass = "AutoComplete";
-        }
-
         var controller = new aria.widgets.controllers.AutoCompleteController();
 
         if (!cfg.expandButton && cfg.bind) {
@@ -90,6 +81,13 @@ Aria.classDefinition({
         WIDGET_AUTOCOMPLETE_INVALID_HANDLER : "%1Could not create resources handler %2: dependency on this handler is missing."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "AutoComplete",
+
         /**
          * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
          * by all instances

--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -29,16 +29,6 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt, lineNumber) {
         this.$Input.constructor.apply(this, arguments);
-
-        if (!this._skinnableClass) {
-            /**
-             * Skinnable class to use for this widget.
-             * @type String
-             * @protected
-             */
-            this._skinnableClass = "CheckBox";
-        }
-
         this._setSkinObj(this._skinnableClass);
         this._setInputType();
         this._setIconPrefix();
@@ -77,6 +67,13 @@ Aria.classDefinition({
         this.$Input.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @type String
+         * @protected
+         */
+        _skinnableClass : "CheckBox",
+
         /**
          * Give focus to the widget
          */
@@ -155,7 +152,8 @@ Aria.classDefinition({
             if (lineHeight && aria.core.Browser.isIE) {
                 out.write('line-height:' + (lineHeight - 2) + 'px;');
             }
-            out.write('vertical-align:middle;"><label style="display:' + cssDisplay);
+            var cssClass = 'class="x' + this._skinnableClass + '_' + cfg.sclass + '_' + this._state + '_label"';
+            out.write('vertical-align:middle;"><label ' + cssClass + ' style="display:' + cssDisplay);
 
             if (margin) {
                 out.write(';margin-' + margin + ':' + this._labelPadding + 'px');

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -24,9 +24,6 @@ Aria.classDefinition({
     $css : ["aria.widgets.form.DatePickerStyle", "aria.widgets.calendar.CalendarStyle",
             "aria.widgets.container.DivStyle"],
     $constructor : function (cfg, ctxt, lineNumber) {
-        if (!this._skinnableClass) {
-            this._skinnableClass = "DatePicker";
-        }
         var controller = new aria.widgets.controllers.DatePickerController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         controller.setPattern(cfg.pattern);
@@ -50,6 +47,12 @@ Aria.classDefinition({
         this.$DropDownTextInput.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+         _skinnableClass : "DatePicker",
 
         /**
          * Handle events raised by the frame

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -28,9 +28,6 @@ Aria.classDefinition({
      * @param {aria.widgets.form.Textcontroller} controller the data controller object
      */
     $constructor : function (cfg, ctxt, lineNumber, controller) {
-        if (!this._skinnableClass) {
-            this._skinnableClass = "DropDownInput";
-        }
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
     },
     $destructor : function () {
@@ -38,6 +35,13 @@ Aria.classDefinition({
         this.$TextInput.$destructor.call(this);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "DropDownInput",
+
         /**
          * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
          * by all instances

--- a/src/aria/widgets/form/Gauge.js
+++ b/src/aria/widgets/form/Gauge.js
@@ -29,8 +29,7 @@ Aria.classDefinition({
      */
     $constructor : function (cfg, ctxt) {
         this.$Widget.constructor.apply(this, arguments);
-        this._cfg = cfg;
-        this.__setSkinObj("Gauge");
+        this.__setSkinObj(this._skinnableClass);
         // Show the label either if it has fixed width (for alignment) or if there's something to show
         this.showLabel = this._cfg.labelWidth > -1 || !!this._cfg.label;
     },
@@ -41,6 +40,13 @@ Aria.classDefinition({
         WIDGET_GAUGE_CFG_MIN_EQUAL_GREATER_MAX : "%1Gauge configuration error: minValue must be lower than maxValue."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Gauge",
+
         /**
          * Internal function to generate the internal widget markup
          * @param {aria.templates.MarkupWriter} out
@@ -61,7 +67,7 @@ Aria.classDefinition({
 
             var barWidth = this.__calculateBarWidth(this._cfg.currentValue);
 
-            out.write(['<div class="xGAUGE_progress_', this._cfg.sclass, '" style="width:',
+            out.write(['<div class="x', this._skinnableClass, '_progress_', this._cfg.sclass, '" style="width:',
                     (barWidth >= 0 ? barWidth : "0"), '%;height:100%"></div>'].join(""));
 
             this._widgetMarkupEnd(out);
@@ -76,7 +82,7 @@ Aria.classDefinition({
          */
         _widgetMarkupBegin : function (out) {
             var skinObj = this._skinObj, cfg = this._cfg;
-            out.write(['<div class="xGAUGE_', cfg.sclass, '" style="float:left;position:relative',
+            out.write(['<div class="x', this._skinnableClass ,'_' , cfg.sclass, '" style="float:left;position:relative',
                     skinObj.border ? ';border:' + skinObj.border : '',
                     skinObj.borderPadding ? ';padding:' + skinObj.borderPadding + 'px' : '', ';height:',
                     skinObj.sprHeight, 'px;width:', cfg.gaugeWidth, 'px;">'].join(""));

--- a/src/aria/widgets/form/GaugeStyle.tpl.css
+++ b/src/aria/widgets/form/GaugeStyle.tpl.css
@@ -18,10 +18,10 @@
     $extends : "aria.widgets.WidgetStyle"
 }}
     {var skinnableClassName="Gauge"/}
-    
+
     {macro writeSkinClass(info)}
-        .xGAUGE_progress_${info.skinClassName}{
-            {call background("transparent",info.skinClass.spriteUrl,"repeat-x")/}    
+        .x${skinnableClassName}_progress_${info.skinClassName}{
+            {call background("transparent",info.skinClass.spriteUrl,"repeat-x")/}
         }
     {/macro}
 {/CSSTemplate}

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -25,9 +25,6 @@ Aria.classDefinition({
     $css : ["aria.widgets.form.MultiSelectStyle", "aria.widgets.form.list.ListStyle",
             "aria.widgets.container.DivStyle", "aria.widgets.form.CheckBoxStyle"],
     $constructor : function (cfg, ctxt, lineNumber) {
-        if (!this._skinnableClass) {
-            this._skinnableClass = "MultiSelect";
-        }
         var controller = new aria.widgets.controllers.MultiSelectController();
 
         // The following line was added for PTR 04557432: if the value in cfg is not set to [] as a default, then the
@@ -89,6 +86,12 @@ Aria.classDefinition({
         this._dropDownList = null;
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "MultiSelect",
 
         /**
          * Callback called when the user clicks on a checkbox (or its label) on a dropdown list.

--- a/src/aria/widgets/form/RadioButton.js
+++ b/src/aria/widgets/form/RadioButton.js
@@ -33,14 +33,6 @@
          * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
          */
         $constructor : function (cfg, ctxt) {
-            /**
-             * Skinnable class to use for this widget.
-             * @type String
-             */
-            if (!this._skinnableClass) {
-                // allow the skinnable class to be defined in the child class, before calling this constructor
-                this._skinnableClass = "RadioButton";
-            }
             this.$CheckBox.constructor.apply(this, arguments);
             if (this._skinObj.simpleHTML) {
                 if (!idManager) {
@@ -74,6 +66,12 @@
         },
 
         $prototype : {
+            /**
+             * Skinnable class to use for this widget.
+             * @protected
+             * @type String
+             */
+             _skinnableClass : "RadioButton",
 
             /**
              * List of radio button instances for keyboard nav

--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -29,9 +29,6 @@ Aria.classDefinition({
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */
     $constructor : function (cfg, ctxt, lineNumber) {
-        if (!this._skinnableClass) {
-            this._skinnableClass = "Select";
-        }
         this.$DropDownInput.constructor.call(this, cfg, ctxt, lineNumber);
 
         var skinObj = this._skinObj;
@@ -58,7 +55,6 @@ Aria.classDefinition({
     $destructor : function () {
         // the controller is disposed in DropDownInput
         this.$DropDownInput.$destructor.call(this);
-        this._skinnableClass = null;
         this._selectField = null;
     },
     $statics : {
@@ -66,6 +62,13 @@ Aria.classDefinition({
         WIDGET_OPTIONS_INVALID_VALUE : "%1Bound value stored in the data model is not a valid option value for the select widget."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Select",
+
         /**
          * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
          * by all instances

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -31,15 +31,18 @@ Aria.classDefinition({
          * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
          */
      $constructor : function (cfg, ctxt, lineNumber) {
-        if (!this._skinnableClass) {
-            this._skinnableClass = "SelectBox";
-        }
-
         var controller = new aria.widgets.controllers.SelectBoxController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         this.controller.setListOptions(this._cfg.options);
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "SelectBox",
+
         $init : function (p) {
             var src = aria.widgets.form.DropDownListTrait.prototype;
             for (var key in src) {

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -30,17 +30,6 @@ Aria.classDefinition({
      * @param {aria.widgets.controller.TextDataController} controller the data controller object
      */
     $constructor : function (cfg, ctxt, lineNumber, controller) {
-        // allow the skinnable class to be defined in the child class, before
-        // calling this constructor
-        if (!this._skinnableClass) {
-            /**
-             * Skinnable class to use for this widget.
-             * @protected
-             * @type String
-             */
-            this._skinnableClass = "TextInput";
-        }
-
         this.$InputWithFrame.constructor.apply(this, arguments);
 
         /**
@@ -168,6 +157,13 @@ Aria.classDefinition({
         WIDGET_VALUE_IS_WRONG_TYPE : "%1Value %2 is of incorrect type."
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "TextInput",
+
         /**
          * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
          * by all instances

--- a/src/aria/widgets/form/Textarea.js
+++ b/src/aria/widgets/form/Textarea.js
@@ -32,14 +32,6 @@ Aria.classDefinition({
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */
     $constructor : function (cfg, ctxt, lineNumber) {
-        if (!this._skinnableClass) {
-            /**
-             * Skinnable class to use for this widget.
-             * @protected
-             * @type String
-             */
-            this._skinnableClass = "Textarea";
-        }
         var controller = new aria.widgets.controllers.TextDataController();
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         this._isTextarea = true;
@@ -49,6 +41,13 @@ Aria.classDefinition({
     },
 
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @protected
+         * @type String
+         */
+        _skinnableClass : "Textarea",
+
         _dom_onkeydown : function (event) {
 
             var maxlength = this.cfg.maxlength;

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -22,19 +22,18 @@ Aria.classDefinition({
     $dependencies : ["aria.utils.Json", "aria.widgets.form.list.ListController"],
     $css : ["aria.widgets.form.list.ListStyle"],
     $constructor : function (cfg, ctxt) {
-
-        if (!cfg) {
-            cfg = {};
-        }
         this.$TemplateBasedWidget.constructor.apply(this, arguments);
-        var realSkinObj = aria.widgets.AriaSkinInterface.getSkinObject("List", cfg.sclass);
+        if (!this._cfg) {
+            this._cfg = {};
+        }
+        var realSkinObj = aria.widgets.AriaSkinInterface.getSkinObject(this._skinnableClass, this._cfg.sclass);
         var skinObj = aria.utils.Json.copy(realSkinObj, false);
-        skinObj.cssClassItem = "xLISTItem_" + cfg.sclass;
-        skinObj.cssClassEnabled = "xLISTEnabledItem_" + cfg.sclass;
-        skinObj.cssClassSelected = "xLISTSelectedItem_" + cfg.sclass;
-        skinObj.cssClassDisabled = "xLISTDisabledItem_" + cfg.sclass;
-        skinObj.cssClassMouseover = "xLISTMouseOverItem_" + cfg.sclass;
-        skinObj.cssClassFooter = "xLISTFooter_" + cfg.sclass;
+        skinObj.cssClassItem = "x"+this._skinnableClass+"Item_" + this._cfg.sclass;
+        skinObj.cssClassEnabled = "x"+this._skinnableClass+"EnabledItem_" + this._cfg.sclass;
+        skinObj.cssClassSelected = "x"+this._skinnableClass+"SelectedItem_" + this._cfg.sclass;
+        skinObj.cssClassDisabled = "x"+this._skinnableClass+"DisabledItem_" + this._cfg.sclass;
+        skinObj.cssClassMouseover = "x"+this._skinnableClass+"MouseOverItem_" + this._cfg.sclass;
+        skinObj.cssClassFooter = "x"+this._skinnableClass+"Footer_" + this._cfg.sclass;
         var divCfg = aria.utils.Json.copy(cfg, true, ["width", "minWidth", "maxWidth", "height", "minHeight",
                 "maxHeight", "scrollBarX", "scrollBarY"]);
         divCfg.sclass = skinObj.divsclass;
@@ -69,6 +68,13 @@ Aria.classDefinition({
         });
     },
     $prototype : {
+        /**
+         * Skinnable class to use for this widget.
+         * @type String
+         * @protected
+         */
+        _skinnableClass : "List",
+
         /**
          * Return true to cancel default action.
          * @param {Number} charCode Character code

--- a/src/aria/widgets/form/list/ListStyle.tpl.css
+++ b/src/aria/widgets/form/list/ListStyle.tpl.css
@@ -18,58 +18,58 @@
     $extends : "aria.widgets.WidgetStyle"
 }}
     {var skinnableClassName="List"/}
-    
+
     {macro writeSkinClass(info)}
         {var skinClassName=info.skinClassName/}
         {var skinClass=info.skinClass/}
         /* List Widget classes */
-        
-        a.xLISTItem_${skinClassName},
-        a.xLISTItem_${skinClassName}:link,
-        a.xLISTItem_${skinClassName}:active,
-        a.xLISTItem_${skinClassName}:visited {
+
+        a.x${skinnableClassName}Item_${skinClassName},
+        a.x${skinnableClassName}Item_${skinClassName}:link,
+        a.x${skinnableClassName}Item_${skinClassName}:active,
+        a.x${skinnableClassName}TItem_${skinClassName}:visited {
             color: #000;
             text-decoration:none;
         }
-        
-        a.xLISTItem_${skinClassName} {
+
+        a.x${skinnableClassName}Item_${skinClassName} {
             display: block;
             padding:1px 1px 1px 2px;
             margin: 1px ${skinClass.link.marginRight}px 1px ${skinClass.link.marginLeft}px;
         }
-        
-        
-        .xLISTEnabledItem_${skinClassName} {
+
+
+        .x${skinnableClassName}EnabledItem_${skinClassName} {
             color:${skinClass.enabledColor};
             cursor:pointer;
         }
-        
-        .xLISTMouseOverItem_${skinClassName} {
+
+        .x${skinnableClassName}MouseOverItem_${skinClassName} {
             background-color:${skinClass.mouseOverBackgroundColor};
             color:${skinClass.mouseOverColor};
         }
-        
-        .xLISTEnabledItem_${skinClassName}:hover {
+
+        .x${skinnableClassName}EnabledItem_${skinClassName}:hover {
         {if skinClass.highlightMouseOver}
             background-color:${skinClass.mouseOverBackgroundColor};
             color: ${skinClass.mouseOverColor};
         {/if}
             text-decoration: none;
         }
-        
-        .xLISTSelectedItem_${skinClassName}, .xLISTSelectedItem_${skinClassName}:link, .xLISTSelectedItem_${skinClassName}:visited, .xLISTSelectedItem_${skinClassName}:active  {
+
+        .x${skinnableClassName}SelectedItem_${skinClassName}, .x${skinnableClassName}SelectedItem_${skinClassName}:link, .x${skinnableClassName}SelectedItem_${skinClassName}:visited, .x${skinnableClassName}SelectedItem_${skinClassName}:active  {
             background-color: ${skinClass.selectedItemBackgroundColor};
             color: ${skinClass.selectedItemColor};
         }
-        
-        .xLISTDisabledItem_${skinClassName},
-        a.xLISTDisabledItem_${skinClassName}:visited,
-        a.xLISTDisabledItem_${skinClassName}:hover,
-        a.xLISTDisabledItem_${skinClassName}:link {
+
+        .x${skinnableClassName}DisabledItem_${skinClassName},
+        a.x${skinnableClassName}DisabledItem_${skinClassName}:visited,
+        a.x${skinnableClassName}DisabledItem_${skinClassName}:hover,
+        a.x${skinnableClassName}DisabledItem_${skinClassName}:link {
             color:#888;
         }
-        
-        .xLISTFooter_${skinClassName} {
+
+        .x${skinnableClassName}Footer_${skinClassName} {
             padding:${skinClass.footer.padding}px;
             background-color: ${skinClass.footer.backgroundColor};
             border-color: ${skinClass.footer.borderColor};
@@ -78,5 +78,5 @@
             margin:    ${skinClass.footer.marginTop}px ${skinClass.footer.marginRight}px ${skinClass.footer.marginBottom}px ${skinClass.footer.marginLeft}px;
         }
     {/macro}
-    
+
 {/CSSTemplate}

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -47,6 +47,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.verticalAlign.VerticalAlignTestCase");
         this.addTests("test.aria.widgets.icon.IconTest");
         this.addTests("test.aria.widgets.splitter.scrollbars.ScrollbarTestCase");
-
+        this.addTests("test.aria.widgets.issue746.SkinClassFallbackTestCase");
     }
 });

--- a/test/aria/widgets/form/GaugeTest.js
+++ b/test/aria/widgets/form/GaugeTest.js
@@ -70,12 +70,12 @@ Aria.classDefinition({
 
             var floatVal = progCont.style.cssFloat || progCont.style.styleFloat;
             this.assertEquals(floatVal, "left");
-            this.assertEquals(progCont.className, "xGAUGE_std");
+            this.assertEquals(progCont.className, "xGauge_std");
 
             // test progress bar
             var progBar = progCont.childNodes[0];
             this.assertEquals(progBar.tagName, "DIV");
-            this.assertEquals(progBar.className, "xGAUGE_progress_std");
+            this.assertEquals(progBar.className, "xGauge_progress_std");
             this.assertEquals(progBar.style.width, "54%");
 
             this._destroyGauge(o);
@@ -174,12 +174,12 @@ Aria.classDefinition({
 
             floatVal = progCont.style.cssFloat || progCont.style.styleFloat;
             this.assertEquals(floatVal, "left");
-            this.assertEquals(progCont.className, "xGAUGE_std");
+            this.assertEquals(progCont.className, "xGauge_std");
 
             // test progress bar
             var progBar = progCont.childNodes[0];
             this.assertEquals(progBar.tagName, "DIV");
-            this.assertEquals(progBar.className, "xGAUGE_progress_std");
+            this.assertEquals(progBar.className, "xGauge_progress_std");
             this.assertEquals(progBar.style.width, "54%");
 
             this._destroyGauge(o);

--- a/test/aria/widgets/form/autocomplete/expandbutton/test4/ExpandButtonCheck.js
+++ b/test/aria/widgets/form/autocomplete/expandbutton/test4/ExpandButtonCheck.js
@@ -114,7 +114,7 @@ Aria.classDefinition({
 
         _afterSelect2 : function () {
             var dropdownPopup = this.getWidgetInstance("ac1")._dropdownPopup;
-            var selectedElt = this.getElementsByClassName(dropdownPopup.domElement, "xLISTSelectedItem_dropdown")[0];
+            var selectedElt = this.getElementsByClassName(dropdownPopup.domElement, "xListSelectedItem_dropdown")[0];
 
             this.assertTrue(selectedElt.innerHTML.match(/<strong>Finnair<\/strong>/gi).length == 1, "The value of the selected element is " + selectedElt.innerHTML + ", but it should be \n<strong>Finnair</strong>\n");
 

--- a/test/aria/widgets/form/selectbox/SelectboxTestCase.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestCase.js
@@ -68,7 +68,7 @@ Aria.classDefinition({
 
         _afterTimer : function () {
             this.dropdown = this.getWidgetDropDownPopup("myId");
-            this.options = this.getElementsByClassName(this.dropdown, "xLISTEnabledItem_dropdown");
+            this.options = this.getElementsByClassName(this.dropdown, "xListEnabledItem_dropdown");
 
             var opts = {};
             opts.to = this.cont == 1 ? this.options[0] : this.options[1];

--- a/test/aria/widgets/issue746/SkinClassFallbackTestCase.js
+++ b/test/aria/widgets/issue746/SkinClassFallbackTestCase.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for aria.widgets.form.GaugeTest
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.issue746.SkinClassFallbackTestCase",
+    $dependencies : ["aria.jsunit.helpers.OutObj", "aria.templates.View"],
+    $extends : "aria.jsunit.WidgetTestCase",
+    $constructor : function() {
+        this.$WidgetTestCase.constructor.call(this);
+        this.__widgets = [
+                            {name : "aria.widgets.container.Fieldset", isContainer : true},
+                            {name : "aria.widgets.action.Button"},
+                            {name : "aria.widgets.action.IconButton", cfg : {icon: "std:collapse"}},
+                            {name : "aria.widgets.calendar.Calendar"},
+                            {name : "aria.widgets.container.Dialog", isContainer : true, checkInnerHTML : false, cfg : {contentMacro : "dialogMacro"}}, //how to config?
+                            {name : "aria.widgets.action.Link"},
+                            {name : "aria.widgets.container.Div", isContainer : true},
+                            {name : "aria.widgets.form.TextField"},
+                            {name : "aria.widgets.form.Textarea"},
+                            {name : "aria.widgets.container.Splitter", isContainer : true, cfg : { border: true ,height: 150, width : 150, macro1:'PanelOne', macro2:'PanelTwo'}}, //how to config?
+                            {name : "aria.widgets.container.Tab", isContainer : true, cfg : {tabId: "tabId"}},
+                            {name : "aria.widgets.container.TabPanel", isContainer : true, cfg : {id: "myId", macro : "myMacro"}},
+                            {name : "aria.widgets.form.PasswordField"},
+                            {name : "aria.widgets.form.DateField"},
+                            {name : "aria.widgets.form.DatePicker"},
+                            {name : "aria.widgets.form.MultiSelect", cfg : {items: ["a", "b", "c"]}},
+                            {name : "aria.widgets.form.TimeField"},
+                            {name : "aria.widgets.form.NumberField"},
+                            {name : "aria.widgets.form.AutoComplete", cfg : {resourcesHandler : function (param) {} }},
+                            {name : "aria.widgets.form.CheckBox", cfg : {label: "Label"}},
+                            {name : "aria.widgets.form.RadioButton", cfg : {label: "Label"}},
+                            //{name : "aria.widgets.Icon", cfg : {icon: "std:collapse"}}, //sclass not used in the widgets markup?
+                            {name : "aria.widgets.form.SelectBox"},
+                            {name : "aria.widgets.form.Select"},
+                            //{name : "aria.widgets.action.SortIndicator", cfg : {sortName : 'SortByName', label : 'Label', view: new aria.templates.View([0, 1, 2, 3, 4])}},
+                            {name : "aria.widgets.form.list.List", checkInnerHTML : false},
+                            {name : "aria.widgets.errorlist.ErrorList", checkInnerHTML : false}];
+    },
+    $prototype : {
+        _createWidget : function (widgetName, cfg, isContainer) {
+            return {
+                instance : isContainer ? this.createContainerAndInit(widgetName, cfg) : this.createAndInit(widgetName, cfg),
+                dom : this.outObj.testArea.childNodes[0]
+            };
+        },
+        _destroyWidget : function (_inst) {
+            _inst.$dispose();
+            this.outObj.clearAll();
+        },
+        testAsyncAllWidgets : function () {
+            // Load all widgets needed for the test and then test them
+            Aria.load({
+                classes : this.__widgets.map(this.__mappingFn),
+                oncomplete : {
+                    fn : this.__performTests,
+                    scope : this
+                }
+            });
+        },
+        //method used to extract the widgetname from the testconfig
+        __mappingFn : function (value) {
+            return value.name;
+        },
+        __performTests : function () {
+            while(this.__widgets.length>0) {
+                var testConfig = this.__widgets.shift();
+                var widgetName = testConfig.name;
+                var cfg = testConfig.cfg || {};
+                var isContainer = testConfig.isContainer;
+
+                var wrongSclass = "doesntExist";
+                //if there is a sclass specified for the test use this, else use the default for the tests defined above
+                if(cfg.sclass) {
+                    wrongSclass = cfg.sclass;
+                } else {
+                    cfg.sclass = wrongSclass;
+                }
+
+                var tf = this._createWidget(widgetName, cfg, isContainer);
+
+                var instance = tf.instance;
+                var correctClassName = ["x", tf.instance._skinnableClass, "_std"].join('');
+                var wrongClassName = ["x", tf.instance._skinnableClass, "_", wrongSclass].join('');
+
+                try{
+                    //check the config was changed to use std as sclass because the given sclass should not exist in the skin
+                    this.assertEquals("std", instance._cfg.sclass, "The style class '" + instance._cfg.sclass + "' does not match the expected 'std' for widgetName " + widgetName);
+
+                    var checkInnerHTML = true;
+                    if(testConfig.checkInnerHTML !== undefined) {
+                        checkInnerHTML = testConfig.checkInnerHTML;
+                    }
+                    if(checkInnerHTML) {
+
+                        if(tf.dom === undefined || tf.dom.innerHTML === undefined) {
+                            this.$logWarn("InnerHTML should be checked but it is undefined for widget " + widgetName);
+                        } else {
+                            //check that the markup is generated using the fallback sclass
+                            this.assertTrue(tf.dom.innerHTML.indexOf(correctClassName) > -1, "In the innerHTML the className '"+ correctClassName + "' could not be found for widget " + widgetName);
+                            //make sure that there is no occurence of the wrong sclass
+                            this.assertTrue(tf.dom.innerHTML.indexOf(wrongClassName) == -1, "Class name should not use the given sclass " + wrongClassName );
+                        }
+                    }
+                }finally{
+                    this._destroyWidget(instance);
+                }
+            }
+            this.notifyTestEnd("testAsyncAllWidgets");
+        }
+    }
+});


### PR DESCRIPTION
If a specified skinClass for a widget does not exist the 'std' skinObject is used (as before) and the skinClass 'std' is used for the naming of the css class names
