### PR TITLE
Sending coverage to https://coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: node_js
+env:
+  - COVERAGE=false
+  - COVERAGE=true
+matrix:
+  fast_finish: true
+  allow_failures:
+   - env: COVERAGE=true
 node_js:
   - 0.8
 before_install:
   - npm config set ca ""
   - phantomjs --version
+  - if [ "$COVERAGE" == "true" ] ; then cat test/attester.coverage.yml >> test/attester.yml ; fi
+  - if [ "$COVERAGE" == "true" ] ; then npm install -g coveralls@2.8.0 &> install-coveralls.log & fi
+  - echo "Content of test/attester.yml:" ; cat test/attester.yml
+after_script:
+  - if [ "$COVERAGE" == "true" ] ; then cat install-coveralls.log; fi
+  - if [ "$COVERAGE" == "true" ] ; then cat test-results/coverage.lcov | coveralls && echo "Successfully sent coverage to https://coveralls.io" ; fi
 notifications:
   email:
     - build@ariatemplates.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aria Templates - JavaScript Framework [![Build Status](https://secure.travis-ci.org/ariatemplates/ariatemplates.png?branch=master)](http://travis-ci.org/ariatemplates/ariatemplates)
+# Aria Templates - JavaScript Framework [![Build Status](https://travis-ci.org/ariatemplates/ariatemplates.png?branch=master)](https://travis-ci.org/ariatemplates/ariatemplates) [![Coverage Status](https://coveralls.io/repos/ariatemplates/ariatemplates/badge.png?branch=master)](https://coveralls.io/r/ariatemplates/ariatemplates?branch=master)
 
 ![Aria Templates logo](http://ariatemplates.com/images/logo-forum.png)
 

--- a/test/attester.coverage.yml
+++ b/test/attester.coverage.yml
@@ -1,0 +1,16 @@
+# This extra configuration is appended to attester.yml when COVERAGE=true in travis
+# (cf ../.travis.yml)
+
+coverage:
+ files:
+  rootDirectory: '.'
+  includes:
+   - 'src/aria/**/*.js'
+  excludes:
+   - 'src/aria/css/**'
+   - 'src/aria/resources/DateRes*.js'
+   - 'src/aria/resources/CalendarRes*.js'
+   - 'src/aria/resources/multiselect/FooterRes*.js'
+coverage-reports:
+ lcov-file: 'test-results/coverage.lcov'
+ json-file: 'test-results/coverage.json'


### PR DESCRIPTION
This pull request adds a new build in [travis](https://travis-ci.org) which runs tests with coverage enabled, and which sends coverage results to https://coveralls.io.

This pull request also adds a badge with coverage results in the README.md file.
