### PR TITLE
fix #969 SynEvent used pageYOffset and pageXOffset on all version of IE.

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -96,10 +96,7 @@ Aria.classDefinition({
     $destructor : function () {
         // Free also some memory cleaning the environment
         this.__cleanEnv(true);
-        if (this.testDiv) {
-            this.testDiv.parentNode.removeChild(this.testDiv);
-            this.testDiv = null;
-        }
+        this.__removeTestDiv();
         if (this.testIframe) {
             this.testIframe.parentNode.removeChild(this.testIframe);
             this.testIframe = null;
@@ -369,10 +366,7 @@ Aria.classDefinition({
                     this._disposeTestTemplate();
 
                     try {
-                        if (this.testDiv) {
-                            // null for iframe tests with errors
-                            this.testDiv.style.display = "none";
-                        }
+                        this.__removeTestDiv();
                         if (this.testIframe) {
                             this.testIframe.style.display = "none";
                         }
@@ -923,6 +917,17 @@ Aria.classDefinition({
             // Template tests are always asynchronous, but we need to call notifyTemplateTestEnd
             this.$logError(this.EXCEPTION_IN_METHOD, methodName, ex);
             this.notifyTemplateTestEnd();
+        },
+
+        /**
+         * Remove the testDiv dom element
+         * @private
+         */
+        __removeTestDiv : function() {
+            if (this.testDiv) {
+                this.testDiv.parentNode.removeChild(this.testDiv);
+                this.testDiv = null;
+            }
         }
     }
 });

--- a/src/aria/utils/SynEvents.js
+++ b/src/aria/utils/SynEvents.js
@@ -2477,9 +2477,16 @@
                 if (typeof el.getBoundingClientRect !== "undefined") {
                     box = el.getBoundingClientRect();
                 }
+                var $window = Aria.$window;
+                var $document = $window.document;
                 var o = {
-                    top: box.top + Aria.$window.pageYOffset - docElem.clientTop,
-                    left: box.left + Aria.$window.pageXOffset - docElem.clientLeft
+                    top: box.top +
+                        (($window.pageYOffset !== undefined) ? $window.pageYOffset : ($document.documentElement || $document.body.parentNode || $document.body).scrollTop) -
+                        docElem.clientTop,
+                    left:
+                        box.left +
+                        (($window.pageXOffset !== undefined) ? $window.pageXOffset : ($document.documentElement || $document.body.parentNode || $document.body).scrollLeft) -
+                        docElem.clientLeft
                 };
                 return {
                     pageX: o.left + (el.offsetWidth / 2),


### PR DESCRIPTION
These properties are not supported on IE <= 8 (http://www.quirksmode.org/dom/w3c_cssom.html#windowview), and returned undefined.

Now a fallback on scrollTop and scrollLeft has been done if these properties doesn't exist.
