### PR TITLE
Fixes #777 Dispose of the previous template before adding the same one again.

### DIFF
--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -543,12 +543,13 @@ Aria.classDefinition({
 
             var cfgTemplate = {
                 classpath : cfg.template,
-                div : pageConfig.animation === null ? (this._activeDiv === 0 ? this._firstDiv : this._secondDiv) : this._getContainer(false),
+                div : this._getContainer(!pageConfig.animation),
                 moduleCtrl : this._rootModule
             };
 
             this._modulesInPage = [];
-            if (!this._animationsManager && this._isTemplateLoaded) {
+            // if the div does not change, let's dispose the previous template first
+            if (cfgTemplate.div == this._getContainer() && this._isTemplateLoaded) {
                 Aria.disposeTemplate(this._getContainer());
             }
             Aria.loadTemplate(cfgTemplate, {

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateDisposalTest.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateDisposalTest.js
@@ -35,7 +35,6 @@ Aria.classDefinition({
         },
 
         _onPageEngineStarted : function (args) {
-
             this._testInstanceCount("MainLayout", 1, 0);
             this._testInstanceCount("Body", 1, 0);
             this._testInstanceCount("Template1", 1, 0);
@@ -64,7 +63,7 @@ Aria.classDefinition({
             this._testInstanceCount("Template5", 0, 0);
             this._testInstanceCount("Template6", 0, 0);
 
-            //Issue722
+            // Issue722
             this._headChildCount = this._testWindow.document.getElementsByTagName("head")[0].childElementCount;
 
             this.pageEngine.navigate({
@@ -85,7 +84,7 @@ Aria.classDefinition({
             this._testInstanceCount("Template5", 1, 0);
             this._testInstanceCount("Template6", 1, 0);
 
-            //Issue722
+            // Issue722
             this.assertEquals(this._testWindow.document.getElementsByTagName("head")[0].childElementCount, this._headChildCount);
 
             this.pageEngine.navigate({
@@ -106,7 +105,28 @@ Aria.classDefinition({
             this._testInstanceCount("Template5", 1, 1);
             this._testInstanceCount("Template6", 1, 1);
 
-            //Issue722
+            // Issue722
+            this.assertEquals(this._testWindow.document.getElementsByTagName("head")[0].childElementCount, this._headChildCount);
+
+            this.pageEngine.navigate({
+                pageId : "ddd"
+            }, {
+                fn : this._afterFifthPageReady,
+                scope : this
+            });
+        },
+
+        _afterFifthPageReady : function () {
+            this._testInstanceCount("MainLayout", 5, 4);
+            this._testInstanceCount("Body", 5, 4);
+            this._testInstanceCount("Template1", 1, 1);
+            this._testInstanceCount("Template2", 1, 1);
+            this._testInstanceCount("Template3", 2, 2);
+            this._testInstanceCount("Template4", 2, 2);
+            this._testInstanceCount("Template5", 2, 1);
+            this._testInstanceCount("Template6", 2, 1);
+
+            // Issue722
             this.assertEquals(this._testWindow.document.getElementsByTagName("head")[0].childElementCount, this._headChildCount);
 
             aria.core.Timer.addCallback({
@@ -131,14 +151,14 @@ Aria.classDefinition({
 
         end : function () {
             this._disposePageEngine();
-            this._testInstanceCount("MainLayout", 4, 4);
-            this._testInstanceCount("Body", 4, 4);
+            this._testInstanceCount("MainLayout", 5, 5);
+            this._testInstanceCount("Body", 5, 5);
             this._testInstanceCount("Template1", 1, 1);
             this._testInstanceCount("Template2", 1, 1);
             this._testInstanceCount("Template3", 2, 2);
             this._testInstanceCount("Template4", 2, 2);
-            this._testInstanceCount("Template5", 1, 1);
-            this._testInstanceCount("Template6", 1, 1);
+            this._testInstanceCount("Template5", 2, 2);
+            this._testInstanceCount("Template6", 2, 2);
 
             this.$PageEngineBaseTestCase.end.call(this);
         },

--- a/test/aria/pageEngine/pageEngine/site/PageProviderFour.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderFour.js
@@ -144,6 +144,33 @@ Aria.classDefinition({
                     }
                 });
             }
+            if (pageId == "ddd") {
+                this.$callback(callback.onsuccess, {
+                    pageId : "ddd",
+                    url : "/pageEngine/ddd",
+                    contents : {
+                        menus : {
+                            mymenu : []
+
+                        },
+                        placeholderContents : {}
+                    },
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.MainLayout",
+                        placeholders : {
+                            "body" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.Body"
+                            },
+                            "body.left" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.Template5"
+                            },
+                            "body.middle" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.Template6"
+                            }
+                        }
+                    }
+                });
+            }
         }
     }
 });


### PR DESCRIPTION
The fix applied to the Page Engine, disposes the previous template before adding the same one again, there should never be multiple instances of the same template with the same container div.
