### PR TITLE
fix #968 multiselect for IE:  focus not correctly assigned

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -847,7 +847,17 @@ Aria.classDefinition({
                     domEvent : domEvent
                 };
                 this.$raiseEvent(event);
-                this.close(domEvent);
+
+                // timeout needed by IE for the PTR07394450 : it allows the browser to move the focus (asynchronous in
+                // IE), before to close the popup
+                if (aria.core.Browser.isIE) {
+                    var that = this;
+                    setTimeout(function () {
+                        that.close(domEvent);
+                    }, 1);
+                } else {
+                    this.close(domEvent);
+                }
                 return true;
             }
         },

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -49,6 +49,7 @@ Aria.classDefinition({
             var onDescription = {
                 "onAfterOpen" : this._afterDropdownOpen,
                 "onAfterClose" : this._afterDropdownClose,
+                "onMouseClickClose" : this._dropDownMouseClickClose,
                 scope : this
             };
 
@@ -143,8 +144,21 @@ Aria.classDefinition({
             this._dropdownPopup.$dispose();
             this._dropdownPopup = null;
             aria.templates.Layout.$unregisterListeners(this);
-            this.focus(null, true);
             this._keepFocus = false;
+        },
+
+        /**
+         * Callback for the event onMouseClickClose raised by the popup. <br>
+         * fix for PTR07394450: method used to fix IE bug (a click in a text input does not trigger the blur event on
+         * the previously selected multiselect input, so that the activeElement does not change properly)
+         * @protected
+         */
+        _dropDownMouseClickClose : function (evt) {
+            if (!aria.utils.Dom.isAncestor(evt.domEvent.target, this._domElt)) {
+                this._keepFocus = false;
+                this._hasFocus = false;
+                this._updateState();
+            }
         },
 
         /**

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -34,6 +34,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.multiselect.toggleMultiSelect.MultiSelect",
                 "test.aria.widgets.form.multiselect.upArrowKey.test1.MultiSelect",
                 "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect",
-                "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim"];
+                "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim",
+                "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase"];
     }
 });

--- a/test/aria/widgets/form/multiselect/focusMove/Issue968TestCase.js
+++ b/test/aria/widgets/form/multiselect/focusMove/Issue968TestCase.js
@@ -1,0 +1,74 @@
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $prototype : {
+
+        _waitOpenDropdown : function (cb) {
+            return function () {
+                this.waitFor({
+                    condition : function () {
+                        return this.getElementsByClassName(Aria.$window.document.body, "xWidget xICNcheckBoxes").length !== 0;
+                    },
+                    callback : cb
+                });
+            };
+        },
+
+        _waitFocusAndOpenDropdown : function (input, cb) {
+            return function () {
+                aria.core.Timer.addCallback({
+                    fn : function () {
+                        this.synEvent.type(input, "[down]", {
+                            fn : this._waitOpenDropdown(cb),
+                            scope : this
+                        });
+                    },
+                    scope : this,
+                    delay : 25
+                });
+            };
+        },
+
+        runTemplateTest : function () {
+            this.ms1 = this.getInputField("ms1");
+            this.ms2 = this.getInputField("ms2");
+            this.synEvent.click(this.ms1, {
+                fn : this._waitFocusAndOpenDropdown(null, this._verifyFirstDropdown),
+                scope : this
+            });
+        },
+
+        _verifyFirstDropdown : function () {
+            var firstOption = this._getFirstOption();
+            this.assertEquals("AC", firstOption, "The first option of the opened dropdown is %2 instead of %1");
+
+            this.synEvent.click(this.ms2, {
+                fn : this._waitFocusAndOpenDropdown(null, this._verifySecondDropdown),
+                scope : this
+            });
+        },
+
+        _verifySecondDropdown : function () {
+            var firstOption = this._getFirstOption();
+            this.assertEquals("IB", firstOption, "The first option of the opened dropdown is %2 instead of %1");
+
+            this.synEvent.click(this.ms1, {
+                fn : this._waitFocusAndOpenDropdown(null, this._verifyAgainFirstDropdown),
+                scope : this
+            });
+        },
+
+        _verifyAgainFirstDropdown : function () {
+            var firstOption = this._getFirstOption();
+            this.assertEquals("AC", firstOption, "The first option of the opened dropdown is %2 instead of %1");
+            this.end();
+        },
+
+        _getFirstOption : function () {
+            var firstCheckbox = this.getElementsByClassName(Aria.$window.document.body, "xWidget xICNcheckBoxes")[0];
+            var firstItem = firstCheckbox.parentNode;
+            return firstItem.getElementsByTagName("label")[0].innerHTML;
+        }
+
+    }
+});

--- a/test/aria/widgets/form/multiselect/focusMove/Issue968TestCaseTpl.tpl
+++ b/test/aria/widgets/form/multiselect/focusMove/Issue968TestCaseTpl.tpl
@@ -1,0 +1,51 @@
+{Template {
+    $classpath:'test.aria.widgets.form.multiselect.focusMove.Issue968TestCaseTpl',
+    $hasScript:false
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        {var testItems1 = [
+                {value:'AF', label:'AF', disabled:false},
+                {value:'AC', label:'AC', disabled:false},
+                {value:'NZ', label:'NZ', disabled:false},
+                {value:'DL', label:'DL', disabled:false},
+                {value:'AY', label:'AY', disabled:false}
+            ]/}
+
+        {var testItems2 = [
+                {value:'IB', label:'IB', disabled:true},
+                {value:'LH', label:'LH', disabled:false},
+                {value:'MX', label:'MX', disabled:false},
+                {value:'QF', label:'QF', disabled:false}
+            ]/}
+
+        {@aria:MultiSelect {
+            activateSort: true,
+            label: "My Multi-select 1:",
+            labelWidth:150,
+            width:400,
+            fieldDisplay: "label",
+            id:"ms1",
+            fieldSeparator:',',
+            valueOrderedByClick: true,
+            maxOptions:3,
+            items:testItems1
+        }/}
+
+        {@aria:MultiSelect {
+            activateSort: true,
+            label: "My Multi-select 2:",
+            labelWidth:150,
+            width:400,
+            fieldDisplay: "label",
+            id:"ms2",
+            fieldSeparator:',',
+            valueOrderedByClick: true,
+            maxOptions:3,
+            items:testItems2
+        }/}
+
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
added some timeouts only for IE, in order to correctly handle the focus and blur events.
As a consequence, also two failing tests have been updated introducing some timeouts that take into account the asynchronous behavior of IE.
