### PR TITLE
test.aria.templates.validation.errortext.ErrorTextTestCase failure in Chrome

### DIFF
--- a/test/aria/templates/validation/errortext/ErrorTextTestCase.js
+++ b/test/aria/templates/validation/errortext/ErrorTextTestCase.js
@@ -40,6 +40,15 @@ Aria.classDefinition({
             var input = this.getInputField("ac1");
             input.focus();
 
+            this.synEvent.click(input, {
+                fn : this.onUserClick,
+                scope : this
+            });
+        },
+
+        onUserClick : function () {
+            var input = this.getInputField("ac1");
+
             this.synEvent.type(input, "blah", {
                 fn : this.onUserTyped,
                 scope : this
@@ -58,7 +67,7 @@ Aria.classDefinition({
         },
 
         afterBlur : function () {
-            this.templateCtxt.$on({
+            this.templateCtxt.$onOnce({
                 "SectionRefreshed" : this.afterRefresh,
                 scope : this
             });


### PR DESCRIPTION
The test was failing because the synthetic type (with the robot) was not working. Clicking on the field first makes it work.
