### PR TITLE
Multiselect - problem in labels with spaces

### DIFF
--- a/src/aria/widgets/controllers/MultiSelectController.js
+++ b/src/aria/widgets/controllers/MultiSelectController.js
@@ -168,22 +168,21 @@ Aria.classDefinition({
         _parseInputString : function (options, textFieldValue) {
 
             var selectedOptions = [];
+            var trim = aria.utils.String.trim;
 
             var inSplit = textFieldValue.split(this._separator);
             if (inSplit) {
                 for (var i = 0, inSplitLen = aria.utils.Math.min(inSplit.length, this._maxOptions); i < inSplitLen; i++) {
                     for (var j = 0, optionsLen = options.length; j < optionsLen; j++) {
-                        var key = aria.utils.String.trim(inSplit[i]);
+                        var key = trim(inSplit[i]);
                         options[j].label = options[j].label + "";
                         options[j].value = options[j].value + "";
                         key = key + "";
 
-                        if ((options[j].label.toLowerCase() == key.toLowerCase() || options[j].value.toLowerCase() == key.toLowerCase())) {
-                            if ((options[j].label.toLowerCase() == key.toLowerCase() || options[j].value.toLowerCase() == key.toLowerCase())
-                                    && !aria.utils.Array.contains(selectedOptions, options[j].value)
-                                    && !options[j].disabled) {
-                                selectedOptions.push(options[j].value);
-                            }
+                        if ((trim(options[j].label.toLowerCase()) == key.toLowerCase() || trim(options[j].value.toLowerCase()) == key.toLowerCase())
+                                && !aria.utils.Array.contains(selectedOptions, options[j].value)
+                                && !options[j].disabled) {
+                            selectedOptions.push(options[j].value);
                         }
                     }
                 }

--- a/src/aria/widgets/frames/FrameWithIcons.js
+++ b/src/aria/widgets/frames/FrameWithIcons.js
@@ -325,7 +325,7 @@ Aria.classDefinition({
                 if (active) {
                     this._icons[icon].tooltip = this._tooltipLabels[param.activeIconIndex++];
                 }
-                param.width += iconInfo.width + iconInfo.borderLeft + iconInfo.borderRight;
+                param.width += iconInfo.width + (iconInfo.borderLeft || 0) + (iconInfo.borderRight || 0);
             } else {
                 this.$logError(this.ICON_NOT_FOUND, icon);
             }

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -33,6 +33,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.multiselect.onblur.MultiSelect",
                 "test.aria.widgets.form.multiselect.toggleMultiSelect.MultiSelect",
                 "test.aria.widgets.form.multiselect.upArrowKey.test1.MultiSelect",
-                "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect"];
+                "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect",
+                "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim"];
     }
 });

--- a/test/aria/widgets/form/multiselect/labelsToTrim/LabelsToTrim.js
+++ b/test/aria/widgets/form/multiselect/labelsToTrim/LabelsToTrim.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            value : ["D", "B", "V"],
+            options : [{
+                        value : "D",
+                        label : "Donizetti "
+                    }, {
+                        value : "B",
+                        label : "Bellini "
+                    }, {
+                        value : "V",
+                        label : " Verdi "
+                    }],
+            popup : false
+        };
+        this.setTestEnv({
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            aria.utils.Json.setValue(this.data, "popup", true);
+            aria.core.Timer.addCallback({
+                fn : this._afterPopupOpen,
+                scope : this
+            });
+        },
+
+        _afterPopupOpen : function () {
+            this.assertJsonEquals(this.data.value, ["D", "B", "V"]);
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/labelsToTrim/LabelsToTrimTpl.tpl
+++ b/test/aria/widgets/form/multiselect/labelsToTrim/LabelsToTrimTpl.tpl
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template{
+	$classpath : "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrimTpl"
+}}
+
+	{macro main()}
+		{@aria:MultiSelect {
+			id : "testms",
+			items : data.options,
+			bind : {
+				value : {
+					to : "value",
+					inside : data
+				},
+				popupOpen : {
+					to : "popup",
+					inside : data
+				}
+			}
+		}/}
+	{/macro}
+
+{/Template}


### PR DESCRIPTION
When labels for multiselect items have trailing spaces, the value in the field is not interpreted correctly. Selected options are not recognized as such, so they get deselected.

While writing a test case, another small issue in the widget width computation has been spotted and fixed.
