### PR TITLE
fix #970 aria.utils.Date.format can now handle falsy values 

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -1448,6 +1448,9 @@ Aria.classDefinition({
          * @return {String}
          */
         format : function (date, pattern, utcTime) {
+            if (!date || !aria.utils.Type.isDate(date)) {
+                return null;
+            }
 
             if (typeof pattern === 'function') {
                 pattern = pattern();
@@ -1455,14 +1458,23 @@ Aria.classDefinition({
                 this.$logError(this.INVALID_FORMAT_TYPE);
             }
 
-            var formatFn = this._getFormatFunction(pattern), formattedDate;
-            this.$assert(118, aria.utils.Type.isFunction(formatFn));
             if (utcTime) {
                 // create a date object whose local time is the UTC time:
-                date = new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds());
+                date = new Date(
+                    date.getUTCFullYear(),
+                    date.getUTCMonth(),
+                    date.getUTCDate(),
+                    date.getUTCHours(),
+                    date.getUTCMinutes(),
+                    date.getUTCSeconds(),
+                    date.getUTCMilliseconds()
+                );
             }
-            formattedDate = formatFn(date);
-            return formattedDate;
+
+            var formatFn = this._getFormatFunction(pattern);
+            this.$assert(118, aria.utils.Type.isFunction(formatFn));
+
+            return formatFn(date);
         },
 
         /**

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -263,6 +263,11 @@ Aria.classDefinition({
         testAsyncDateFormatting : function () {
             var ariaDateUtil = aria.utils.Date;
 
+            this.assertEquals(null, ariaDateUtil.format(null, "dd/MM/yyyy"));
+            this.assertEquals(null, ariaDateUtil.format(undefined, "dd/MM/yyyy"));
+            this.assertEquals(null, ariaDateUtil.format("", "dd/MM/yyyy"));
+            this.assertEquals(null, ariaDateUtil.format({}, "dd/MM/yyyy"));
+
             var formattedValue = ariaDateUtil.format(new Date(2010, 3, 1, 0, 0, 0), "d MMM y");
             this.assertTrue(formattedValue === "1 Apr 10", "Wrong output: " + formattedValue);
 


### PR DESCRIPTION
fix #970 aria.utils.Date.format can now handle falsy values and empty objects and returns null in those cases instead of failing with a TypeError
