### PR TITLE
[on hold] fix #962 autoselect is called asynchronously after focus()

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -1184,7 +1184,14 @@ Aria.classDefinition({
             textInputField.value = textInputField.value;
 
             if (!fromSelf) {
-                this._autoselect();
+                // IE FIX: the focus() can be asynchronous, so let's add a timeout to manage the autoselect
+                aria.core.Timer.addCallback({
+                    fn : function() {
+                        this._autoselect();
+                    },
+                    scope : this,
+                    delay : 25
+                });
             }
         },
 


### PR DESCRIPTION
Fix required as test.aria.widgets.autoselect.programmatic.AutoSelect failed on IE 11,
as .focus() is asynchronous on this browser.
