### PR TITLE
fix #858 bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "test": "npm run-script lint && npm run-script grunt && npm run-script mocha && npm run-script attester"
   },
   "devDependencies": {
-    "gzip-js": "0.3.2",
-    "grunt-verifylowercase": "0.2.0",
+    "atpackager": "0.2.2",
+    "attester": "1.3.0",
+    "express": "3.4.8",
+    "grunt": "0.4.2",
+    "grunt-contrib-jshint": "0.8.0",
     "grunt-leading-indent": "0.1.0",
-    "grunt": "git+https://github.com/divdavem/grunt.git#13da751bdfd291c25a47ca7669ae0778eb289b28",
-    "grunt-contrib-jshint": "0.6.3",
-    "attester": "1.2.0",
-    "express": "3.3.5",
-    "jade": "0.34.1",
-    "atpackager": "0.1.0",
-    "mocha": "1.11.0"
+    "grunt-verifylowercase": "0.2.0",
+    "gzip-js": "0.3.2",
+    "jade": "1.1.5",
+    "mocha": "1.17.0"
   }
 }

--- a/scripts/assets/views/playground.jade
+++ b/scripts/assets/views/playground.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
 	head
 		meta(charset="utf-8")

--- a/scripts/assets/views/test.jade
+++ b/scripts/assets/views/test.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
 	head
 		meta(charset="utf-8")

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -26,7 +26,7 @@
             return null;
         if (typeof(expectedEvt) != typeof(evt))
             return [];
-        if (typeof(expectedEvt) == 'object' || typeof(expectedEvt) == 'array') {
+        if (typeof(expectedEvt) == 'object') {
             for (var i in expectedEvt) {
                 var res = diffObjects(evt[i], expectedEvt[i]);
                 if (res != null) {


### PR DESCRIPTION
Update to Grunt 0.4.2, Attester 1.3.0, and other new versions.

Sorted deps alphabetically by the way. Minor code fixes done for new versions of JSHint (the new check was failing build) and Jade (to have pages behind `npm start` work).

---

Regarding the change in Assert.js: typeof array is object so the second check is not needed ( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof )
