### PR TITLE
Button text alignment in IE7

### DIFF
--- a/src/aria/widgets/action/ButtonStyle.tpl.css
+++ b/src/aria/widgets/action/ButtonStyle.tpl.css
@@ -35,6 +35,12 @@
             tabindex:10;
         }
 
+        {if aria.core.Browser.isIE7}
+            .xButton .xFrameContent {
+                text-align: center;
+            }
+        {/if}
+
         button.xButton::-moz-focus-inner {
              border: 0;
         }


### PR DESCRIPTION
This commit fixes a problem on IE7 where text inside buttons is not centered.
