### PR TITLE
refactor #961 Add timeout after focus or blur action, on some tests.

### DIFF
--- a/test/aria/widgets/form/multiselect/checkFeatures/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/checkFeatures/MultiSelect.js
@@ -40,8 +40,14 @@ Aria.classDefinition({
 
         _onMSOpened : function () {
             this.getInputField("ms1").blur();
-            this.assertTrue(this.getInputField("ms1").value == "Air France,Air Canada");
-            this.toggleMultiSelectOn("ms1", this._onIconClicked);
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.assertTrue(this.getInputField("ms1").value == "Air France,Air Canada");
+                    this.toggleMultiSelectOn("ms1", this._onIconClicked);
+                },
+                scope : this,
+                delay : 25
+            });
         },
 
         _onIconClicked : function () {

--- a/test/aria/widgets/form/multiselect/issue223/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/issue223/MultiSelect.js
@@ -10,11 +10,16 @@ Aria.classDefinition({
         runTemplateTest : function () {
             this.assertTrue(this.getInputField("ms1").value === "");
             this.getInputField("ms1").focus();
-            this.synEvent.type(this.getInputField("ms1"), "AF,AC,DL,AY", {
-                fn : this._afterTyping,
-                scope : this
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.synEvent.type(this.getInputField("ms1"), "AF,AC,DL,AY", {
+                        fn : this._afterTyping,
+                        scope : this
+                    });
+                },
+                scope : this,
+                delay : 25
             });
-
         },
 
         _afterTyping : function () {
@@ -29,8 +34,14 @@ Aria.classDefinition({
 
         finishTest : function () {
             this.getInputField("myTextField").focus();
-            this.assertTrue(this.getInputField("ms1").value === "AF,AC,DL");
-            this.end();
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.assertTrue(this.getInputField("ms1").value === "AF,AC,DL");
+                    this.end();
+                },
+                scope : this,
+                delay : 25
+            });
         }
     }
 });

--- a/test/aria/widgets/form/multiselect/issue312/Common.js
+++ b/test/aria/widgets/form/multiselect/issue312/Common.js
@@ -104,7 +104,13 @@ Aria.classDefinition({
             };
             var outerWidget = this.getWidgetInstance("widget");
             outerWidget.focus();
-            outerWidget._toggleDropdown();
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    outerWidget._toggleDropdown();
+                },
+                scope : this,
+                delay : 25
+            });
         },
 
         _checkInnerSclassCb : function (args) {

--- a/test/aria/widgets/form/multiselect/onblur/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/onblur/MultiSelect.js
@@ -28,9 +28,15 @@ Aria.classDefinition({
         runTemplateTest : function () {
             this.assertTrue(this.getInputField("ms1").value === "");
             this.getInputField("ms1").focus();
-            this.synEvent.type(this.getInputField("ms1"), "AF,AC,NZ,IB", {
-                fn : this._afterTyping,
-                scope : this
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.synEvent.type(this.getInputField("ms1"), "AF,AC,NZ,IB", {
+                        fn : this._afterTyping,
+                        scope : this
+                    });
+                },
+                scope : this,
+                delay : 25
             });
 
         },

--- a/test/aria/widgets/form/passwordfield/PasswordField.js
+++ b/test/aria/widgets/form/passwordfield/PasswordField.js
@@ -45,9 +45,15 @@ Aria.classDefinition({
 
         _afterFieldType : function () {
             this.getInputField("pf").blur();
-            this.assertTrue(this.getInputField("tf").value == "abcd");
-            this.assertTrue(this.data.password == "abcd");
-            this.notifyTemplateTestEnd();
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.assertTrue(this.getInputField("tf").value == "abcd");
+                    this.assertTrue(this.data.password == "abcd");
+                    this.notifyTemplateTestEnd();
+                },
+                scope : this,
+                delay : 25
+            });
 
         }
     }

--- a/test/aria/widgets/form/timefield/checkFormat/TimeField.js
+++ b/test/aria/widgets/form/timefield/checkFormat/TimeField.js
@@ -46,8 +46,14 @@ Aria.classDefinition({
             var pm = aria.utils.Date.res.timeFormatLabels.pm;
 
             myField.blur();
-            this.assertTrue(myField.value == "12:0:0 " + pm, "'12:0:0 PM' was expected in the timefield 1.");
-            this.notifyTemplateTestEnd();
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.assertTrue(myField.value == "12:0:0 " + pm, "'12:0:0 PM' was expected in the timefield 1.");
+                    this.notifyTemplateTestEnd();
+                },
+                scope : this,
+                delay : 25
+            });
         }
     }
 

--- a/test/aria/widgets/form/timefield/checkValue/TimeField.js
+++ b/test/aria/widgets/form/timefield/checkValue/TimeField.js
@@ -45,8 +45,14 @@ Aria.classDefinition({
             var myField = this.getInputField("tf1");
 
             myField.blur();
-            this.assertTrue(myField.value === "00:00", "'00:00' was expected in the timefield.");
-            this.notifyTemplateTestEnd();
+            aria.core.Timer.addCallback({
+                fn : function() {
+                    this.assertTrue(myField.value === "00:00", "'00:00' was expected in the timefield.");
+                    this.notifyTemplateTestEnd();
+                },
+                scope : this,
+                delay : 25
+            });
         }
     }
 


### PR DESCRIPTION
Fix theses tests on IE 11:

test.aria.widgets.form.multiselect.checkFeatures.MultiSelect
test.aria.widgets.form.multiselect.issue223.MultiSelect
test.aria.widgets.form.multiselect.issue312.AutoComplete
test.aria.widgets.form.multiselect.onblur.MultiSelect
test.aria.widgets.form.timefield.checkFormat.TimeField
test.aria.widgets.form.timefield.checkValue.TimeField
test.aria.widgets.form.passwordfield.PasswordField
