### PR TITLE
fix #868 Introducing allowInvalidText property for Selectbox widget

### DIFF
--- a/src/aria/DomEvent.js
+++ b/src/aria/DomEvent.js
@@ -439,7 +439,7 @@
                 }
                 // changed for PTR04462051 as hyphens were included and this was breaking the AutoComplete widget.
                 if (kc == 45 || kc == 46) {
-                    return false; // insert or delete
+                    return true; // insert or delete
                 }
                 /*
                  * not a special key, just / * - + if (kc == 106 || kc == 107 || kc == 109 || kc == 111) { return true; }

--- a/src/aria/jsunit/RobotJavaApplet.js
+++ b/src/aria/jsunit/RobotJavaApplet.js
@@ -67,6 +67,7 @@ Aria.classDefinition({
             VK_BACK_QUOTE : 192,
             VK_BACK_SLASH : 92,
             VK_BACK_SPACE : 8,
+            VK_BACKSPACE : 8,
             VK_BEGIN : 65368,
             VK_BRACELEFT : 161,
             VK_BRACERIGHT : 162,

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -816,6 +816,11 @@ Aria.beanDefinitions({
                     },
                     $default : []
                 },
+                "allowInvalidText" : {
+                    $type : "json:Boolean",
+                    $description : "If true gives to the user the possibility to type inside the input field whatever he wants",
+                    $default : false
+                },
                 "bind" : {
                     $type : "DropDownTextInputCfg.bind",
                     $properties : {

--- a/src/aria/widgets/controllers/SelectBoxController.js
+++ b/src/aria/widgets/controllers/SelectBoxController.js
@@ -30,7 +30,7 @@ Aria.classDefinition({
          * @protected
          */
         this._options = null;
