### PR TITLE
Incorrect sample in bean definition for IOAsyncRequestCfg

### DIFF
--- a/src/aria/core/CfgBeans.js
+++ b/src/aria/core/CfgBeans.js
@@ -277,7 +277,10 @@ Aria.beanDefinitions({
                 "headers" : {
                     $type : "json:Object",
                     $description : "HTTP message headers",
-                    $sample : "{'Content-Type' : 'text/plain', 'Connection' : 'keep-alive'}",
+                    $sample : {
+                        "Content-Type" : "text/plain",
+                        "Connection" : "keep-alive"
+                    },
                     $restricted : false
                 },
                 "timeout" : {

--- a/src/aria/modules/RequestBeans.js
+++ b/src/aria/modules/RequestBeans.js
@@ -76,7 +76,11 @@ Aria.beanDefinitions({
                 /* Backward Compatibility ends here */
                 "headers" : {
                     $type : "json:Object",
-                    $description : "Request Headers to be used."
+                    $description : "Request Headers to be used.",
+                    $sample : {
+                        "Content-Type" : "text/plain",
+                        "Connection" : "keep-alive"
+                    }
                 }
             }
         },


### PR DESCRIPTION
headers property in aria.core.CfgBeans:IOAsyncRequestCfg had an incorrect sample.
