### PR TITLE
fix #770 Multiple embed:Elements linked to page engine instances cause w...

### DIFF
--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -684,37 +684,40 @@ Aria.classDefinition({
          * @return {Array} List of content descriptions accepted by placeholders
          */
         getContent : function (placeholderPath) {
+            var outputContent;
             var typeUtil = aria.utils.Type;
             var pageConfig = this._pageConfigs[this.currentPageId];
-            var placeholders = pageConfig.pageComposition.placeholders;
-            var content = placeholders[placeholderPath] || [];
-            var outputContent = [];
-            var plainContent;
-            if (!typeUtil.isArray(content)) {
-                content = [content];
-            }
+            if (pageConfig) {
+                var placeholders = pageConfig.pageComposition.placeholders;
+                var content = placeholders[placeholderPath] || [];
+                outputContent = [];
+                var plainContent;
+                if (!typeUtil.isArray(content)) {
+                    content = [content];
+                }
 
-            for (var i = 0, ii = content.length; i < ii; i++) {
-                var item = content[i];
-                if (typeUtil.isObject(item)) {
-                    if (this._lazyContent && item.lazy) {
-                        outputContent.push({
-                            loading : true,
-                            width : item.lazy.width || null,
-                            height : item.lazy.height || null,
-                            color : item.lazy.color || null,
-                            innerHTML : item.lazy.innerHTML || null
-                        });
-                    } else {
-                        if (item.template) {
-                            outputContent.push(this._getTemplateCfg(item, pageConfig));
-                        } else if (item.contentId) {
-                            plainContent = this._getPlaceholderContents(pageConfig, item.contentId);
-                            outputContent = outputContent.concat(plainContent);
+                for (var i = 0, ii = content.length; i < ii; i++) {
+                    var item = content[i];
+                    if (typeUtil.isObject(item)) {
+                        if (this._lazyContent && item.lazy) {
+                            outputContent.push({
+                                loading : true,
+                                width : item.lazy.width || null,
+                                height : item.lazy.height || null,
+                                color : item.lazy.color || null,
+                                innerHTML : item.lazy.innerHTML || null
+                            });
+                        } else {
+                            if (item.template) {
+                                outputContent.push(this._getTemplateCfg(item, pageConfig));
+                            } else if (item.contentId) {
+                                plainContent = this._getPlaceholderContents(pageConfig, item.contentId);
+                                outputContent = outputContent.concat(plainContent);
+                            }
                         }
+                    } else {
+                        outputContent.push(item);
                     }
-                } else {
-                    outputContent.push(item);
                 }
             }
             return outputContent;

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -32,5 +32,6 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTest");
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTestWithAnimations");
         this.addTests("test.aria.pageEngine.pageEngine.issue626.PageReadyEventTest");
+        this.addTests("test.aria.pageEngine.pageEngine.issue770.GetContentTest");
     }
 });

--- a/test/aria/pageEngine/pageEngine/issue770/GetContentTest.js
+++ b/test/aria/pageEngine/pageEngine/issue770/GetContentTest.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.issue770.GetContentTest",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.defaultTestTimeout = 10000;
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.issue770.PageProvider770");
+
+        this.__pageReadyEventWasRaised = false;
+    },
+    $prototype : {
+
+        /**
+         * @override
+         */
+        runTestInIframe : function () {
+            this._createPageEngine();
+        },
+
+        _createPageEngine : function () {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.issue770.PageProvider770();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this._onPageEngineStart,
+                    scope : this
+                }
+            });
+            
+            // Testing that no error is raised when the page engine, as a content provider, is asked for a content that it cannot provide because it hasn't received any page definition yet
+            var ex;
+            try {
+                this.pageEngine.getContent("body");
+            } catch (e) {
+                ex = e;
+            }
+            this.assertTrue(typeof ex == "undefined");
+        },
+
+        _onPageEngineStart : function () {
+            this.end();
+        },
+
+        /**
+         * @override
+         */
+        end : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+            this.$PageEngineBaseTestCase.end.call(this);
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/issue770/PageProvider770.js
+++ b/test/aria/pageEngine/pageEngine/issue770/PageProvider770.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.issue770.PageProvider770",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+
+    $prototype : {
+
+        /**
+         * @override
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                appData : {},
+                containerId : "at-main",
+                animations : false
+            };
+
+            this.$callback(callback.onsuccess, siteConfig);
+        },
+
+        /**
+         * @override
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            this.$callback(callback.onsuccess, {
+                pageId : "aaa",
+                url : "/pageEngine/aaa",
+                animation : this._animationCfg,
+                pageComposition : {
+                    template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
+                    placeholders : {}
+                }
+            });
+        }
+    }
+});


### PR DESCRIPTION
...idget errors

This PR fixes the first part of the issue.

For the second part, it is much more complicated.
By design, placeholders are currently managed globally and so their id must be unique in a given application.
It would possible to change it, but it would have many impacts on the framework.
So for now, this won't be changed as a workaround is available.
