### PR TITLE
fix #801 Wrong validation on the textinput widget

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -917,9 +917,6 @@ Aria.classDefinition({
                     this.setHelpText(true);
                 }
 
-                if (!cfg.directOnBlurValidation) {
-                    this.changeProperty("error", false);
-                }
                 this._updateState();
 
                 if (cfg.formatError && cfg.validationEvent === 'onBlur') {

--- a/test/aria/widgets/form/textinput/TextInputTestSuite.js
+++ b/test/aria/widgets/form/textinput/TextInputTestSuite.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this._tests = ["test.aria.widgets.form.textinput.onchange.OnChangeTestCase",
+                "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCase",
                 "test.aria.widgets.form.textinput.quotes.QuotesTestCase",
                 "test.aria.widgets.form.textinput.onclick.OnClickTest",
                 "test.aria.widgets.form.textinput.onfocus.OnFocusTest"];

--- a/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCase.js
+++ b/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCase.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCaseTpl",
+            data : {
+                value1: "",
+                value2 : ""
+            }
+        });
+    },
+    $prototype : {
+        _getErrorElements : function() {
+            var tpl = this.testDiv.getElementsByTagName("div")[0];
+
+            var arr = [];
+            var nl = this.getElementsByClassName(tpl, "xTextInput_std_normalError_w");
+            for(var i = 0, n; n = nl[i]; ++i) {
+                arr.push(n);
+            }
+
+            var nl = this.getElementsByClassName(tpl, "xTextInput_std_normalErrorFocused_w");
+            for(var i = 0, n; n = nl[i]; ++i) {
+                arr.push(n);
+            }
+
+            return arr;
+        },
+
+        runTemplateTest : function () {
+
+            // Check the init states
+            this.assertEquals(this._getErrorElements().length, 2, "The two textfields should be in error");
+
+            // The two fields are in error state, check here that the focus-blur actions without change don't change their state
+            this.synEvent.click(this.getInputField("tfBlurValidation"), {
+                fn : this.focusSecondField,
+                scope : this
+            });
+
+        },
+
+        focusSecondField : function () {
+            this.synEvent.click(this.getInputField("tfNoBlurValidation"), {
+                fn : this.focusFirstField,
+                scope : this
+            });
+        },
+        focusFirstField : function () {
+            this.synEvent.click(this.getInputField("tfBlurValidation"), {
+                fn : this.checkStates,
+                scope : this
+            });
+        },
+        checkStates : function() {
+            this.assertEquals(this._getErrorElements().length, 2, "The two textfields should be in error after the focus-blur iteration");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCaseTpl.tpl
+++ b/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCaseTpl.tpl
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCaseTpl",
+    $hasScript : true,
+}}
+
+{macro main()}
+
+{@aria:TextField {
+    id : "tfBlurValidation",
+    label: "Textfield with blur validation ",
+    labelWidth : 200,
+    directOnBlurValidation:true,
+    bind : {
+        value : {
+            to : "value1",
+            inside : data
+        }
+    }
+}/}
+<br /><br />
+{@aria:TextField {
+    id : "tfNoBlurValidation",
+    label: "Textfield without blur validation ",
+    labelWidth : 200,
+    directOnBlurValidation:false,
+    bind : {
+        value : {
+            to : "value2",
+            inside : data
+        }
+    }
+}/}
+{/macro}
+{/Template}

--- a/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCaseTplScript.js
+++ b/test/aria/widgets/form/textinput/blurvalidation/BlurValidationTestCaseTplScript.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCaseTplScript",
+    $dependencies: ["aria.utils.Data", "aria.utils.validators.Mandatory"],
+    $destructor : function() {
+        aria.utils.Data.unsetValidator(this.data, "value1");
+        aria.utils.Data.unsetValidator(this.data, "value2");
+        this.validator.$dispose();
+    },
+    $prototype : {
+        $dataReady : function () {
+            var validator = this.validator = new aria.utils.validators.Mandatory("This field is mandatory");
+            aria.utils.Data.setValidator(this.data, "value1", validator, null, "onblur");
+            aria.utils.Data.setValidator(this.data, "value2", validator, null, "onblur");
+            aria.utils.Data.validateModel(this.data);
+        }
+    }
+});

--- a/test/aria/widgets/form/textinput/quotes/QuotesTestCase.js
+++ b/test/aria/widgets/form/textinput/quotes/QuotesTestCase.js
@@ -26,9 +26,6 @@ Aria.classDefinition({
             }
         };
     },
-    $destructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
-    },
     $prototype : {
         runTemplateTest : function () {
             var tf = this.getInputField("tf");


### PR DESCRIPTION
If a textinput widget, with directOnBlurValidation set to false, has an error state, focusing and bluring the field removed the error state, which is wrong as no changes occurred
