### PR TITLE
fix #934 Missing and duplicate tests in the suite

### DIFF
--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -70,7 +70,7 @@ Aria.classDefinition({
 
         this.addTests("test.aria.templates.dynamicSection.DynSectionTestCase");
         this.addTests("test.aria.templates.focusHandling.FocusHandlingTestCase");
-        this.addTests("test.aria.templates.focusHandling.FocusHandlingTestCase");
+        this.addTests("test.aria.templates.focusHandling.focuscheck.FocusCheckTestCase");
         this.addTests("test.aria.templates.inheritance.TemplateInheritanceTestCase");
         this.addTests("test.aria.templates.generatedId.IncrementalElementIdTestCase");
         this.addTests("test.aria.templates.issue142.HtmlStyleTemplateTestCase");

--- a/test/aria/utils/UtilsTestSuite.js
+++ b/test/aria/utils/UtilsTestSuite.js
@@ -21,7 +21,6 @@ Aria.classDefinition({
 
         this.addTests("test.aria.utils.cssLoader.CSSLoader");
         this.addTests("test.aria.utils.cfgframe.AriaWindowTest");
-        this.addTests("test.aria.utils.dragdrop.DragDropBean");
         this.addTests("test.aria.utils.css.AnimationsTestSuite");
         this.addTests("test.aria.utils.css.Effects");
         this.addTests("test.aria.utils.environment.EnvironmentTestSuite");


### PR DESCRIPTION
1) `test.aria.utils.dragdrop.DragDropBean` is included later via `test.aria.utils.dragdrop.DragTestSuite`
which you can see in Travis logs https://travis-ci.org/ariatemplates/ariatemplates/builds/15773779#L844

2) Seems that `FocusHandlingTestCase` was a duplicate for 6 months while `FocusCheckTestCase` was not included in any suite (probably a copy-paste error) and no one noticed. Time to work on #924 finally?
