### PR TITLE
Removing overflow property from Select Widget style

### DIFF
--- a/src/aria/widgets/form/SelectStyle.tpl.css
+++ b/src/aria/widgets/form/SelectStyle.tpl.css
@@ -24,7 +24,6 @@
         .xSelect {
             display:inline-block;
             white-space:nowrap;
-            overflow:hidden;
         }
         {call startLooping()/}
     {/macro}


### PR DESCRIPTION
Removing the overflow:hidden property from the CSS template of Select widget
