### PR TITLE
refactor remove verbosity from DOCTYPEs

### DIFF
--- a/scripts/assets/playground.html
+++ b/scripts/assets/playground.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">

--- a/src/aria/ext/filesgenerator/tpl/Bootstrap.tpl.txt
+++ b/src/aria/ext/filesgenerator/tpl/Bootstrap.tpl.txt
@@ -15,8 +15,8 @@
 
 {TextTemplate {$classpath: 'aria.ext.filesgenerator.tpl.Bootstrap'}}
 {macro main()}
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
         <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 

--- a/src/aria/jsunit/TestReport.js
+++ b/src/aria/jsunit/TestReport.js
@@ -85,7 +85,7 @@ Aria.classDefinition({
          * @return {String}
          */
         getMailHeader : function () {
-            var header = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
+            var header = '<!DOCTYPE html>'
                     + '<html>'
                     + '<head>'
                     + '<meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">'

--- a/src/aria/tester/index.html
+++ b/src/aria/tester/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 	<title>Aria Tester</title>

--- a/src/aria/utils/Bridge.js
+++ b/src/aria/utils/Bridge.js
@@ -152,7 +152,7 @@ Aria.classDefinition({
             // var devPart = "dev/";
 
             var sourceCode = [
-                    '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n',
+                    '<!DOCTYPE html>\n',
                     "<html><head><title>" + config.title + "</title>", // HEAD
 
                     "<script type='text/javascript'>Aria = { _xxDebug: true, rootFolderPath : '" + root

--- a/src/aria/utils/FrameATLoaderHTML.html
+++ b/src/aria/utils/FrameATLoaderHTML.html
@@ -1,27 +1,27 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 </head>
 <body>
-	<script type="text/javascript">
-		Aria = {
-			eval : function(src) {
-				return eval(src);
-			}
-		};
-		(function() {
-			var href = decodeURIComponent(window.location.search.substring(1));
-			var head = document.getElementsByTagName('head')[0];
-			var base = document.createElement('base');
-			base.setAttribute('href', href);
-			head.appendChild(base);
+<script type="text/javascript">
+Aria = {
+	eval : function(src) {
+		return eval(src);
+	}
+};
+(function() {
+	var href = decodeURIComponent(window.location.search.substring(1));
+	var head = document.getElementsByTagName('head')[0];
+	var base = document.createElement('base');
+	base.setAttribute('href', href);
+	head.appendChild(base);
 
-			var hash = window.location.hash.substring(1);
-			window.location.hash = "";
-			(opener || parent).aria.utils.FrameATLoader.callFromFrame(hash);
-		})()
-	</script>
+	var hash = window.location.hash.substring(1);
+	window.location.hash = "";
+	(opener || parent).aria.utils.FrameATLoader.callFromFrame(hash);
+})()
+</script>
 </body>
 </html>

--- a/test/aria/core/test/TestFile.html
+++ b/test/aria/core/test/TestFile.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head><title>HTML mock content for file upload</title></head>
 <body><textarea>Test file content. &amp;lt;=&lt;  &amp;gt;=&gt;.Tags: <b>in a &lt;b&gt; tag</b>.</textarea></body>
 </html>

--- a/test/aria/modules/requestHandler/test/WrongType.html
+++ b/test/aria/modules/requestHandler/test/WrongType.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/test/aria/templates/testmode/TestIdsTestCase.html
+++ b/test/aria/templates/testmode/TestIdsTestCase.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title>Generated Ids for test</title>


### PR DESCRIPTION
Let's just use HTML5's <!DOCTYPE html> everywhere.
Also strip some indentation in `FrameATLoaderHTML` which is deployed unminified.
