### PR TITLE
fix #917 Remove unnecessary body focus in aria.templates.TemplateCtxt.$focus

### DIFF
--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -1463,9 +1463,6 @@
              * @implements aria.templates.ITemplate
              */
             $focus : function (idArray) {
-                if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
-                    Aria.$window.document.body.focus();
-                }
                 var idToFocus;
                 if (aria.utils.Type.isArray(idArray)) {
                     idArray = idArray.slice(0);

--- a/test/aria/templates/keyboardNavigation/TableNavTestCase.js
+++ b/test/aria/templates/keyboardNavigation/TableNavTestCase.js
@@ -39,9 +39,6 @@ Aria.classDefinition({
         },
         runTemplateTest : function () {
 
-            if (aria.core.Browser.isIE8 || aria.core.Browser.isIE7) {
-                this.notifyTemplateTestEnd(); // FIXME!! PTR 06248406
-            }
             // clean what was before
             this._disposeTestTemplate();
 


### PR DESCRIPTION
This one broke test.aria.templates.keyboardNavigation.TableNavTestCase on IE <= 8
