### PR TITLE
feat #102 timeout for RequestMgr.send|submitJsonRequest

### DIFF
--- a/src/aria/modules/RequestBeans.js
+++ b/src/aria/modules/RequestBeans.js
@@ -64,6 +64,10 @@ Aria.beanDefinitions({
                     $type : "env:RequestJsonSerializerCfg",
                     $description : "JSON serializer settings that have to be used for this request"
                 },
+                "timeout" : {
+                    $type : "json:Integer",
+                    $description : "Timeout in milliseconds (after which the request is canceled if no answer was received before). If this parameter is not set, the default timeout applies (specified in aria.core.IO.defaultTimeout). This property can be changed by filters."
+                },
                 /* Backward Compatibility begins here */
                 "postHeader" : {
                     $type : "json:String",

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -300,6 +300,7 @@ Aria.classDefinition({
                 requestObject : requestObject,
                 jsonData : jsonData,
                 data : null,
+                timeout : requestObject.timeout,
                 method : "POST"
             }, id = this._idCounter++;
 
@@ -381,6 +382,7 @@ Aria.classDefinition({
                 method : req.method,
                 postData : req.data,
                 headers : req.headers,
+                timeout : req.timeout,
                 callback : {
                     fn : this._onresponse,
                     onerror : this._onresponse,

--- a/test/aria/modules/RequestMgrTimeoutTest.js
+++ b/test/aria/modules/RequestMgrTimeoutTest.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for the timeouts in `sendJsonRequest` and `submitJsonRequest` methods of RequestMgr class. The tests here only
+ * use `sendJsonRequest`, but the interface of `submitJsonRequest` is the same and under the hood (indirectly) it calls
+ * the former method.
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.modules.RequestMgrTimeoutTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.modules.RequestMgr", "aria.core.IOFiltersMgr",
+            "aria.modules.requestHandler.JSONRequestHandler"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.filterPath = "test.aria.modules.test.StaticResponseFilter";
+        this.defaultTestTimeout = 1000;
+    },
+    $prototype : {
+
+        /**
+         * Save parameters of the Request Manager before each test to restore them later.
+         */
+        setUp : function () {
+            this._saved = {
+                filters : aria.core.IOFiltersMgr._filters,
+                handler : aria.modules.RequestMgr._requestHandler
+            };
+
+            aria.modules.RequestMgr._requestHandler = new aria.modules.requestHandler.JSONRequestHandler();
+
+            aria.core.IOFiltersMgr._filters = null;
+            aria.core.IOFiltersMgr.addFilter({
+                classpath : this.filterPath
+            });
+        },
+
+        /**
+         * Restore saved parameters of the Request Manager after each test.
+         */
+        tearDown : function () {
+            aria.core.IOFiltersMgr.removeFilter(this.filterPath);
+            aria.core.IOFiltersMgr._filters = this._saved.filters;
+
+            aria.modules.RequestMgr._requestHandler.$dispose();
+            aria.modules.RequestMgr._requestHandler = this._saved.handler;
+        },
+
+        /**
+         * Set very low timeout; check that the callback is called with error=true
+         */
+        testAsyncHaveTimeoutLegacy : function () {
+            aria.modules.RequestMgr.sendJsonRequest({
+                moduleName : "xxx",
+                actionName : "yyy",
+                timeout : 1
+            }, {
+                reqData : "test"
+            }, {
+                fn : this._haveTimeoutOkCbWithError,
+                scope : this
+            });
+        },
+
+        _haveTimeoutOkCbWithError : function (resp) {
+            this.assertEquals(resp.error, true, "This request should have timed out.");
+            this.notifyTestEnd("testAsyncHaveTimeoutLegacy");
+        },
+
+        /**
+         * Set high enough timeout and check that the success callback is called without errors.
+         */
+        testAsyncNoTimeout : function () {
+            aria.modules.RequestMgr.sendJsonRequest({
+                moduleName : "xxx",
+                actionName : "yyy",
+                timeout : 1000
+            }, {
+                reqData : "test"
+            }, {
+                fn : this._noTimeoutOkCb,
+                scope : this,
+                onerror : this._noTimeoutErrorCb
+            });
+        },
+
+        _noTimeoutOkCb : function (resp) {
+            this.assertTrue(resp.error == null);
+            this.assertTrue(resp.response != null);
+            this.assertEquals(resp.response.hello, "world");
+
+            this.notifyTestEnd("testAsyncHaveTimeoutWithErrorCb");
+        },
+
+        _noTimeoutErrorCb : function (resp) {
+            this.fail("This function should NOT have been called");
+        }
+    }
+});

--- a/test/aria/modules/test/SampleResponse.json
+++ b/test/aria/modules/test/SampleResponse.json
@@ -1,0 +1,3 @@
+{
+    "hello" : "world"
+}

--- a/test/aria/modules/test/StaticResponseFilter.js
+++ b/test/aria/modules/test/StaticResponseFilter.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Sample filter which returns a static response.
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.modules.test.StaticResponseFilter",
+    $extends : "aria.core.IOFilter",
+    $constructor : function (args) {
+        args = args || {};
+        this.$IOFilter.constructor.call(this, args);
+
+        this._responseFile = args.responseFile || "test/aria/modules/test/SampleResponse.json";
+    },
+    $prototype : {
+
+        /**
+         * Method called before a request is sent to get a chance to change its arguments
+         * @override
+         * @param {aria.modules.RequestMgr.FilterRequest} req
+         */
+        onRequest : function (req) {
+            req.delay = this.requestDelay;
+            this.redirectToFile(req, this._responseFile, true);
+        },
+
+        /**
+         * Method called when a response is received to change the result values before the RequestMgr callback is
+         * called
+         * @override
+         * @param {aria.modules.RequestMgr.FilterResponse} resp
+         */
+        onResponse : function (resp) {
+            resp.delay = this.responseDelay;
+        }
+    }
+});


### PR DESCRIPTION
It's been always possible to pass a `timeout` to the calls of
    `aria.core.IO.asyncRequest`
    `aria.core.IO.asyncFormSubmit`
but not to the calls of
    `aria.modules.RequestMgr.submitJsonRequest`
    `aria.modules.RequestMgr.sendJsonRequest`

The latter only had the `aria.core.IO.defaultTimeout` applied.

This commit makes it possible to pass `timeout` as the key of the request
parameter object (first parameter) of them.

---

After discussion with David, I removed the previously added `onerror` handler from RequestMgr.
