### PR TITLE
Making text-decoration property of Link Widget customizable

### DIFF
--- a/src/aria/widgets/AriaSkinBeans.js
+++ b/src/aria/widgets/AriaSkinBeans.js
@@ -599,6 +599,9 @@ Aria.beanDefinitions({
             $properties : {
                 "color" : {
                     $type : "Color"
+                },
+                "textDecoration" :  {
+                    $type : "json:String"
                 }
 
             }

--- a/src/aria/widgets/action/LinkStyle.tpl.css
+++ b/src/aria/widgets/action/LinkStyle.tpl.css
@@ -27,6 +27,9 @@
         
         a${pseudoclass}.xLink_${info.skinClassName} {
             color:${info.state.color};
+            {if info.state.textDecoration}
+                text-decoration:${info.state.textDecoration};
+            {/if}
         }
     {/macro}
     


### PR DESCRIPTION
Adding the possibility to customize the text-decoration property of Link widget
