### PR TITLE
Workaround for getStyle in order to return correct value for backgroundPosition(X|Y) in FF

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -879,10 +879,21 @@ Aria.classDefinition({
                         property = "cssFloat";
                     }
                     var computed = window.getComputedStyle(element, "");
-                    if (computed) {
-                        value = computed[property];
+                    if (browser.isFirefox && (property == "backgroundPositionX" || property == "backgroundPositionY")) {
+                        if (computed) {
+                            var bgPos = computed["backgroundPosition"];
+                        }
+                        value = (bgPos || element.style["backgroundPosition"]);
+                        if (value) {
+                            var bgPosArr = value.split(" ");
+                            return ((property == "backgroundPositionX") ? bgPosArr[0] : bgPosArr[1]);
+                        }
+                    } else {
+                        if (computed) {
+                            value = computed[property];
+                        }
+                        return (value || element.style[property]);
                     }
-                    return (value || element.style[property]);
                 };
             }
 

--- a/test/aria/utils/Dom.js
+++ b/test/aria/utils/Dom.js
@@ -491,6 +491,22 @@ Aria.classDefinition({
             this.assertEquals(domUtil.getStyle(element, "width"), "100px");
         },
 
+        test_getStyle_backgroundPosition : function () {
+            var domUtil = aria.utils.Dom;
+            Aria.$window.scroll(0, 0);
+            var document = Aria.$window.document;
+
+            var element = document.createElement("div");
+            this.domCreated.push(element);
+            document.body.appendChild(element);
+
+            if (aria.core.Browser.isFirefox) {
+                element.style.cssText = "background: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7) 40px 30px";
+                this.assertEquals(domUtil.getStyle(element, "backgroundPositionX"), "40px");
+                this.assertEquals(domUtil.getStyle(element, "backgroundPositionY"), "30px");
+            }
+        },
+
         /**
          * Checks that, after calling refreshScrollbars, the unnecessary scrollbar has disappeared.
          */


### PR DESCRIPTION
Firefox does not handle backgroundPositionX and backgroundPositionY, so these value have to be collected by parsing the backgroundPosition value.
