### PR TITLE
fix #954 Improvement of the focus template API test

### DIFF
--- a/test/aria/templates/focusAfterRefresh/FocusTemplateTestCase.js
+++ b/test/aria/templates/focusAfterRefresh/FocusTemplateTestCase.js
@@ -18,7 +18,6 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TemplateTestCase",
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
-        this.defaultTestTimeout = 30000; // takes ~3s in Fx and up to ~23s in IE8 in dev mode!!! funnily IE7 = ~7s
         this.setTestEnv({
             template : "test.aria.templates.focusAfterRefresh.RefreshTemplate"
         });
@@ -32,57 +31,34 @@ Aria.classDefinition({
         },
 
         _testSetGetFocusedWidget : function () {
-            this.getWidgetInstance('txtf0').initWidgetDom();
             this.__getInput().focus();
             this.templateCtxt.$setFocusedWidget();
             this._assertWidgetPath();
         },
 
         _testSetGetFocusedWidgetAfterRefresh : function () {
-            this.__clickAndContinue(this.__getButton(), this._buttonClicked1);
-        },
-        _buttonClicked1 : function () {
-            this.__getInput().focus();
+            this.templateCtxt.$refresh();
             this._assertWidgetPath();
         },
 
         _testFocusAfterRefresh : function () {
-            this.__clickAndContinue(this.__getButton(), this._buttonClicked2);
-        },
-        _buttonClicked2 : function () {
-            this.__clickAndContinue(this.__getInput(), this._focusedWidget);
-        },
-        _focusedWidget : function () {
             var element = this.__getInput();
             var focusedElement = Aria.$window.document.activeElement;
-            this.assertEquals(element.innerHTML, focusedElement.innerHTML, "Widget was not focused after refresh.");
-            this._finishTest();
-        },
-
-        _finishTest : function () {
-            this.notifyTemplateTestEnd();
+            this.assertEquals(element, focusedElement, "Widget was not focused after refresh.");
+            this.end();
         },
 
         _assertWidgetPath : function () {
-            var Ids = this.templateCtxt.$getFocusedWidget();
-            this.assertEquals(Ids.length, this.widgetPath.length, "The widget path was empty! It should be: '"
+            var ids = this.templateCtxt.$getFocusedWidget();
+            this.assertEquals(ids.length, this.widgetPath.length, "The widget path was not correct. It should be: '"
                     + this.widgetPath + "'");
-            for (var i = 0; i < Ids.length; i++) {
-                this.assertEquals(this.widgetPath[i], Ids[i], "The widget path is incorrect. It should be '"
-                        + this.widgetPath[i] + "' but instead it is '" + Ids[i] + "'.");
+            for (var i = 0; i < ids.length; i++) {
+                this.assertEquals(this.widgetPath[i], ids[i], "The widget path is incorrect. It should be '"
+                        + this.widgetPath[i] + "' but instead it is '" + ids[i] + "'.");
             }
         },
-        __getButton : function () {
-            return this.getElementById("refreshPage");
-        },
         __getInput : function () {
-            return Aria.$window.document.getElementsByTagName("input")[0];
-        },
-        __clickAndContinue : function (elm, continueWith) {
-            this.synEvent.click(elm, {
-                fn : continueWith,
-                scope : this
-            });
+            return this.getInputField("txtf0");
         }
     }
 });

--- a/test/aria/templates/focusAfterRefresh/TemplateA.tpl
+++ b/test/aria/templates/focusAfterRefresh/TemplateA.tpl
@@ -26,7 +26,8 @@
                     id : "txtf0",
                     label : "TextField ",
                     labelWidth:100,
-                    width:300
+                    width:300,
+                    value:"aaa"
                 } /}
             </li>
             <li>


### PR DESCRIPTION
An existing test (test.aria.templates.focusAfterRefresh.FocusTemplateTestCase) has been improved in order to actually test that the focus is given back to the widget that had it before a refresh.
