### PR TITLE
fix #936 Cross icon is no longer displayed for input widgets

### DIFF
--- a/src/aria/widgets/GlobalStyle.tpl.css
+++ b/src/aria/widgets/GlobalStyle.tpl.css
@@ -109,7 +109,7 @@
 }
 {/if}
 
-{if aria.core.Browser.isIE10 }
+{if aria.core.Browser.isIE10 || aria.core.Browser.isModernIE}
 .xTextInputInput::-ms-clear {
     display: none;
 }


### PR DESCRIPTION
Resolves the issue in the following samples:
- [TextWidget](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/textfield/binding)
- [DatePicker](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/datepicker/customized)
- [TimeField](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/timefield)
- [NumberField](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/numberfield)
- [DateField](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/datefield)
- [MultiSelect](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/multiselect)
- [AutoComplete](http://snippets.ariatemplates.com/samples/github.com/ariatemplates/documentation-code/tree/master/samples/widgets/autocomplete/basic)
