### PR TITLE
fix for IE7 bug (when focused, a click outside the multiselect does not trigger the blur event)

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -847,8 +847,10 @@ Aria.classDefinition({
                     domEvent : domEvent
                 };
                 this.$raiseEvent(event);
-                this.close(domEvent);
-                return true;
+                if (!event.cancelClose) {
+                    this.close(domEvent);
+                    return true;
+                }
             }
         },
 

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -49,6 +49,7 @@ Aria.classDefinition({
             var onDescription = {
                 "onAfterOpen" : this._afterDropdownOpen,
                 "onAfterClose" : this._afterDropdownClose,
+                "onMouseClickClose" : this._dropDownMouseClickClose,
                 scope : this
             };
 
@@ -143,8 +144,34 @@ Aria.classDefinition({
             this._dropdownPopup.$dispose();
             this._dropdownPopup = null;
             aria.templates.Layout.$unregisterListeners(this);
-            this.focus(null, true);
+            if (!aria.core.Browser.isIE) {
+                this.focus(null, true);
+            }
             this._keepFocus = false;
+        },
+
+        /**
+         * Callback for the event onMouseClickClose raised by the popup. <br>
+         * fix for PTR07002335: method used to fix IE bug (a click in a text input does not trigger the blur event on
+         * the previously selected multiselect input, so that the activeElement does not change properly)
+         * @protected
+         */
+        _dropDownMouseClickClose : function (evt) {
+            if (aria.core.Browser.isIE) {
+                evt.cancelClose = true;
+                var self = this;
+                setTimeout(function () {
+                    var activeElement = Aria.$window.document.activeElement;
+                    self.focus(null, true);
+                    self._keepFocus = false;
+                    setTimeout(function () {
+                        if (activeElement) {
+                            activeElement.focus();
+                        }
+                        self._dropdownPopup.close();
+                    }, 1);
+                }, 1);
+            }
         },
 
         /**

--- a/test/aria/widgets/form/multiselect/focusIssue/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/focusIssue/MultiSelect.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.focusIssue.MultiSelect",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.jsunit.MultiSelectTemplateTestCase"],
+
+    $prototype : {
+
+        /**
+         * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
+         * by all instances
+         * @param {Object} p the prototype object being built
+         */
+        $init : function (p) {
+            var src = aria.jsunit.MultiSelectTemplateTestCase.prototype;
+            for (var key in src) {
+
+                if (src.hasOwnProperty(key) && !p.hasOwnProperty(key)) {
+                    // copy methods which are not already on this object (this avoids copying $classpath and
+                    // $destructor)
+                    p[key] = src[key];
+                }
+            }
+
+        },
+
+        /**
+         * This method is always the first entry point to a template test Start the test by opening the first
+         * MultiSelect popup.
+         */
+        runTemplateTest : function () {
+            this.ms1 = this.getInputField("ms1");
+            this.ms2 = this.getInputField("ms2");
+            this.synEvent.type(this.ms1, "[down]", {
+                fn : this._onTestMS1,
+                scope : this
+            });
+        },
+
+        _onTestMS1 : function () {
+            this.waitUntilMsOpened('ms1', this._onTestMS2);
+        },
+
+        /**
+         * Click on the second multiselect input.
+         */
+        _onTestMS2 : function () {
+            this.synEvent.click(this.ms2, {
+                fn : this._onTestMS3,
+                scope : this
+            });
+        },
+
+        /**
+         * Open the second multiselect popup.
+         */
+        _onTestMS3 : function () {
+            this.assertEquals(Aria.$window.document.activeElement.value, "AF1");
+            this.synEvent.type(this.ms2, "[down]", {
+                fn : this._onTestMS4,
+                scope : this
+            });
+        },
+
+        _onTestMS4 : function () {
+            this.waitUntilMsOpened('ms2', this._onTestMS5);
+        },
+
+        _onTestMS5 : function () {
+            this.synEvent.click(Aria.$window.document.activeElement, {
+                fn : this._onTestMS6,
+                scope : this
+            });
+        },
+
+        _onTestMS6 : function () {
+            this.synEvent.click(this.ms2, {
+                fn : this.finishTest,
+                scope : this
+            });
+        },
+
+        finishTest : function () {
+            this.assertEquals(this.ms2.value, "AC1,AF1");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/focusIssue/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/focusIssue/MultiSelectTpl.tpl
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.form.multiselect.focusIssue.MultiSelectTpl",
+    $hasScript:false
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {var testItems = {
+          selected: 2,
+          isChecked : false,
+          items: [{
+              value: "AF",
+              label: "Air France",
+              disabled: false
+          },
+          {
+              value: "AC",
+              label: "Air Canada",
+              disabled: false
+          },
+          {
+              value: "NZ",
+              label: "Air New Zealand",
+              disabled: false
+          },
+          {
+              value: "DL",
+              label: "Delta Airlines",
+              disabled: false
+          },
+          {
+              value: "AY",
+              label: "Finnair",
+              disabled: false
+          },
+          {
+              value: "IB",
+              label: "Iberia",
+              disabled: true
+          },
+          {
+              value: "LH",
+              label: "Lufthansa",
+              disabled: false
+          },
+          {
+              value: "MX",
+              label: "Mexicana",
+              disabled: false
+          },
+          {
+              value: "QF",
+              label: "Quantas",
+              disabled: false
+          }],
+          tableItems: [{
+                  value: "AF1",
+                  label: "Air France|1st Class|AF",
+                  disabled: false
+              },
+              {
+                  value: "AF2",
+                  label: "Air France|Business Class|AF",
+                  disabled: false
+              },
+              {
+                  value: "AC1",
+                  label: "Air Canada|1st Class|AF",
+                  disabled: false
+              },
+              {
+                  value: "AC2",
+                  label: "Air Canada|Business Class|AF",
+                  disabled: false
+              }]
+        }/}
+
+
+      {@aria:MultiSelect {
+        id:"ms1",
+        activateSort : true,
+        label : "Multi-select 1:",
+        labelWidth : 150,
+        width : 400,
+        fieldDisplay : "code",
+        fieldSeparator :',',
+        valueOrderedByClick : true,
+        maxOptions : 7,
+        numberOfRows : 4,
+        displayOptions : {
+          flowOrientation : 'horizontal',
+          listDisplay : "both",
+          displayFooter : true
+        },
+        items : testItems.items,
+        value : ["AC"]
+      }/}
+
+
+
+      {@aria:MultiSelect {
+        id:"ms2",
+        activateSort : true,
+        label : "Multi-select 2:",
+        labelWidth : 150,
+        width : 400,
+        fieldDisplay : "code",
+        fieldSeparator : ',',
+        valueOrderedByClick : true,
+        maxOptions : 7,
+        numberOfRows : 9,
+        displayOptions : {
+          flowOrientation :'horizontal',
+          tableMode : true,
+          listDisplay : "both"
+        },
+        items : testItems.tableItems,
+        value : ["AF1"]
+      }/}
+
+
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
fix for IE bug (a click in a text input does not trigger the blur event on the previously selected multiselect input, so that the activeElement does not change properly)
