### PR TITLE
fix #983 Error tip is now positioned relative to the invalid entry

### DIFF
--- a/src/aria/widgets/WidgetTrait.js
+++ b/src/aria/widgets/WidgetTrait.js
@@ -46,6 +46,13 @@ Aria.classDefinition({
             if (this._onValidatePopup) {
                 this._onValidatePopup.hide();
             }
+        },
+
+        /**
+         * Method used to get a dom reference for positioning the popup
+         */
+        getValidationPopupReference : function () {
+            return this.getDom();
         }
     }
 });

--- a/src/aria/widgets/form/InputValidationHandler.js
+++ b/src/aria/widgets/form/InputValidationHandler.js
@@ -23,7 +23,7 @@ Aria.classDefinition({
     $constructor : function (widget) {
         this._context = widget._context;
         this._lineNumber = widget._lineNumber;
-        this._field = widget.getDom();
+        this._field = widget.getValidationPopupReference();
         this._WidgetCfg = widget._cfg;
         this._validationPopup = null; // null when the validation is closed
         this._preferredPositions = {

--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -360,6 +360,12 @@ Aria.classDefinition({
             this.setProperty("value", newSuggestions);
             this._textInputField.style.width = "0px";
             this.__resizeInput();
+        },
+        /**
+         * Method used to get a dom reference for positioning the popup
+         */
+        getValidationPopupReference : function () {
+            return this.getTextInputField();
         }
     }
 });

--- a/test/aria/widgets/form/InputValidationHandlerTest.js
+++ b/test/aria/widgets/form/InputValidationHandlerTest.js
@@ -57,6 +57,9 @@ Aria.classDefinition({
                 },
                 getDom : function () {
                     return anchor;
+                },
+                getValidationPopupReference : function () {
+                    return this.getDom();
                 }
             };
 


### PR DESCRIPTION
It is now possible to position the error tool tip on any element within the <code>@aria:MultiAutoComplete</code> or any other widget that uses <code>aria.widgets.WidgetTrait</code>

To change the position of the error tip, simply use the <code>errorTipPosition</code> property of the widget.  Possible values:

``` javascript
errorTipPosition : "top left"
errorTipPosition : "top right"
errorTipPosition : "bottom left"
errorTipPosition : "bottom right"
```

Here is an example with the <code>@aria:MultiAutoComplete</code> widget:

``` javascript
{@aria:MultiAutoComplete{
      label:"Choose your city: ",
      labelPos:"left",
      labelAlign:"right",
      width:400,
      block:false,
      labelWidth:180,
      resourcesHandler : getNationsHandler(1),
      spellCheck: false,
      freeText:false,      
      errorTipPosition: "top left",
      bind:{
        "value" : {
          inside : data,
          to : 'foo'
        }
      }
}/}
```
