### PR TITLE
doc Fix missing doc, wrong types, typos

### DIFF
--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -1334,23 +1334,24 @@
      * @param {Object} desc the description of the files to load and the callback [loadDesc]
      *
      * <pre>
-     * { classes:[] {Array} list of classpaths to be loaded
-     *         oncomplete:{
-     *             fn: {Function} the callback function - may be called synchronously if
-     * all dependencies are already available
-     *             scope: {Object} [optional] scope object (i.e. 'this') to associate to fn - if not provided, the Aria object will be used args: {Object} [optional] callback arguments (passed back
-     * as argument when the callback is called)
-     *         }
-     *         onerror:{
-     *             fn: ...
-     *             ...,
-     *             override:true // used to disable error warnings
-     *         }
+     * {
+     *   classes : []        // {Array of String} - classpaths to be loaded (dot is a separator)
+     *   oncomplete : {
+     *      fn: {Function}   // the callback function - may be called synchronously if all dependencies are already available
+     *      scope: {Object}  // [optional] scope object (i.e. 'this') to associate to fn - if not provided, the Aria object will be used
+     *      args: {Object}   // [optional] callback arguments (passed back as an argument to the callback function)
+     *   },
+     *   onerror: {
+     *      fn: ...
+     *      ...,
+     *      override:true    // used to disable error warnings
+     *   }
      * }
      * </pre>
      *
-     * Alternatively, if there is no need to specify a scope and args, the callback property can contain directly the
-     * callback function oncomplete: function () {...} instead of: oncomplete: {fn: function () {...}}
+     * If there is no need to specify the <code>scope</code> and <code>args</code>, the callbacks can be passed
+     * directly as functions: e.g. <code>oncomplete: function () {...}</code> instead of
+     * <code>oncomplete: {fn: function () {...}}</code>
      */
     Aria.load = function (desc) {
         var ml = new aria.core.MultiLoader(desc);

--- a/src/aria/core/ClassMgr.js
+++ b/src/aria/core/ClassMgr.js
@@ -25,7 +25,6 @@ Aria.classDefinition({
     $events : {
         /**
          * Raised in the listener of the 'complete' event raised by the appropriate classLoader.
-         * @event classComplete
          */
         "classComplete" : {
             description : "notifies that the class loader process is done.",

--- a/src/aria/core/FileLoader.js
+++ b/src/aria/core/FileLoader.js
@@ -17,9 +17,6 @@ Aria.classDefinition({
     $classpath : "aria.core.FileLoader",
 
     $events : {
-        /**
-         * @event fileReady
-         */
         "fileReady" : {
             description : "notifies that the file associated to the loader is ready for use or that an error occured",
             properties : {
@@ -28,9 +25,6 @@ Aria.classDefinition({
                 downloadFailed : "{boolean} if true, no path in logicalPaths could be retrieved successfully (maybe other logical paths)"
             }
         },
-        /**
-         * @event complete
-         */
         "complete" : {
             description : "notifies that the file loader process is done and that it can be disposed (i.e. fileReady listeners have already been called when this event is raised)"
         }
@@ -71,7 +65,7 @@ Aria.classDefinition({
         _logicalPathHeader : /^\/\/LOGICAL-PATH:([^\s]+)$/,
 
         /**
-         * Start the dowload of the file associated to the loader url
+         * Start the download of the file associated to the loader url
          */
         loadFile : function () {
             if (this._isProcessing) {
@@ -128,7 +122,7 @@ Aria.classDefinition({
         },
 
         /**
-         * Internal callback called by the IO object when the file has been succesfully received
+         * Internal callback called by the IO object when the file has been successfully received
          * @param {Object} ioRes IO result object
          * @private
          */
@@ -190,7 +184,7 @@ Aria.classDefinition({
             }
 
             if (downloadFailed && multipart == null) {
-                // if an error occured, and we have not yet done it,
+                // if an error occurred, and we have not yet done it,
                 // we put the error in the cache for every expected logical path
                 for (var i = 0; i < this._logicalPaths.length; i++) {
                     aria.core.DownloadMgr.loadFileContent(this._logicalPaths[i], ioRes.responseText, true);

--- a/src/aria/core/MultiLoader.js
+++ b/src/aria/core/MultiLoader.js
@@ -66,8 +66,8 @@ Aria.classDefinition({
     },
     $prototype : {
         /**
-         * Start the load of the resources passed to the constructor Warning: this mehod may be synchronous if all
-         * resources are already available As such, the caller should not make any processing but the callback after
+         * Start the load of the resources passed to the constructor. Warning: this method may be synchronous if all
+         * resources are already available. As such, the caller should not make any processing but the callback after
          * this method call
          */
         load : function () {
@@ -84,7 +84,7 @@ Aria.classDefinition({
                 "CML" : cm.filterMissingDependencies(descriptor.cml)
             };
 
-            // This first loop only detects whether there are error or missing dependencies
+            // This first loop only detects whether there are errors or missing dependencies
             for (var type in dependencies) {
                 if (dependencies.hasOwnProperty(type)) {
                     var missing = dependencies[type];
@@ -103,7 +103,7 @@ Aria.classDefinition({
                 if (this._loadDesc['onerror'] && this._loadDesc['onerror'].override) {
                     loader.handleError = false;
                 }
-                this._clsLoader = loader; // usefull reference for debugging
+                this._clsLoader = loader; // useful reference for debugging
 
                 loader.$on({
                     "classReady" : this._onClassesReady,

--- a/src/aria/map/MapManager.js
+++ b/src/aria/map/MapManager.js
@@ -92,20 +92,12 @@
 
         },
         $events : {
-
-            /**
-             * @event mapReady
-             */
             "mapReady" : {
                 description : "Notifies that a certain map has been loaded",
                 properties : {
                     mapId : "{String} id of the map"
                 }
             },
-
-            /**
-             * @event mapDestroy
-             */
             "mapDestroy" : {
                 description : "Notifies that a certain map has been destroyed",
                 properties : {

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -79,14 +79,14 @@ Aria.classDefinition({
         /**
          * Holds the Url Service Creation implementation instance
          * @protected
-         * @type Object implements aria.modules.urlService.IUrlService
+         * @type aria.modules.urlService.IUrlService
          */
         this._urlService = null;
 
         /**
          * Request handler instance attached to the request manager
          * @protected
-         * @type Object implements aria.modules.requestHandler.IRequestHandler
+         * @type aria.modules.requestHandler.IRequestHandler
          */
         this._requestHandler = null;
 

--- a/src/aria/modules/requestHandler/RequestHandler.js
+++ b/src/aria/modules/requestHandler/RequestHandler.js
@@ -30,7 +30,7 @@ Aria.classDefinition({
     },
     $constructor : function () {
         /**
-         * JSON serialiazer used to stringify the request jason data before sending the request
+         * JSON serializer used to stringify the request json data before sending the request
          * @protected
          * @type aria.modules.requestHandler.environment.RequestHandler:RequestJsonSerializerCfg
          */

--- a/src/aria/templates/ModuleCtrl.js
+++ b/src/aria/templates/ModuleCtrl.js
@@ -65,9 +65,15 @@ Aria.classDefinition({
 
         /**
          * Handler to use with this module.
-         * @implement aria.modules.requestHandler.IRequestHandler
+         * @type aria.modules.requestHandler.IRequestHandler
          */
         this.$requestHandler = null;
+
+        /**
+         * UrlService instance to use with this module.
+         * @type aria.modules.urlService.IUrlService
+         */
+        this.$urlService = null;
 
         /**
          * Object containing the instance and the options for the JSON serializer used in the requests issued by the

--- a/src/aria/utils/Path.js
+++ b/src/aria/utils/Path.js
@@ -73,9 +73,9 @@ Aria.classDefinition({
 
         /**
          * Resolve a path inside an object, and return result
-         * @param {String|Array} path. If a string, will parse it. If Array, specifies the suite of parameters to
+         * @param {String|Array} path If a string, will parse it. If Array, specifies the suite of parameters to
          * follow.
-         * @param {Object} inside. If not specified, window is used.
+         * @param {Object} inside If not specified, window is used.
          */
         resolve : function (path, inside) {
             if (aria.utils.Type.isString(path)) {
@@ -104,7 +104,7 @@ Aria.classDefinition({
 
         /**
          * Parse a string path and return parameter suite in an array
-         * @param {String} path, like obj.param1[0]["param2"]
+         * @param {String} path like obj.param1[0]["param2"]
          * @return {Array}
          */
         parse : function (path) {
@@ -114,7 +114,7 @@ Aria.classDefinition({
         /**
          * Parse parameters in path
          * @protected
-         * @param {String} path, like .param1[0]["param2"]
+         * @param {String} path like .param1[0]["param2"]
          * @return {Array}
          */
         _paramParse : function (path) {

--- a/src/aria/widgets/controllers/DropDownListController.js
+++ b/src/aria/widgets/controllers/DropDownListController.js
@@ -115,7 +115,7 @@ Aria.classDefinition({
          * @param {Integer} keyCode
          * @param {String} currentText
          * @param {Integer} caretPos
-         * @parm {aria.DomEvent} event
+         * @param {aria.DomEvent} event
          * @return {aria.widgets.controllers.reports.ControllerReport}
          */
         checkKeyStroke : function (charCode, keyCode, currentText, caretPosStart, caretPosEnd, event) {

--- a/test/aria/templates/autorefresh/AutorefreshTestCase.js
+++ b/test/aria/templates/autorefresh/AutorefreshTestCase.js
@@ -16,9 +16,6 @@
 Aria.classDefinition({
     $classpath : "test.aria.templates.autorefresh.AutorefreshTestCase",
     $events : {
-        /**
-         * @event classReady
-         */
         "Ready" : {
             description : "Raised when the template content is fully displayed."
         }

--- a/test/aria/templates/autorefresh/AutorefreshTestCase2.js
+++ b/test/aria/templates/autorefresh/AutorefreshTestCase2.js
@@ -16,9 +16,6 @@
 Aria.classDefinition({
     $classpath : "test.aria.templates.autorefresh.AutorefreshTestCase2",
     $events : {
-        /**
-         * @event classReady
-         */
         "Ready" : {
             description : "Raised when the template content is fully displayed."
         }

--- a/test/aria/templates/autorefresh/AutorefreshTestCase4.js
+++ b/test/aria/templates/autorefresh/AutorefreshTestCase4.js
@@ -16,9 +16,6 @@
 Aria.classDefinition({
     $classpath : "test.aria.templates.autorefresh.AutorefreshTestCase4",
     $events : {
-        /**
-         * @event classReady
-         */
         "Ready" : {
             description : "Raised when the template content is fully displayed."
         }

--- a/test/aria/templates/autorefresh/AutorefreshTestCase5.js
+++ b/test/aria/templates/autorefresh/AutorefreshTestCase5.js
@@ -16,9 +16,6 @@
 Aria.classDefinition({
     $classpath : "test.aria.templates.autorefresh.AutorefreshTestCase5",
     $events : {
-        /**
-         * @event classReady
-         */
         "Ready" : {
             description : "Raised when the template content is fully displayed."
         }


### PR DESCRIPTION
1) make type="implements Foo" notation consistent with the other classes.
Search for `@type(.*)\.I[A-Z](.*)` in the repo, we never precede it with the Object

2) missing `$urlService` in the API docs while `$requestHandler` is there

3) typos

4) remove `@event` annotation, it's useless and not used in most of the other files
