### PR TITLE
Improvement of page definition for page engine

### DIFF
--- a/src/aria/pageEngine/CfgBeans.js
+++ b/src/aria/pageEngine/CfgBeans.js
@@ -188,7 +188,7 @@ Aria.beanDefinitions({
                 "contents" : {
                     $type : "PageContents",
                     $description : "Contents for the current page",
-                    $mandatory : true
+                    $default : {}
                 },
                 "pageComposition" : {
                     $type : "PageComposition",
@@ -239,7 +239,15 @@ Aria.beanDefinitions({
                         $description : "ContentId's that are present in the pageComposition"
                     },
                     $contentType : {
-                        $type : "Content"
+                        $type : "json:MultiTypes",
+                        $contentTypes : [{
+                                    $type : "Content"
+                                }, {
+                                    $type : "json:Array",
+                                    $contentType : {
+                                        $type : "Content"
+                                    }
+                                }]
                     }
                 }
             }

--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -756,7 +756,7 @@ Aria.classDefinition({
          */
         _getPlaceholderContents : function (pageConfig, contentId) {
             var outputContent = [];
-            var content = pageConfig.contents.placeholderContents[contentId];
+            var content = pageConfig.contents.placeholderContents ? pageConfig.contents.placeholderContents[contentId] : null;
             if (!content) {
                 return outputContent;
             }

--- a/src/aria/pageEngine/utils/PageConfigHelper.js
+++ b/src/aria/pageEngine/utils/PageConfigHelper.js
@@ -51,7 +51,8 @@ Aria.classDefinition({
          * @private
          */
         getMenus : function () {
-            return this._pageConfig.contents.menus;
+            var contents = this._pageConfig.contents;
+            return contents ? contents.menus : null;
         },
 
         /**

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestFour");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestFive");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestSix");
+        this.addTests("test.aria.pageEngine.pageEngine.PageEngineTestSeven");
         this.addTests("test.aria.pageEngine.pageEngine.PageDefinitionChangeTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTestWithAnimations");

--- a/test/aria/pageEngine/pageEngine/PageEngineTestSeven.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTestSeven.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.PageEngineTestSeven",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.site.PageProviderSeven");
+    },
+    $prototype : {
+
+        runTestInIframe : function () {
+            this._createPageEngine({
+                oncomplete : "_onPageEngineStarted"
+            });
+        },
+
+        _onPageEngineStarted : function () {
+            this._checkTextIsInDom("1234567");
+            this._checkTextIsInDom("abcdef");
+            this._checkTextIsInDom("ghi");
+            this._checkTextIsInDom("jastAStrangeString");
+
+            this.end();
+        },
+
+        _createPageEngine : function (args) {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.site.PageProviderSeven();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this[args.oncomplete],
+                    scope : this
+                }
+            });
+        },
+
+        end : function () {
+            this._disposePageEngine();
+            this.$PageEngineBaseTestCase.end.call(this);
+        },
+
+        _disposePageEngine : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+        },
+
+        _checkTextIsInDom : function (text) {
+            var elt = this._testWindow.aria.utils.Dom.getElementById("at-main");
+            var firstDiv = elt.innerHTML;
+            this.assertTrue(firstDiv.indexOf(text) != -1, "Text " + text + " was not found in the page.");
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/fakeSite/PageProvider.js
+++ b/test/aria/pageEngine/pageEngine/fakeSite/PageProvider.js
@@ -71,8 +71,7 @@ Aria.classDefinition({
             }
             if (this._incorrectPage) {
                 this.$callback(callback.onsuccess, {
-                    pageId : "aaa",
-                    contrrrents : {},
+                    pagdsdseId : "aaa",
                     pageComposition : {
                         template : "pagengine.site.tpls.layouts.MainLayout",
                         placeholders : {
@@ -86,10 +85,6 @@ Aria.classDefinition({
             if (this._missingPageDependencies) {
                 this.$callback(callback.onsuccess, {
                     pageId : "aaa",
-                    contents : {
-                        menus : {},
-                        placeholderContents : {}
-                    },
                     pageComposition : {
                         template : "invalid.MainLayout",
                         placeholders : {

--- a/test/aria/pageEngine/pageEngine/issue626/PageProvider626.js
+++ b/test/aria/pageEngine/pageEngine/issue626/PageProvider626.js
@@ -52,7 +52,6 @@ Aria.classDefinition({
                 pageId : "aaa",
                 url : "/pageEngine/aaa",
                 animation : this._animationCfg,
-                contents : {},
                 pageComposition : {
                     template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
                     placeholders : {}

--- a/test/aria/pageEngine/pageEngine/site/PageProviderFour.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderFour.js
@@ -62,8 +62,7 @@ Aria.classDefinition({
                         menus : {
                             mymenu : []
 
-                        },
-                        placeholderContents : {}
+                        }
                     },
                     pageComposition : {
                         template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.MainLayout",
@@ -93,8 +92,7 @@ Aria.classDefinition({
                         menus : {
                             mymenu : []
 
-                        },
-                        placeholderContents : {}
+                        }
                     },
                     pageComposition : {
                         template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.MainLayout",
@@ -125,8 +123,7 @@ Aria.classDefinition({
                         menus : {
                             mymenu : []
 
-                        },
-                        placeholderContents : {}
+                        }
                     },
                     pageComposition : {
                         template : "test.aria.pageEngine.pageEngine.site.templates.providerFour.MainLayout",

--- a/test/aria/pageEngine/pageEngine/site/PageProviderSeven.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderSeven.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.PageProviderSeven",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $prototype : {
+
+        /**
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                containerId : "at-main"
+            };
+            this.$callback(callback.onsuccess, siteConfig);
+
+        },
+
+        /**
+         * @param {String} pageId Id of the page
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            var pageId = pageRequest.pageId;
+            if ((!pageId) || (pageId == "aaa")) {
+                this.$callback(callback.onsuccess, {
+                    pageId : "aaa",
+                    contents : {
+                        placeholderContents : {
+                            "first" : [{
+                                        value : "1"
+                                    }, {
+                                        value : "2"
+                                    }, {
+                                        value : "3"
+                                    }, {
+                                        value : "4567"
+                                    }],
+                            "second" : [{
+                                        value : "abcdef"
+                                    }, {
+                                        value : "ghi"
+                                    }],
+                            "third" : {
+                                value : "jastAStrangeString"
+                            }
+                        }
+                    },
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
+                        placeholders : {
+                            "header" : [{
+                                        contentId : "second"
+                                    }, {
+                                        contentId : "fake"
+                                    }],
+                            "body" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerSeven.Body",
+                                contentId : "first"
+                            },
+                            "footer" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.providerSeven.Body",
+                                contentId : "third"
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/PageProviderSix.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderSix.js
@@ -83,8 +83,7 @@ Aria.classDefinition({
                     contents : {
                         menus : {
                             mymenu : []
-                        },
-                        placeholderContents : {}
+                        }
                     },
                     pageComposition : {
                         template : "test.aria.pageEngine.pageEngine.site.templates.providerSix.MainLayout",

--- a/test/aria/pageEngine/pageEngine/site/templates/providerSeven/Body.tpl
+++ b/test/aria/pageEngine/pageEngine/site/templates/providerSeven/Body.tpl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+  $classpath : "test.aria.pageEngine.pageEngine.site.templates.providerSeven.Body",
+  $wlibs: {
+     "embed": "aria.embed.EmbedLib"
+  }
+}}
+
+	{macro main (args)}
+		{foreach cont inArray args.contents}
+			${cont}
+		{/foreach}
+	{/macro}
+
+
+{/Template}

--- a/test/aria/pageEngine/utils/PageConfigHelperTest.js
+++ b/test/aria/pageEngine/utils/PageConfigHelperTest.js
@@ -42,6 +42,16 @@ Aria.classDefinition({
             pgh.$dispose();
         },
 
+        testGetMenusEmpty : function () {
+            var pageDef = {
+                pageComposition : {}
+            };
+
+            var pgh = new aria.pageEngine.utils.PageConfigHelper(pageDef);
+            this.assertTrue(pgh.getMenus() === null, "getMenus method should return null when no menu is defined.");
+            pgh.$dispose();
+        },
+
         testGetPageDependencies : function () {
             var pgh = new aria.pageEngine.utils.PageConfigHelper(this.pageDefOne.pageDef);
             var dep = pgh.getPageDependencies();

--- a/test/aria/pageEngine/utils/test/PageConfigOne.js
+++ b/test/aria/pageEngine/utils/test/PageConfigOne.js
@@ -20,8 +20,7 @@ Aria.resourcesDefinition({
             contents : {
                 menus : {
                     "menuOne" : ["childOne", "childTwo"]
-                },
-                placeholderContents : {}
+                }
             },
             pageComposition : {
                 template : "main.page.template",
@@ -98,8 +97,7 @@ Aria.resourcesDefinition({
             contents : {
                 menus : {
                     "menuOne" : ["childOne", "childTwo"]
-                },
-                placeholderContents : {}
+                }
             },
             pageComposition : {
                 template : "main.page.template",


### PR DESCRIPTION
Two features are added with this commit:

1 - property "contents" is no longer mandatory in a page composition
2 - The bean definition for "placeholderContents" has been changed in order to reflect the code: values in the map can be either a single content or an array of them. The code was already taking that possibility into account. Tests have been added also for the case in which a template and a contentId are set in a placeholder configuration.
