### PR TITLE
test.aria.utils.Dom failure in some browsers

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -881,7 +881,7 @@ Aria.classDefinition({
                         // backgroundPositionX and backgroundPositionY are not standard
                         var backgroundPosition = this.getStyle(element, "backgroundPosition");
                         if (backgroundPosition) {
-                            var match = /^([^ ]+) ([^ ]+)$/.exec(backgroundPosition);
+                            var match = /^([-.0-9a-z%]+)\s([-.0-9a-z%]+)($|,)/.exec(backgroundPosition);
                             if (match) {
                                 value = ((property == "backgroundPositionX") ? match[1] : match[2]);
                             }

--- a/test/aria/utils/Dom.js
+++ b/test/aria/utils/Dom.js
@@ -504,10 +504,26 @@ Aria.classDefinition({
             this.assertEquals(domUtil.getStyle(element, "backgroundPositionX"), "40px");
             this.assertEquals(domUtil.getStyle(element, "backgroundPositionY"), "30px");
 
+            var browser = aria.core.Browser;
+            var isIE8OrLess = browser.isIE && browser.majorVersion <= 8;
+
             element.style.cssText = "background-image: " + inlineImage + "," + inlineImage
                     + "; background-position: 10px 20px, center;";
-            this.assertEquals(domUtil.getStyle(element, "backgroundPositionX"), null);
-            this.assertEquals(domUtil.getStyle(element, "backgroundPositionY"), null);
+
+            this.assertEquals(domUtil.getStyle(element, "backgroundPositionX"), isIE8OrLess ? "0%" : "10px");
+            this.assertEquals(domUtil.getStyle(element, "backgroundPositionY"), isIE8OrLess ? "0%" : "20px");
+
+            element.style.cssText = "background-image: " + inlineImage + "," + inlineImage
+                    + "; background-position: bottom left, center;";
+            this.assertEquals(domUtil.getStyle(element, "backgroundPositionX"), isIE8OrLess ? "0%" : "0%");
+            this.assertEquals(domUtil.getStyle(element, "backgroundPositionY"), isIE8OrLess ? "0%" : "100%");
+
+            element.style.cssText = "background-image: " + inlineImage + "," + inlineImage
+                    + "; background-position: bottom -5px left 20px, center;";
+            this.assertTrue(domUtil.getStyle(element, "backgroundPositionX") == "0%"
+                    || domUtil.getStyle(element, "backgroundPositionX") === null);
+            this.assertTrue(domUtil.getStyle(element, "backgroundPositionY") == "0%"
+                    || domUtil.getStyle(element, "backgroundPositionY") === null);
         },
 
         /**


### PR DESCRIPTION
Method `getStyle` was giving the wrong values for `"backgroundPositionX"` and `"backgroundPositionY"`.
On top of that, even on modern borwsers, a null value is returned in some cases even when a value is available.
