### PR TITLE
Form serialization method

### DIFF
--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -325,7 +325,16 @@ Aria.classDefinition({
         },
 
         /**
-         * Make a pseudo asynchronous form submission.
+         * Make a pseudo asynchronous form submission. The form is submitted through an iframe, that is set as the
+         * target of the form. When calling this method, the form is actually submitted, so that the response is added
+         * in the body of the iframe. This mechanism is a common workaround that avoids the full refresh of the current
+         * page, as everything happens in the iframe. BEWARE: this method may fail in certain browsers depending on the
+         * Content-Type of the response. For example, if the Content-Type of the response is "application/json", some
+         * browsers will not output its content inside the body, or will prompt you to save or open the file. XML
+         * responses are generally accepted. In these specific cases, bear in mind that it is possible to serialize a
+         * form using method aria.utils.Html.serializeForm and use the extracted string as the data of a standard ajax
+         * request (aria.core.IO.asyncRequest). This will not be possible if some of the elements of your form are not
+         * serializable.
          * @param {aria.core.CfgBeans:IOAsyncRequestCfg} request Request description
          *
          * <pre>

--- a/src/aria/utils/Html.js
+++ b/src/aria/utils/Html.js
@@ -79,6 +79,62 @@ Aria.classDefinition({
                 }
             }
             return result.join('');
+        },
+
+        /**
+         * Turn an HTML form element into a string that contains the list of name-value pairs of all relevant elements
+         * of the form. For example, the following form
+         *
+         * <pre>
+         * &lt;form id=&quot;myForm&quot;&gt;
+         *     &lt;input type=&quot;text&quot; name=&quot;firstname&quot; value=&quot;Colin&quot;&gt;
+         *     &lt;input type=&quot;text&quot; name=&quot;lastname&quot; value=&quot;Pitt&quot; disabled&gt;
+         *     &lt;input type=&quot;date&quot; name=&quot;birth&quot; value=&quot;2012-04-04&quot;
+         *     &lt;input type=&quot;text&quot;&gt;
+         *     &lt;input type=&quot;file&quot; name=&quot;picture&quot; /&gt;
+         *     &lt;input type=&quot;submit&quot; name=&quot;submit&quot;/&gt;
+         *     &lt;input type=&quot;checkbox&quot; name=&quot;vehicle&quot; value=&quot;Bike&quot; checked /&gt;
+         * &lt;/form&gt;
+         * </pre>
+         *
+         * yields
+         *
+         * <pre>
+         * firstname
+         * =Colin&amp;birth=2012-04-04&amp;vehicle=Bike
+         * </pre>
+         *
+         * This method can be useful when you want to send the form information as data of an ajax call
+         * @param {HTMLElement} form
+         * @return {String}
+         */
+        serializeForm : function (form) {
+            var elements = form.elements, params = [], element, name, value;
+            for (var i = 0, len = elements.length; i < len; i++) {
+                element = elements[i];
+                if (this._isSerializable(element)) {
+                    name = encodeURIComponent(element.name);
+                    value = encodeURIComponent(element.value.replace(/\r?\n/g, "\r\n"));
+                    params.push(name + "=" + value);
+                }
+            }
+            return params.join("&").replace(/%20/g, "+");
+        },
+
+        /**
+         * Return true if the HTML element is serializable in a form. Serializable elements are input, select, textarea,
+         * keygen, which have a name attribute, a certain type, and are not disabled
+         * @param {HTMLElement} element
+         * @return {Boolean}
+         */
+        _isSerializable : function (element) {
+            var submittable = /^(?:input|select|textarea|keygen)/i;
+            var submitterTypes = /^(?:submit|button|image|reset|file)$/i;
+            var type = element.type;
+            var checkableTypes = /^(?:checkbox|radio)$/i;
+
+            return element.name && !element.disabled && submittable.test(element.nodeName)
+                    && !submitterTypes.test(type) && (element.checked || !checkableTypes.test(type));
         }
     }
 });

--- a/test/aria/utils/Html.js
+++ b/test/aria/utils/Html.js
@@ -143,6 +143,48 @@ Aria.classDefinition({
             };
             json.dataset[key] = "test";
             return aria.utils.Html.buildAttributeList(json);
+        },
+
+        test_serializeForm : function () {
+
+            var document = Aria.$window.document, testDiv = document.createElement("div"), html = aria.utils.Html;
+            document.body.appendChild(testDiv);
+            testDiv.innerHTML = '<form id="testForm"></form>';
+            var testFormElement = document.getElementById("testForm");
+
+            // simple scenario
+            testFormElement.innerHTML = '<input type="text" name="firstname" value="Colin"/><input type="date" name="birth" value="2012-04-04"/>';
+            this.assertEquals(html.serializeForm(testFormElement), "firstname=Colin&birth=2012-04-04");
+
+            // disabled element
+            testFormElement.innerHTML = '<input type="text" name="firstname" value="Colin"/><input type="date" name="birth" value="2012-04-04" disabled/>';
+            this.assertEquals(html.serializeForm(testFormElement), "firstname=Colin");
+
+            // element without name attribute
+            testFormElement.innerHTML = '<input type="text" name="firstname" value="Colin"/><input type="date" value="2012-04-04" />';
+            this.assertEquals(html.serializeForm(testFormElement), "firstname=Colin");
+
+            // element without value
+            testFormElement.innerHTML = '<input type="text" name="firstname"/><input type="date" value="2012-04-04" />';
+            this.assertEquals(html.serializeForm(testFormElement), "firstname=");
+
+            // element with characters to encode
+            testFormElement.innerHTML = '<input type="text" name="first name" value="Co&in"/><input type="date" value="2012-04-04" />';
+            this.assertEquals(html.serializeForm(testFormElement), "first+name=Co%26in");
+
+            // submittable element
+            testFormElement.innerHTML = '<input type="text" name="first name" value="Co&in"/><input type="file" name="picture" />';
+            this.assertEquals(html.serializeForm(testFormElement), "first+name=Co%26in");
+
+            // select and textarea
+            testFormElement.innerHTML = '<select type="text" name="class" value="A"><option value="A">A</option><option value="B">B</option></select><textarea name="comment">whatever you want</textarea>';
+            this.assertEquals(html.serializeForm(testFormElement), "class=A&comment=whatever+you+want");
+
+            // checkbox
+            testFormElement.innerHTML = '<input type="checkbox" name="vehicle" value="Bike" checked /><input type="checkbox" name="other" value="Car" />';
+            this.assertEquals(html.serializeForm(testFormElement), "vehicle=Bike");
+
+            document.body.removeChild(testDiv);
         }
     }
 });


### PR DESCRIPTION
A new method is available in singleton aria.utils.Html. It allows to serialize forms in order to use standard ajax calls to submit them.
