### PR TITLE
fix #857 in test case test.aria.utils.css.Effects for FF (backgroundPosition)

### DIFF
--- a/test/aria/utils/css/Effects.js
+++ b/test/aria/utils/css/Effects.js
@@ -161,7 +161,10 @@ Aria.classDefinition({
                     fn : function () {
                         if (prop.name == "opacity") {
                             this._checkOpacity(this.div1, prop.value);
-                        } else {
+                        } else if (prop.name == "backgroundPositionX" || prop.name == "backgroundPositionY") {
+                            var val = this.div1.style["backgroundPosition"].split(" ");
+                            this.assertEquals(prop.value, ((prop.name == "backgroundPositionX")? val[0] : val[1]), 'The property has not been set to its final value');
+                        } else{
                             this.assertEquals(prop.value, this.div1.style[prop.name], 'The property has not been set to its final value');
                         }
                         if (++this.propIndex < this._animProperties.length) {


### PR DESCRIPTION
fix in test case test.aria.utils.css.Effects for FF that does not recognise backgroundPositionX and backgroundPositionY (not standard)
