### PR TITLE
data Model updation while removing options using close_btn

### DIFF
--- a/src/aria/widgets/controllers/MultiAutoCompleteController.js
+++ b/src/aria/widgets/controllers/MultiAutoCompleteController.js
@@ -128,8 +128,34 @@
                     if (dataModel.value) {
                         report.value = addedValue;
                     }
-
                 }
+                return report;
+            },
+
+            /**
+             * Removal of a suggestion
+             * @param {String} label
+             * @return {aria.widgets.controllers.reports.DropDownControllerReport}
+             * @override
+             */
+            removeValue : function (label) {
+                var newSuggestions = aria.utils.Json.copy(this.selectedSuggestions);
+                var report = new aria.widgets.controllers.reports.DropDownControllerReport();
+                var indexToRemove;
+                var arrayUtil = aria.utils.Array;
+                arrayUtil.forEach(this.selectedSuggestions, function (obj, index) {
+                    var suggestionLabel = obj.label || obj;
+                    if (suggestionLabel == label) {
+                        indexToRemove = index;
+                        this.editedSuggestion = obj;
+                    }
+                });
+
+                arrayUtil.removeAt(newSuggestions, indexToRemove);
+                arrayUtil.remove(this.selectedSuggestionsLabelsArray, label);
+                this.selectedSuggestions = newSuggestions;
+                report.value = this.selectedSuggestions;
+                report.ok = true;
                 return report;
             },
 
@@ -139,9 +165,11 @@
              * @return {aria.widgets.controllers.reports.DropDownControllerReport}
              * @override
              */
