### PR TITLE
Prefix URLs in CSS templates

### DIFF
--- a/build/config/files-prod.json
+++ b/build/config/files-prod.json
@@ -64,7 +64,8 @@
             "aria/templates/TextTemplate.js",
             "aria/templates/TxtClassGenerator.js",
             "aria/templates/TxtCtxt.js",
-            "aria/templates/ViewCfgBeans.js"
+            "aria/templates/ViewCfgBeans.js",
+            "aria/templates/environment/*"
         ]
     },
     {

--- a/src/aria/templates/environment/ImgUrlMapping.js
+++ b/src/aria/templates/environment/ImgUrlMapping.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "aria.templates.environment.ImgUrlMapping",
+    $dependencies : ["aria.templates.environment.ImgUrlMappingCfgBeans"],
+    $extends : "aria.core.environment.EnvironmentBase",
+    $singleton : true,
+    $prototype : {
+        /**
+         * Classpath of the bean which allows to validate the part of the environment managed by this class.
+         * @type String
+         */
+        _cfgPackage : "aria.templates.environment.ImgUrlMappingCfgBeans.AppCfg",
+
+        /**
+         * Get the imgUrlMapping classpath configuration. It is a copy of the current configuration and not a reference to
+         * the object itself.
+         * @public
+         * @return {aria.core.environment.environment.EnvironmentBaseCfgBeans:AppCfg} The classpath configuration
+         */
+        getImgUrlMappingCfg : function () {
+            return aria.utils.Json.copy(this.checkApplicationSettings("imgUrlMapping"));
+        }
+    }
+});

--- a/src/aria/templates/environment/ImgUrlMappingCfgBeans.js
+++ b/src/aria/templates/environment/ImgUrlMappingCfgBeans.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Bean definitions that are either common to multiple areas of the framework, or are needed before dependencies are
+ * loaded by the framework.
+ */
+Aria.beanDefinitions({
+    $package : "aria.templates.environment.ImgUrlMappingCfgBeans",
+    $description : "A definition of the JSON beans used to set the environment settings.",
+    $namespaces : {
+        "json" : "aria.core.JsonTypes"
+    },
+    $beans : {
+        "AppCfg" : {
+            $type : "json:Object",
+            $description : "Application environment variables",
+            $restricted : false,
+            $properties : {
+                "imgUrlMapping" : {
+                    $type : "json:FunctionRef",
+                    $description : "Method to map img urls inside CSS templates.",
+                    $default : null
+                }
+            }
+        }
+    }
+});

--- a/test/aria/templates/css/CSSTestSuite.js
+++ b/test/aria/templates/css/CSSTestSuite.js
@@ -35,6 +35,7 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.css.widgetContext.ContextTest");
         this.addTests("test.aria.templates.css.events.EventsTestCase");
         this.addTests("test.aria.templates.css.global.GlobalCssTemplateTestCase");
+        this.addTests("test.aria.templates.css.imgprefix.ImgPrefixTemplateTestCase");
         this.addTests("test.aria.templates.css.inheritance.InheritTestCase");
         this.addTests("test.aria.templates.css.numberReload.OneLevelTemplate");
     }

--- a/test/aria/templates/css/imgprefix/ImgPrefixTemplateTestCase.js
+++ b/test/aria/templates/css/imgprefix/ImgPrefixTemplateTestCase.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.css.imgprefix.ImgPrefixTemplateTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+
+    $constructor : function () {
+
+        this.$TemplateTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            template : "test.aria.templates.css.imgprefix.SimpleTemplate"
+        });
+
+        this.imgPaths = ["images/bg.jpg", "images/bg.jpg", "images/bg.jpg", "images)/bg.jpg", "images/?bg.jpg", "images'/bg.'jpg", "images\"/bg.\"jpg"];
+
+        // set the app environment
+        aria.core.AppEnvironment.setEnvironment({
+            "imgUrlMapping" : this._fakeUrlMapping
+        });
+    },
+    $prototype : {
+        _fakeUrlMapping : function (url, cssClasspath) {
+            return "ariatemplates/prefix/" + url;
+        },
+
+        runTemplateTest : function () {
+            var firstCSS = aria.templates.CSSCtxtManager.getContext("test.aria.templates.css.imgprefix.SimpleTemplateCss").getText();
+            var secondCSS = aria.templates.CSSCtxtManager.getContext("test.aria.templates.css.imgprefix.SimpleTemplateCss2").getText();
+
+            var urls = firstCSS.match(/\bariatemplates\/prefix\/([^"'\r\n,]+|[^'\r\n,]+|[^"\r\n,]+)["']?\s*\)/gi).concat(secondCSS.match(/\bariatemplates\/prefix\/([^"'\r\n,]+|[^'\r\n,]+|[^"\r\n,]+)["']?\s*\)/gi));
+
+            for (var i = 0; i < urls.length; i++) {
+                var tmp = this._cleanUrls(urls[i]);
+                this.assertTrue(tmp === "ariatemplates/prefix/" + this.imgPaths[i], "There isn't any prefix for image urls inside CSS templates");
+            }
+
+            aria.templates.CSSMgr.invalidate("test.aria.templates.css.imgprefix.SimpleTemplateCss", true);
+            aria.templates.CSSMgr.invalidate("test.aria.templates.css.imgprefix.SimpleTemplateCss2", true);
+
+            // reset app environment
+            aria.core.AppEnvironment.setEnvironment({
+                "imgUrlMapping" : null
+            }, { fn : this._afterAppEnvResetting, scope : this}, true);
+        },
+
+        _afterAppEnvResetting : function () {
+            // changing template
+            this._replaceTestTemplate({
+                template : "test.aria.templates.css.imgprefix.SimpleTemplateTwo"
+            }, this._afterSecondTemplateLoaded);
+        },
+
+        _afterSecondTemplateLoaded : function () {
+            // check that is not adding any prefix to image urls
+            var firstCSS = aria.templates.CSSCtxtManager.getContext("test.aria.templates.css.imgprefix.SimpleTemplateCss").getText();
+            var secondCSS = aria.templates.CSSCtxtManager.getContext("test.aria.templates.css.imgprefix.SimpleTemplateCss2").getText();
+
+            var urls = firstCSS.match(/\bimages([^"'\r\n,]+|[^"\r\n,]+|[^'\r\n,]+)["']?\s*\)/gi).concat(secondCSS.match(/\bimages([^"'\r\n,]+|[^"\r\n,]+|[^'\r\n,]+)["']?\s*\)/gi));
+
+            for (var i = 0; i < urls.length; i++) {
+                var tmp = this._cleanUrls(urls[i]);
+                this.assertTrue(tmp === this.imgPaths[i], "The framework is adding a prefix for image urls inside CSS templates, it shouldn't.");
+            }
+            this.end();
+        },
+
+        _cleanUrls : function (url) {
+            url = url[url.length - 1] === ")" ? url.substring(0, url.length - 1) : url;
+            url = url[url.length - 1] === "\"" || url[url.length - 1] === "\'" ? url.substring(0, url.length - 1) : url;
+            return url;
+        }
+    }
+});

