### PR TITLE
[on hold] less.js integration implementation in the AT CSS templating mechanism

### DIFF
--- a/src/aria/templates/CSSClassGenerator.js
+++ b/src/aria/templates/CSSClassGenerator.js
@@ -51,6 +51,7 @@ Aria.classDefinition({
             out.enterBlock("classInit");
             this._writeMapInheritance(out, "__$csslibs", out.templateParam.$csslibs, "{}");
             this._writeValueInheritance(out, "__$prefix", out.templateParam.$prefix, "true");
+            this._writeValueInheritance(out, "__$less", out.templateParam.$less, "false");
             out.leaveBlock();
             this.$ClassGenerator._writeClassInit.call(this, out);
         }

--- a/src/aria/templates/CSSCtxt.js
+++ b/src/aria/templates/CSSCtxt.js
@@ -82,7 +82,8 @@ Aria.classDefinition({
         this.$BaseCtxt.$destructor.call(this);
     },
     $statics : {
-        MEDIA_RULE : /@media\b/
+        MEDIA_RULE : /@media\b/,
+        LESS_INCLUDE_ERROR : "Error while attempting to use less.js API - please check if less.js script has been included"
     },
     $prototype : {
         /**
@@ -180,6 +181,23 @@ Aria.classDefinition({
             this._callMacro(null, "main");
             var text = this._out.join("");
             this._out = null;
+
+            if (this._tpl.__$less) {
+                var less = Aria.$global.less;
+                if (typeof less == 'undefined' || !less.Parser) {
+                    this.$logError(this.LESS_INCLUDE_ERROR);
+                } else {
+                    var parser = new less.Parser();
+                    parser.parse(text, function (err, tree) {
+                        if (err) {
+                            Aria.$logError([err.message].concat(err.extract).join("\n"));
+                        } else {
+                            text = tree.toCSS();
+                        }
+
+                    });
+                }
+            }
 
             this.__cachedOutput = text;
             return text;

--- a/src/aria/templates/CfgBeans.js
+++ b/src/aria/templates/CfgBeans.js
@@ -192,6 +192,10 @@ Aria.beanDefinitions({
                 "$prefix" : {
                     $type : "json:Boolean",
                     $description : "Defaulted to true. Use it only when required to use features like ( @font-face and @keyframes), avoid otherwise, to limit  CSS class name collisions."
+                },
+                "$less" : {
+                    $type : "json:Boolean",
+                    $description : "Defaulted to false. Used to add less.js features to the template CSS."
                 }
             }
         },


### PR DESCRIPTION
less.js can be used by including the less.js file and adding the parameter "$less : true" to the css.tpl class definition;
in this case, it is possible to use all the less.js features with its sintax.
