### PR TITLE
Mispositioned labels in TextArea in IE7

### DIFF
--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -273,7 +273,11 @@ Aria.classDefinition({
             } else {
                 out.write('vertical-align:' + IE7Align + ';');
             }
-            out.write('display:' + cssDisplay);
+            if (aria.core.Browser.isIE7 && cssDisplay === "inline-block") {
+                out.write('display:inline;zoom:1');
+            } else {
+                out.write('display:' + cssDisplay);
+            }
             if (margin) {
                 out.write(';margin-' + margin + ':' + this._labelPadding + 'px');
             }

--- a/src/aria/widgets/frames/TableFrame.js
+++ b/src/aria/widgets/frames/TableFrame.js
@@ -103,7 +103,13 @@ Aria.classDefinition({
             };
             this._appendInnerWidthInfo(sizeInfo);
             this._appendInnerHeightInfo(sizeInfo);
-            var displayInline = (this._inlineBlock) ? "display:inline-block;vertical-align: middle;" : "";
+            var displayInline = "";
+
+            if (this._inlineBlock) {
+                displayInline = "vertical-align: middle;display: inline";
+                displayInline += (aria.core.Browser.isIE7) ? ";zoom:1" : "-block;";
+            }
+
             out.write(['<table cellspacing="0" cellpadding="0" style="position: relative;' + displayInline + '"',
                     frameContainerClass, '><tbody isFrame="1">', '<tr>', '<td class="', cssPrefix, 'tlc ', cssPrefix,
                     'bkgA"></td>', '<td class="', cssPrefix, 'ts ', cssPrefix,


### PR DESCRIPTION
This commit fixes the display:inline-block bug in IE7 that is affecting the label position for the TextArea widget.
