### PR TITLE
Enable back test.aria.templates.keyboardNavigation.TableNavTestCase on IE <= 8

### DIFF
--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -1463,9 +1463,7 @@
              * @implements aria.templates.ITemplate
              */
             $focus : function (idArray) {
-                if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
-                    Aria.$window.document.body.focus();
-                }
+                aria.utils.Delegate.ieFocusFix();
                 var idToFocus;
                 if (aria.utils.Type.isArray(idArray)) {
                     idArray = idArray.slice(0);

--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -38,6 +38,12 @@ Aria.classDefinition({
     $constructor : function () {
 
         /**
+         * This variable is set to true on IE 7 and 8 when the focused element was just removed from the DOM.
+         * @type Boolean
+         */
+        this._focusedElementRemoved = false;
+
+        /**
          * Number of level up to look delegated element. -1 will go to the top.
          * @type Number
          */
@@ -573,6 +579,7 @@ Aria.classDefinition({
 
             // focus tracking
             if (evt.type == "focus") {
+                this._focusedElementRemoved = false;
                 this._focusTracking = evt.target;
                 if (this._focusTracking && ATflag) {
 
@@ -625,6 +632,29 @@ Aria.classDefinition({
          */
         getFocus : function () {
             return this._focusTracking;
+        },
+
+        /**
+         * This method is intended to be called before focusing any DOM element to apply a work-around for an issue on
+         * IE 7 and 8. It gives the focus to document.body if the last focused element was removed from the DOM.<br>
+         * If the work-around is not applied, on IE 7 and 8, after removing from the DOM a focused element, the next
+         * call to the focus method on a DOM element does not work correctly.
+         */
+        ieFocusFix : function () {
+            if (this._focusedElementRemoved) {
+                Aria.$window.document.body.focus();
+                this._focusedElementRemoved = false;
+            }
+        },
+
+        /**
+         * This method is intended to be called only on IE 7 and 8 in order notify this class that a focused element was
+         * removed from the DOM. Then, the next time the ieFocusFix method is called, a work-around is applied (which is
+         * to give the focus to document.body). This method is automatically called from aria.utils.Dom.replaceHTML when
+         * it is needed, so in most cases, there is no need to call it directly.
+         */
+        ieRemovingFocusedElement : function () {
+            this._focusedElementRemoved = true;
         }
     }
 });

--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -219,6 +219,15 @@ Aria.classDefinition({
                 domElt = this.getElementById(domElt);
             }
             if (domElt) {
+                if ((aria.core.Browser.isIE7 || aria.core.Browser.isIE8) && aria.utils && aria.utils.Delegate) {
+                    var activeElement = Aria.$window.document.activeElement;
+                    if (activeElement && this.isAncestor(activeElement, domElt)) {
+                        // On IE 7-8, there is an issue after removing from the DOM a focused element.
+                        // We detect it here so that next time there is a need to focus an element, we focus the body
+                        // first (which is the work-around for IE 7-8)
+                        aria.utils.Delegate.ieRemovingFocusedElement();
+                    }
+                }
                 // PROFILING // var msr2 = this.$startMeasure("RemoveHTML");
                 // TODO: check HTML for security (no script ...)
                 try {

--- a/test/aria/templates/keyboardNavigation/TableNavTestCase.js
+++ b/test/aria/templates/keyboardNavigation/TableNavTestCase.js
@@ -39,9 +39,6 @@ Aria.classDefinition({
         },
         runTemplateTest : function () {
 
-            if (aria.core.Browser.isIE8 || aria.core.Browser.isIE7) {
-                this.notifyTemplateTestEnd(); // FIXME!! PTR 06248406
-            }
             // clean what was before
             this._disposeTestTemplate();
 


### PR DESCRIPTION
This pull request contains a new fix for the issue that commit 8fcb1826e247320e3730a19e9736b2ecee12c148
tried to solve, and which was reverted in commit 82b8cbf1ea1682361fac60ccef35d558c6aa6bba.

See also #917
