### PR TITLE
Overlay behaviour when body is scrollable

### DIFF
--- a/src/aria/templates/GlobalStyle.tpl.css
+++ b/src/aria/templates/GlobalStyle.tpl.css
@@ -33,6 +33,7 @@
     {call opacity(80)/}
     width: 100%;
     height: 100%;
+    overflow: hidden;
 }
 
 .xOverlay {

--- a/src/aria/utils/DomOverlay.js
+++ b/src/aria/utils/DomOverlay.js
@@ -20,7 +20,7 @@
 Aria.classDefinition({
     $classpath : "aria.utils.DomOverlay",
     $dependencies : ["aria.utils.overlay.LoadingOverlay", "aria.utils.Type", "aria.utils.Event",
-            "aria.utils.AriaWindow"],
+            "aria.utils.AriaWindow", "aria.templates.Layout"],
     $singleton : true,
     $statics : {
         UNIQUE_ID_GENERATOR : 12
@@ -70,9 +70,13 @@ Aria.classDefinition({
                 aria.utils.AriaWindow.attachWindow();
                 // Listen for scroll event to update the position of the overlay
                 aria.utils.Event.addListener(Aria.$window, "scroll", {
-                    fn : this.__onScroll,
+                    fn : this.__refresh,
                     scope : this
                 }, true);
+                aria.templates.Layout.$on({
+                    "viewportResized" : this.__refresh,
+                    scope : this
+                });
             }
         },
 
@@ -83,7 +87,11 @@ Aria.classDefinition({
         _reset : function () {
             if (this.overlays != null) {
                 aria.utils.Event.removeListener(Aria.$window, "scroll", {
-                    fn : this.__onScroll
+                    fn : this.__refresh
+                });
+                aria.templates.Layout.$removeListeners({
+                    "viewportResized" : this.__refresh,
+                    scope : this
                 });
                 aria.utils.AriaWindow.detachWindow();
                 this.overlays = null;
@@ -196,19 +204,21 @@ Aria.classDefinition({
         },
 
         /**
-         * Refresh the position of the overlays after a scroll event
+         * Refresh the position of the overlays
          * @private
          */
-        __onScroll : function () {
+        __refresh : function () {
             // Refresh any open overlay
             this.$assert(184, this.overlays != null);
             var overlays = this.overlays;
             for (var key in overlays) {
                 if (overlays.hasOwnProperty(key)) {
                     var overlay = overlays[key];
-
                     overlay.refreshPosition();
                 }
+            }
+            if (this.bodyOverlay) {
+                this.bodyOverlay.refreshPosition();
             }
         },
 

--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -64,14 +64,33 @@ Aria.classDefinition({
          */
         _setInPosition : function (element, overlay) {
             var geometry = aria.utils.Dom.getGeometry(element);
+            var viewportSize = aria.utils.Dom.getViewportSize();
+            var overlayGeometry = null;
+
+            if (geometry) {
+                overlayGeometry = {
+                    x : Math.max(geometry.x, 0),
+                    y : Math.max(geometry.y, 0)
+                };
+
+                overlayGeometry.width = Math.min(geometry.width + Math.min(geometry.x, 0), viewportSize.width
+                        - overlayGeometry.x);
+                overlayGeometry.height = Math.min(geometry.height + Math.min(geometry.y, 0), viewportSize.height
+                        - overlayGeometry.y);
+            }
+
             var style = overlay.style;
             // geometry may be null if the element is not currently visible
-            if (geometry) {
-                style.top = geometry.y + "px";
-                style.left = geometry.x + "px";
-                style.width = geometry.width + "px";
-                style.height = geometry.height + "px";
+            if (overlayGeometry && overlayGeometry.height > 0 && overlayGeometry.width > 0) {
+                style.top = overlayGeometry.y + "px";
+                style.left = overlayGeometry.x + "px";
+                style.width = overlayGeometry.width + "px";
+                style.height = overlayGeometry.height + "px";
                 style.display = "block";
+                var browser = aria.core.Browser;
+                if (browser.isIE && browser.majorVersion < 9 && overlay.firstChild) {
+                    overlay.firstChild.style.top = Math.round(overlayGeometry.height / 2) + "px";
+                }
             } else {
                 style.display = "none";
             }

--- a/test/aria/utils/overlay/OverlayTestSuite.js
+++ b/test/aria/utils/overlay/OverlayTestSuite.js
@@ -14,9 +14,9 @@
  */
 
 Aria.classDefinition({
-    $classpath: "test.aria.utils.overlay.OverlayTestSuite",
-    $extends: "aria.jsunit.TestSuite",
-    $constructor: function () {
+    $classpath : "test.aria.utils.overlay.OverlayTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.utils.overlay.loadingIndicator.automatic.AutomaticTestCase");
@@ -24,5 +24,6 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.overlay.loadingIndicator.scrollbar.ScrollbarTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.zindex.IndexTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.refresh.RefreshTest");
+        this.addTests("test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest");
     }
 });

--- a/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
+++ b/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            template : "test.aria.utils.overlay.loadingIndicator.scrollableBody.TestTemplate",
+            iframe : true
+        });
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.body = this.testDocument.body;
+            this.body.style.overflow = "auto";
+            this.spanWithLoader = this.testWindow.aria.utils.Dom.getElementById("needLoader");
+            this.domOverlay = this.testWindow.aria.utils.DomOverlay;
+            this.testWindow.Aria.load({
+                classes : ["aria.utils.DomOverlay"],
+                oncomplete : {
+                    fn : this._addLoadingIndicatorOnSpan,
+                    scope : this
+                }
+            });
+        },
+
+        _addLoadingIndicatorOnSpan : function () {
+            this.domOverlay.create(this.spanWithLoader, "just a message");
+            this.domOverlay.create(this.body, "just a message");
+            this._testOverlay(this.spanWithLoader, "none");
+            this._testBodyOverlay();
+
+            this._setScroll(2000, 0);
+            aria.core.Timer.addCallback({
+                fn : this._afterFirstScroll,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterFirstScroll : function () {
+            this._testOverlay(this.spanWithLoader, "block", 300, 200);
+            this._testBodyOverlay();
+
+            this._setScroll(2100, 0);
+            aria.core.Timer.addCallback({
+                fn : this._afterSecondScroll,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterSecondScroll : function () {
+            this._testOverlay(this.spanWithLoader, "block", 300, 100, 0, 20);
+            this._testBodyOverlay();
+
+            this.testIframe.style.width = "100px";
+            aria.core.Timer.addCallback({
+                fn : this._afterResize,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterResize : function () {
+            this._testOverlay(this.spanWithLoader, "none");
+            this._testBodyOverlay();
+
+            this.testIframe.style.width = "1000px";
+            this._setScroll(2500, 0);
+            aria.core.Timer.addCallback({
+                fn : this._afterThirdScroll,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterThirdScroll : function () {
+            this._testOverlay(this.spanWithLoader, "none");
+            this._testBodyOverlay();
+
+            this._setScroll(2000, 1000);
+            aria.core.Timer.addCallback({
+                fn : this._afterForthScroll,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterForthScroll : function () {
+            this._testOverlay(this.spanWithLoader, "none");
+            this._testBodyOverlay();
+
+            this._setScroll(2000, 200);
+            aria.core.Timer.addCallback({
+                fn : this._afterFifthScroll,
+                scope : this,
+                delay : 300
+            });
+
+        },
+
+        _afterFifthScroll : function () {
+            this._testOverlay(this.spanWithLoader, "block", 250, 200, 10);
+            this._testBodyOverlay();
+
+            aria.utils.DomOverlay.detachFrom(this.spanWithLoader);
+            aria.utils.DomOverlay.detachFrom(this.body);
+
+            this.end();
+        },
+
+        _setScroll : function (scrollTop, scrollLeft) {
+            this.testWindow.scrollTo(scrollLeft, scrollTop);
+        },
+
+        _testOverlay : function (element, display, width, height, tolWidth, tolHeight) {
+            tolWidth = tolWidth || 0;
+            tolHeight = tolHeight || 0;
+            var overlay = this.domOverlay.__getOverlay(element).overlay.overlay;
+            if (display) {
+                this.assertEquals(overlay.style.display, display);
+            }
+            if (width) {
+                var actualWidth = parseInt(overlay.style.width, 10);
+                this.assertTrue(Math.abs(actualWidth - width) <= tolWidth, "Wrong width");
+            }
+            if (height) {
+                var actualHeight = parseInt(overlay.style.height, 10);
+                this.assertTrue(Math.abs(actualHeight - height) <= tolHeight, "Wrong height");
+            }
+        },
+
+        _testBodyOverlay : function () {
+            var viewportSize = this.testWindow.aria.utils.Dom.getViewportSize();
+            this._testOverlay(this.body, "block", viewportSize.width, viewportSize.height);
+        }
+    }
+});

--- a/test/aria/utils/overlay/loadingIndicator/scrollableBody/TestTemplate.tpl
+++ b/test/aria/utils/overlay/loadingIndicator/scrollableBody/TestTemplate.tpl
@@ -1,0 +1,17 @@
+{Template {
+	$classpath : "test.aria.utils.overlay.loadingIndicator.scrollableBody.TestTemplate"
+}}
+
+	{macro main()}
+		<div id="container" style="height:5000px; width: 3000px;">
+
+			<div style="height: 2000px">
+				fake div
+			</div>
+			<span id="needLoader" style="margin-left: 150px; background: blue; display: inline-block; height: 200px; width: 300px;">this span needs a loading indicator</span>
+		</div>
+
+	{/macro}
+
+
+{/Template}

--- a/test/attester.yml
+++ b/test/attester.yml
@@ -19,3 +19,5 @@ tests:
    #Excluded because PhantomJS has random issues with the viewport
     - test.aria.widgets.container.dialog.scroll.OnScrollTestCase
     - test.aria.widgets.container.dialog.resize.test3.DialogOnResizeTestCase
+    - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
+    - test.aria.widgets.container.dialog.indicators.DialogTestCase


### PR DESCRIPTION
Loading indicators associated to an element are supposed to be cover and be cenetered only in the visible portion of the element.
This worked correctly apart from the case in which the body of the document has scrollbars. In that case, the overlay was not constrained to the viewport.

This commit fixes the issue by always constraining the overley in the viewport.

Furthermore, two other issues have been tackled by this commit:
- loading indicators were not being refreshed on window resize
- The message displayed underneath the spinner could end up outside the element, or was simply mispositioned in early versions of IE.