-
+        this._allowInvalidText = false;
     },
     $statics : {
         /**
@@ -242,6 +242,9 @@ Aria.classDefinition({
                 jsonUtils.setValue(dataModel, 'listContent', sgs);
                 jsonUtils.setValue(dataModel, 'selectedIdx', exactMatch);
                 dataModel.initialInput = report.text;
+            } else if (this._allowInvalidText) {
+                report.text = nextValue;
+                report.displayDropDown = false;
             }
             report.cancelKeyStroke = true;
             return report;

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -25,7 +25,7 @@ Aria.classDefinition({
         DUPLICATE_VALUE : "%1 - Duplicate values %2 found in options"
     },
     /**
-     * RadioButton constructor
+     * Selectbox constructor
      * @param {aria.widgets.CfgBeans:SelectBoxCfg} cfg the widget configuration
      * @param {aria.templates.TemplateCtxt} ctxt template context
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
@@ -34,6 +34,12 @@ Aria.classDefinition({
         var controller = new aria.widgets.controllers.SelectBoxController();
         this.$DropDownTextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         this.controller.setListOptions(this._cfg.options);
+        controller._allowInvalidText = cfg.allowInvalidText;
+    },
+    $destructor : function () {
+        var field = this.getTextInputField();
+        aria.utils.Event.removeListener(field, "paste");
+        this.$DropDownTextInput.$destructor.call(this);
     },
     $prototype : {
         /**
@@ -52,6 +58,17 @@ Aria.classDefinition({
                     p[key] = src[key];
                 }
             }
+        },
+        /**
+         * OVERRIDE initWidget
+         */
+        initWidget : function () {
+            this.$DropDownTextInput.initWidget.call(this);
+            var field = this.getTextInputField();
+            aria.utils.Event.addListener(field, "paste", {
+                fn : this._onpaste,
+                scope : this
+            });
         },
         /**
          * This method checks the consistancy of the values provided in the attributes of SelectBox and logs and error
@@ -77,6 +94,19 @@ Aria.classDefinition({
                 this.$logError(this.DUPLICATE_VALUE, [dupValues]);
             }
 
+        },
+        /**
+         * This method prevent to paste something inside the input field if the allowInvalidText property is set to false
+         * if there are any descripancies
+         */
+        _onpaste : function (event) {
+            if (!this._cfg.allowInvalidText) {
+                if (event.preventDefault) {
+                    event.preventDefault(true);
+                } else {
+                    event.returnValue = false;
+                }
+            }
         },
         /**
          * Internal method called when one of the model property that the widget is bound to has changed Must be

--- a/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
@@ -19,6 +19,7 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
         this.addTests("test.aria.widgets.form.selectbox.SelectboxTestCase");
+        this.addTests("test.aria.widgets.form.selectbox.checkInvalidText.MainTemplateTestCase");
         this.addTests("test.aria.widgets.form.selectbox.checkValue.MainTemplateTestCase");
         this.addTests("test.aria.widgets.form.selectbox.checkTypeLetters.SelectBoxTypeAllLetters");
     }

--- a/test/aria/widgets/form/selectbox/checkInvalidText/MainTemplate.tpl
+++ b/test/aria/widgets/form/selectbox/checkInvalidText/MainTemplate.tpl
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+  $classpath : "test.aria.widgets.form.selectbox.checkInvalidText.MainTemplate"
+}}
+
+  {macro main()}
+      <h2>Selectbox with alloowInvalidText = true</h2>
+      {@aria:SelectBox {
+        id : "selectbox1",
+        label : "Choose one option: ",
+        allowInvalidText : true,
+        options : data.countries,
+        bind : {
+          options : {
+            inside : data,
+            to : "countries"
+            }
+        }
+      }/}
+
+      <h2>Selectbox with alloowInvalidText = false (default case)</h2>
+      {@aria:SelectBox {
+        id : "selectbox2",
+        label : "Choose one option: ",
+        allowInvalidText : false,
+        options : data.countries,
+        bind : {
+          options : {
+            inside : data,
+            to : "countries"
+            }
+        }
+      }/}
+
+    {/macro}
+{/Template}

--- a/test/aria/widgets/form/selectbox/checkInvalidText/MainTemplateTestCase.js
+++ b/test/aria/widgets/form/selectbox/checkInvalidText/MainTemplateTestCase.js
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.selectbox.checkInvalidText.MainTemplateTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {
+            countries : [{
+                        value : "FR",
+                        label : "France"
+                    }, {
+                        value : "CH",
+                        label : "Switzerland"
+                    }, {
+                        value : "UK",
+                        label : "United Kingdom"
+                    }, {
+                        value : "BR",
+                        label : "Brazil"
+                    }, {
+                        value : "ES",
+                        label : "Spain"
+                    }, {
+                        value : "IT",
+                        label : "Italy"
+                    }, {
+                        value : "SE",
+                        label : "Sweden"
+                    }, {
+                        value : "USA",
+                        label : "United States of America"
+                    }]
+        };
+
+        this.setTestEnv({
+            template : "test.aria.widgets.form.selectbox.checkInvalidText.MainTemplate",
+            data : this.data
+        });
+        this.selectbox1 = null;
+        this.selectbox2 = null;
+    },
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            this.selectbox1 = this.getInputField("selectbox1");
+            this.selectbox2 = this.getInputField("selectbox2");
+
+            this.synEvent.click(this.selectbox1, {
+                fn : this.typeInsideFirstSelectBox,
+                scope : this
+            });
+        },
+        /**
+         * Type an invalid entry inside the first selectbox (that has the allowInvalidText = true)
+         */
+        typeInsideFirstSelectBox : function () {
+            this.synEvent.type(this.selectbox1, "Germany", {
+                fn : this.afterTypingInvalidText,
+                scope : this
+            });
+        },
+        /**
+         * Check that the input field is updated and delete one character using backspace key
+         */
+        afterTypingInvalidText : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Germany", "The Selectbox value should be equal to Germany");
+            this.synEvent.type(this.selectbox1, "[backspace]", {
+                fn : this.afterRemovingByBackspace,
+                scope : this
+            });
+        },
+        /**
+         * Test backspace is working and remove 2 characters using delete key
+         */
+        afterRemovingByBackspace : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "German", "The Selectbox value should be equal to German (without y)");
+            this.synEvent.type(this.selectbox1, "[left][left][delete][delete]", {
+                fn : this.afterRemovingByDelete,
+                scope : this
+            });
+        },
+        /**
+         * Test delete is working, clean the field and put another invalid entry
+         */
+        afterRemovingByDelete : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Germ", "The Selectbox value should be equal to Germ");
+            this.synEvent.type(this.selectbox1, "[backspace][backspace][backspace][backspace]Japan", {
+                fn : this.prepareCopy,
+                scope : this
+            });
+        },
+        /**
+         * CTRL+C to copy the invalid text
+         */
+        prepareCopy : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Japan", "The Selectbox value should be equal to Japan");
+            aria.utils.Caret.setPosition(this.selectbox1, 0, 5);
+            this.synEvent.type(this.selectbox1, "[<CTRL>]c[>CTRL<]", {
+                fn : this.onCopy,
+                scope : this
+            });
+        },
+        /**
+         * Check the input value and clean the input field
+         */
+        onCopy : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Japan", "The Selectbox value should be equal to Japan");
+            this.synEvent.type(this.selectbox1, "[backspace][backspace][backspace][backspace][backspace]", {
+                fn : this.afterRemovingEverything,
+                scope : this
+            });
+        },
+        /**
+         * CTRL+V to paste the invalid text
+         */
+        afterRemovingEverything : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value === "", "The Selectbox value should be empty");
+            this.synEvent.type(this.selectbox1, "[<CTRL>]v[>CTRL<]", {
+                fn : this.onPaste,
+                scope : this
+            });
+        },
+        /**
+         * After pasting, check that the input field is updated
+         */
+        onPaste : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Japan", "The Selectbox value should be equal to Japan");
+            this.synEvent.type(this.selectbox1, "[backspace]", {
+                fn : this.afterRemovingByBackspaceTwo,
+                scope : this
+            });
+        },
+        /**
+         * Checking that backspace is still working
+         */
+        afterRemovingByBackspaceTwo : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Japa", "The Selectbox value should be equal to Japa (without n)");
+            this.synEvent.type(this.selectbox1, "[left][left][delete]", {
+                fn : this.afterRemovingByDeleteTwo,
+                scope : this
+            });
+        },
+        /**
+         * Checking that delete is still working and focus on the second selectbox (that has the allowInvalidText = false)
+         */
+        afterRemovingByDeleteTwo : function () {
+            var value = this.selectbox1.value;
+            this.assertTrue(value == "Jaa", "The Selectbox value should be equal to Jaa");
+
+            this.synEvent.click(this.selectbox2, {
+                fn : this.typeInsideSecondSelectBox,
+                scope : this
+            });
+        },
+        /**
+         * Type an invalid text
+         */
+        typeInsideSecondSelectBox : function () {
+            this.synEvent.type(this.selectbox2, "A", {
+                fn : this.afterTypingInvalidTextThree,
+                scope : this
+            });
+        },
+        /**
+         * Check that the input field is not updated and paste an invalid text
+         */
+        afterTypingInvalidTextThree : function () {
+            var value = this.selectbox2.value;
+            this.assertTrue(value === "", "The Selectbox value should be empty");
+
+            this.synEvent.type(this.selectbox2, "[<CTRL>]v[>CTRL<]", {
+                fn : this.onPasteTwo,
+                scope : this
+            });
+        },
+        /**
+         * After pasting, check that the input field is not updated
+         */
+        onPasteTwo : function () {
+            var value = this.selectbox2.value;
+            this.assertTrue(value === "", "The Selectbox value should be empty");
+            this.synEvent.type(this.selectbox2, "Bra", {
+                fn : this.onLastType,
+                scope : this
+            });
+        },
+        /**
+         * Check that the selectbox is working typing a valid text
+         */
+        onLastType : function () {
+            var value = this.selectbox2.value;
+            this.assertTrue(value == "Bra", "The Selectbox value should be equal to Bra");
+            this.synEvent.type(this.selectbox2, "[backspace][backspace][backspace]", {
+                fn : this.onLastDelete,
+                scope : this
+            });
+        },
+        /**
+         * Check that the backspace is working
+         */
+         onLastDelete : function () {
+            var value = this.selectbox2.value;
+            this.assertTrue(value === "", "The Selectbox value should be empty");
+            this.notifyTemplateTestEnd();
+        }
+
+    }
+});


### PR DESCRIPTION
Adding the possibility to define the allowInvalidText property in order to give to the user the possibility to write whatever he wants inside the input field of a selectbox widget.