+
             checkValue : function (value, init) {
                 var report = new aria.widgets.controllers.reports.DropDownControllerReport(), dataModel = this._dataModel, rangeMatch = [], reportVal = [];
                 var addedValue, isRangeValue = this._isRangeValue;
+
                 if (value == null || aria.utils.Array.isEmpty(value)) {
                     // can be null either because it bound to null or because it is bind to value or request is in
                     // progress

--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -98,8 +98,8 @@ Aria.classDefinition({
             if (element.className === "closeBtn") {
                 this._removeMultiselectValues(element, event);
             }
-            this.__resizeInput();
             this._textInputField.focus();
+            this.__resizeInput();
         },
         /**
          * Private method to increase the textInput width on focus
@@ -295,6 +295,7 @@ Aria.classDefinition({
             }
             this.$DropDownTextInput._dom_onkeydown.call(this, event);
         },
+
         /**
          * To remove suggestion on click of close
          * @protected
@@ -308,12 +309,8 @@ Aria.classDefinition({
             var label = parent.firstChild.innerText || parent.firstChild.textContent;
             domUtil.removeElement(parent);
             this._removeValues(label);
-            if (event.type == "click") {
-                this.getTextInputField().focus();
-
-            }
-
         },
+
         /**
          * To edit suggestion on doubleclick
          * @param {aria.utils.HTML} domElement
@@ -330,36 +327,24 @@ Aria.classDefinition({
             this._textInputField.focus();
             // to select the edited text.
             this._keepFocus = true;
-            // this._textInputField.style.width = "0px";
             var report = this.controller.checkValue(label);
             report.caretPosStart = 0;
             report.caretPosEnd = label.length;
             this.$TextInput._reactToControllerReport.call(this, report, arg);
             // after setting the value removing focus
             this._keepFocus = false;
-
         },
+
         /**
          * To remove the label from widget
          * @param {String} label
          * @protected
          */
         _removeValues : function (label) {
-            var indexToRemove, controller = this.controller;
-            var arrayUtil = aria.utils.Array;
-            arrayUtil.forEach(controller.selectedSuggestions, function (obj, index) {
-                var suggestionLabel = obj.label || obj;
-                if (suggestionLabel == label) {
-                    indexToRemove = index;
-                    controller.editedSuggestion = obj;
-                }
-            });
-            arrayUtil.removeAt(controller.selectedSuggestions, indexToRemove);
-            arrayUtil.remove(controller.selectedSuggestionsLabelsArray, label);
-            var newSuggestions = aria.utils.Json.copy(controller.selectedSuggestions);
-            this.setProperty("value", newSuggestions);
+            var controller = this.controller;
+            var report = controller.removeValue(label);
+            this._reactToControllerReport(report);
             this._textInputField.style.width = "0px";
-            this.__resizeInput();
         }
     }
 });

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
@@ -22,7 +22,8 @@ Aria.classDefinition({
 
         this.data = this.data || {
             ac_airline_values : [],
-            freeText : true
+            freeText : true,
+            refresh : 0
         };
         this.setTestEnv({
             template : "test.aria.widgets.form.autocomplete.multiautocomplete.template.MultiAutoTpl",

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -30,5 +30,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test8.MultiAutoMaxOptions");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test9.MultiAutoBackSpace");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.duplicateValuesAfterError.DuplicateValuesAfterError");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.OnChangeHandler.MultiAutoOnChangeTest");
+
     }
 });

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/OnChangeHandler/MultiAutoOnChangeTest.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/OnChangeHandler/MultiAutoOnChangeTest.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.OnChangeHandler.MultiAutoOnChangeTest",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $dependencies : ["aria.utils.FireDomEvent"],
+
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            this.synEvent.click(this.getInputField("MultiAutoId"), {
+                fn : this.typeSomething,
+                scope : this
+            });
+        },
+
+        typeSomething : function (evt, callback) {
+            // give it the time to open a drop down
+            this.synEvent.type(this.getInputField("MultiAutoId"), "sca", {
+                fn : this._wait,
+                scope : this,
+                args : this._selectVal
+            });
+        },
+        _wait : function (evt, callback) {
+            aria.core.Timer.addCallback({
+                fn : callback,
+                scope : this,
+                delay : 1000
+            });
+        },
+        _selectVal : function () {
+            this.synEvent.type(this.getInputField("MultiAutoId"), "[down][enter]", {
+                fn : this._checkDataAdded,
+                scope : this
+            });
+        },
+
+        _checkDataAdded : function () {
+            this.assertEquals(this.data.ac_airline_values.length, 1, "The data is not updated after removing the entry");
+            var parentNode = this.getInputField("MultiAutoId").parentNode;
+            var msIcon = this.getElementsByClassName(parentNode, "closeBtn");
+            this.synEvent.click(msIcon[0], {
+                fn : this._checkValue,
+                scope : this,
+                delay : 2000
+            });
+        },
+
+        _checkValue : function () {
+            this.assertEquals(this.data.ac_airline_values.length, 0, "The data is not updated after removing the entry");
+            this.assertEquals(this.data.refresh, 4, "Onchange handler not called properly");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTpl.tpl
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTpl.tpl
@@ -36,6 +36,10 @@
 			maxOptions: data.maxOptions || 8,
 			freeText: (data.freeText !== false),
 			resourcesHandler: getAirLinesHandler(),
+			onchange: {
+				fn : this.changeHandler,
+				scope : this
+			},
 			bind:{
 			  	"value" : {
 			  		inside : data,

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTplScript.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTplScript.js
@@ -42,19 +42,19 @@ Aria.tplScriptDefinition({
                 }, {
                     label : 'P4.redd',
                     code : 'P4'
-                },{
+                }, {
                     label : 'P5.loreum',
                     code : 'P5'
-                },{
+                }, {
                     label : 'P6.ipsum',
                     code : 'P6'
-                },{
+                }, {
                     label : 'P7.lomeo',
                     code : 'P7'
-                },{
+                }, {
                     label : 'P8.amino',
                     code : 'P8'
-                },{
+                }, {
                     label : 'Scandinavian Airlines System',
                     code : 'SK'
                 }]);
@@ -66,6 +66,9 @@ Aria.tplScriptDefinition({
     $prototype : {
         getAirLinesHandler : function () {
             return this._airLineHandler;
+        },
+        changeHandler : function () {
+            this.data.refresh++;
         }
     }
 });


### PR DESCRIPTION
Onchange was not getting triggered when an option is deleted with the cross icon.
And this causes in-consisitencies in data model updation.
