### PR TITLE
fix #838 prefer `updateRootMap` instead of `rootFolderPath` in NodeJS

### DIFF
--- a/src/aria/node.js
+++ b/src/aria/node.js
@@ -4,6 +4,7 @@ var vm = require("vm"), fs = require("fs"), path = require("path");
 /* aria and Aria are going to be global */
 aria = {};
 
+// DownloadMgr is not yet available, set rootFolderPath temporarily to load the framework
 Aria = {
     rootFolderPath : __dirname + "/../"
 };
@@ -46,6 +47,15 @@ try {
     aria.core.IO.updateTransports({
         "sameDomain" : "aria.node.Transport"
     });
+
+    // Update the root map, so `aria.*` is always served from AT npm installation, regardless of `rootFolderPath`
+    // (and so that the user can change `Aria.rootFolderPath` without breaking framework's classes loading).
+    aria.core.DownloadMgr.updateRootMap({
+        aria : {
+            "*" : __dirname + "/../"
+        }
+    });
+
 } catch (ex) {
     console.error('\n[Error] Aria Templates framework not loaded.', ex);
     process.exit(1);


### PR DESCRIPTION
This commit adds `DownloadMgr.updateRootMap` call in the AT loader for NodeJS, so that the user can change `Aria.rootFolderPath` to a folder of his custom files, without worrying of breaking the loading of AT internal files (`aria.*` classpath).

This is a backward-compatible commit, a prerequisite for #805 which will change the default `rootFolderPath`.

---

I've decided it's better to go the safe route here, we can merge #805 in 1.5.1.
