### PR TITLE
Section processing indicator not following parent section if not bound to the data model

### DIFF
--- a/src/aria/templates/Section.js
+++ b/src/aria/templates/Section.js
@@ -638,7 +638,7 @@
              */
             registerProcessing : function (bind) {
                 if (!bind || !this.__isValidProcessingBind(bind)) {
-                    return;
+                    bind = { inside: {}, to: 'processing' };
                 }
 
                 this.registerBinding(bind, this._notifyProcessingChange);


### PR DESCRIPTION
If one creates a section inside a movable parent (for example a dialog) and creates a process indicator on it by using `this.$getElementById('sectionId').setProcessingIndicator(true, '')` (called on the attached `SectionWrapper` companion) the behaviour is different whether the `bindProcessingTo` attribute of section configuration has been set.

If one activates the spinner on a section for which processing indicator is not bound and then moves the dialog, the spinner remains at the same place. And if one closes the dialog the spinner remains in place. If otherwise processing indicator activation is bound then the spinner follows and closes correctly.

Can be seem using this [demo gist](https://gist.github.com/mathbruyen/8349721).

It sound very strange to me that binding state or letting it free has an impact on spinner behaviour. To me the binding is just another way of enabling/disabling spinner, it should not impact behaviour.

The proposed fix is not smart, but I tried debugging and did not find where the difference was on dialog closing. If the proposed approach (always having a binding) is to be kept, then a bit of cleanup can be done in `Section` not to test whether it is bound (because it will be).
