### PR TITLE
[1.6.1] feat #805 change `rootFolderPath` in NodeJS

### DIFF
--- a/src/aria/node.js
+++ b/src/aria/node.js
@@ -56,6 +56,10 @@ try {
         }
     });
 
+    // Update root folder to point to the user's repo root folder;
+    // assuming we're in "<projectFolder>/node_modules/ariatemplates/src/aria"
+    Aria.rootFolderPath = __dirname + "/../../../../";
+
 } catch (ex) {
     console.error('\n[Error] Aria Templates framework not loaded.', ex);
     process.exit(1);


### PR DESCRIPTION
This commit changes the `Aria.rootFolderPath` to point to the project's folder (i.e. the one containing `node_modules`) instead of the AT installation folder, when the framework is loaded from NodeJS using `require('ariatemplates')`.

It doesn't make much sense to point to a folder inside `node_modules/ariatemplates` as a root path, since we won't expect the user to create any files manually there. Hence it's enough to create the `aria.*` entry in the URL map, instead of altering `rootFolderPath`. 

Note that this commit is backward-incompatible if someone used sth like this in their NodeJS code:

```
folder = Aria.rootFolderPath + "../../../"
```

i.e. any relative reference using the `rootFolderPath`.

---

The main added value here is that the user can easily change the `rootFolderPath` without worrying of doing harm to AT internal files (no need to update the root map additionally).

As I noted in the commit message, this change is backward incompatible, on the other hand it can be treated as a bugfix :) Any opinions if we should wait for 1.5.1 to include this?
