### PR TITLE
fix #775 popup widget positioning

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -56,7 +56,9 @@ Aria.classDefinition({
         ANCHOR_BOTTOM : "bottom",
         ANCHOR_TOP : "top",
         ANCHOR_LEFT : "left",
-        ANCHOR_RIGHT : "right"
+        ANCHOR_RIGHT : "right",
+        //DEBUG MESSAGE
+        DEBUG_OVERWRITE_POSITION : "Absolute %1 position %2 is used to overwrite calculated relative position %3!"
     },
     $constructor : function () {
         /**
@@ -255,7 +257,9 @@ Aria.classDefinition({
             this.setSection(conf.section);
 
             if (!conf.center) {
-                if (conf.absolutePosition === null) {
+                if (conf.absolutePosition === null ||
+                        //allow mixing of relative and absolute positioning #775
+                        (conf.absolutePosition !== null && conf.domReference !== null)) {
                     this.setReference(conf.domReference);
                 } else {
                     this.setPositionAsReference(conf.absolutePosition);
@@ -552,6 +556,27 @@ Aria.classDefinition({
             }
             if (top != null) {
                 top += documentScroll.scrollTop;
+            }
+
+            //allow mixing of relative and absolute positioning #775
+            if(this.conf.domReference !== null && this.conf.absolutePosition !== null) {
+                var abs = this.conf.absolutePosition;
+                if (abs.top !== null) {
+                    this.$logDebug(this.DEBUG_OVERWRITE_POSITION, [this.ANCHOR_TOP, abs.top, top]);
+                    top = abs.top;
+                }
+                if (abs.bottom !== null) {
+                    this.$logDebug(this.DEBUG_OVERWRITE_POSITION, [this.ANCHOR_BOTTOM, abs.bottom, bottom]);
+                    bottom = abs.bottom;
+                }
+                if(abs.left !== null) {
+                    this.$logDebug(this.DEBUG_OVERWRITE_POSITION, [this.ANCHOR_LEFT, abs.left, left]);
+                    left = abs.left;
+                }
+                if (abs.right !== null) {
+                    this.$logDebug(this.DEBUG_OVERWRITE_POSITION, [this.ANCHOR_RIGHT, abs.right, right]);
+                    right = abs.right;
+                }
             }
 
             var position = {

--- a/test/aria/popups/Popup.js
+++ b/test/aria/popups/Popup.js
@@ -172,7 +172,88 @@ Aria.classDefinition({
             document.body.removeChild(bigContainer);
 
         },
+        testPopupPositioningMixed1 : function () {
+            var document = Aria.$window.document;
+            var popup = new aria.popups.Popup();
 
+            var myDiv = document.createElement("div");
+            myDiv.id = "myDiv";
+            document.body.appendChild(myDiv);
+
+            var conf = {
+                // Content
+                section : this.mockSection,
+                domReference : document.getElementById('myDiv'),
+                preferredPositions : [{
+                            reference : "bottom left",
+                            popup : "top left"
+                        }],
+                absolutePosition : {left: 0, right: 0},
+                closeOnMouseOut : true
+            };
+
+            popup.open(conf);
+
+            var popupContent = document.getElementById("myId");
+
+            var top = parseInt(popupContent.parentNode.style.top, 10);
+            this.assertEqualsWithTolerance(top, 8, 2, "Expected 8, found " + top);
+
+            var left = parseInt(popupContent.parentNode.style.left, 10);
+            var right = parseInt(popupContent.parentNode.style.right, 10);
+
+            this.assertEqualsWithTolerance(left, 0, 2, "Expected 0, found " + left);
+            this.assertEqualsWithTolerance(right, 0, 2, "Expected 0, found " + right);
+
+            popup.close();
+            popup.$dispose();
+
+            document.body.removeChild(myDiv);
+
+            this.assertErrorInLogs(aria.popups.Popup.DEBUG_OVERWRITE_POSITION, 2);
+
+        },
+        testPopupPositioningMixed2 : function () {
+            var document = Aria.$window.document;
+            var popup = new aria.popups.Popup();
+
+            var myDiv = document.createElement("div");
+            myDiv.id = "myDiv";
+            document.body.appendChild(myDiv);
+
+            var conf = {
+                // Content
+                section : this.mockSection,
+                domReference : document.getElementById('myDiv'),
+                preferredPositions : [{
+                            reference : "bottom right",
+                            popup : "top left"
+                        }],
+                absolutePosition : {top: 0, bottom: 0, left: 17},
+                closeOnMouseOut : true
+            };
+
+            popup.open(conf);
+
+            var popupContent = document.getElementById("myId");
+
+            var left = parseInt(popupContent.parentNode.style.left, 10);
+            this.assertEqualsWithTolerance(left, 17, 2, "Expected 17, found " + left);
+
+            var top = parseInt(popupContent.parentNode.style.top, 10);
+            var bottom = parseInt(popupContent.parentNode.style.top, 10);
+
+            this.assertEqualsWithTolerance(top, 0, 2, "Expected 0, found " + top);
+            this.assertEqualsWithTolerance(bottom, 0, 2, "Expected 0, found " + bottom);
+
+            popup.close();
+            popup.$dispose();
+
+            document.body.removeChild(myDiv);
+
+            this.assertErrorInLogs(aria.popups.Popup.DEBUG_OVERWRITE_POSITION, 3);
+
+        },
         /**
          * Make sure everything is unchanged for AriaJSP popup bridge
          */


### PR DESCRIPTION
Allow mixing of absolute and relative positioning for popups.

If a domReference/referenceId is given and an absolutePosition configuration,
then the given absolute positions will overwrite the ones calculated based on the given reference.

Added tests for the new behavior.