--- a/test/aria/templates/css/imgprefix/SimpleTemplate.tpl
+++ b/test/aria/templates/css/imgprefix/SimpleTemplate.tpl
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.templates.css.imgprefix.SimpleTemplate",
+    $css : ["test.aria.templates.css.imgprefix.SimpleTemplateCss", "test.aria.templates.css.imgprefix.SimpleTemplateCss2"]
+}}
+
+{macro main ()}
+    <div class="container-1">
+        <p>Container 1</p>
+    </div>
+
+    <div class="container-2">
+        <p>Container 2</p>
+    </div>
+
+    <div class="container-3">
+        <p>Container 3</p>
+    </div>
+
+    <div class="container-4">
+        <p>Container 4</p>
+    </div>
+
+    <div class="container-5">
+        <p>Container 5</p>
+    </div>
+
+    <div class="container-6">
+        <p>Container 6</p>
+    </div>
+
+{/macro}
+
+{/Template}

--- a/test/aria/templates/css/imgprefix/SimpleTemplateCss.tpl.css
+++ b/test/aria/templates/css/imgprefix/SimpleTemplateCss.tpl.css
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath : "test.aria.templates.css.imgprefix.SimpleTemplateCss"
+}}
+
+{macro main ()}
+    * {
+      margin: 0;
+      padding: 0;
+    }
+
+    .container-1 {
+        height: 100%;
+        width: 100%;
+        background: url(images/bg.jpg) no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    .container-2 {
+        height: 100%;
+        width: 100%;
+        background: url("images/bg.jpg") no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    .container-3 {
+        height: 100%;
+        width: 100%;
+        background: url('images/bg.jpg') no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    p {
+      font: 15px/2 Georgia, Serif;
+      margin: 0 0 30px 0;
+      text-indent: 40px;
+    }
+{/macro}
+
+{/CSSTemplate}

--- a/test/aria/templates/css/imgprefix/SimpleTemplateCss2.tpl.css
+++ b/test/aria/templates/css/imgprefix/SimpleTemplateCss2.tpl.css
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath : "test.aria.templates.css.imgprefix.SimpleTemplateCss2"
+}}
+
+{macro main ()}
+    * {
+      margin: 0;
+      padding: 0;
+    }
+
+    .container-4 {
+        height: 100%;
+        width: 100%;
+        background: url('images)/bg.jpg') no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    .container-5 {
+        height: 100%;
+        width: 100%;
+        background: url (images/?bg.jpg) no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    .container-6 {
+        height: 100%;
+        width: 100%;
+        background: url("images'/bg.'jpg") no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    .container-7 {
+        height: 100%;
+        width: 100%;
+        background: url('images"/bg."jpg') no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        width: 400px;
+        -moz-box-shadow: 0 0 20px black;
+        -webkit-box-shadow: 0 0 20px black;
+        box-shadow: 0 0 20px black;
+    }
+
+    p {
+      font: 15px/2 Georgia, Serif;
+      margin: 0 0 30px 0;
+      text-indent: 40px;
+    }
+{/macro}
+
+{/CSSTemplate}

--- a/test/aria/templates/css/imgprefix/SimpleTemplateTwo.tpl
+++ b/test/aria/templates/css/imgprefix/SimpleTemplateTwo.tpl
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.templates.css.imgprefix.SimpleTemplateTwo",
+    $css : ["test.aria.templates.css.imgprefix.SimpleTemplateCss", "test.aria.templates.css.imgprefix.SimpleTemplateCss2"]
+}}
+
+{macro main ()}
+    <div class="container-1">
+        <p>Container 1</p>
+    </div>
+
+    <div class="container-2">
+        <p>Container 2</p>
+    </div>
+
+    <div class="container-3">
+        <p>Container 3</p>
+    </div>
+
+    <div class="container-4">
+        <p>Container 4</p>
+    </div>
+
+    <div class="container-5">
+        <p>Container 5</p>
+    </div>
+
+    <div class="container-6">
+        <p>Container 6</p>
+    </div>
+
+    <div class="container-7">
+        <p>Container 6</p>
+    </div>
+
+{/macro}
+
+{/Template}


### PR DESCRIPTION
This commit introduces the possibility to define a method to be used to prefix all the image urls inside css templates.
