### PR TITLE
Changing message when user tries to load a library already loaded

### DIFF
--- a/src/aria/templates/BaseCtxt.js
+++ b/src/aria/templates/BaseCtxt.js
@@ -160,8 +160,8 @@ Aria.classDefinition({
                         this.$logError(this.LIBRARY_HANDLE_CONFLICT, [handle]);
                         continue;
                     } else if (allClasspaths[libsMap[handle]]) {
-                        // we've already loaded a library with the same classpath: throw an error
-                        this.$logError(this.LIBRARY_ALREADY_LOADED, [handle]);
+                        // we've already loaded a library with the same classpath: throw a warning
+                        this.$logWarn(this.LIBRARY_ALREADY_LOADED, [handle]);
                         continue;
                     }
 


### PR DESCRIPTION
Changing from an error to a warning message since it's not breaking anything and the framework continues working properly.
