### PR TITLE
fix #1001 UTC date was wrongly formatted

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -1440,6 +1440,23 @@ Aria.classDefinition({
         },
 
         /**
+         * Utility which return a new date object with the non UTC function replaced by the UTC ones
+         * @param {Date} date
+         * @return {Date} a new date object
+         */
+        _createUTCDate : function (date) {
+            var newDate = new Date(date.getTime());
+            newDate.getFullYear = newDate.getUTCFullYear;
+            newDate.getMonth = newDate.getUTCMonth;
+            newDate.getDate = newDate.getUTCDate;
+            newDate.getHours = newDate.getUTCHours;
+            newDate.getMinutes = newDate.getUTCMinutes;
+            newDate.getSeconds = newDate.getUTCSeconds;
+            newDate.getMilliseconds = newDate.getUTCMilliseconds;
+            return newDate;
+        },
+
+        /**
          * Format a date from a given pattern
          * @param {Date} date
          * @param {String} pattern. See
@@ -1460,7 +1477,7 @@ Aria.classDefinition({
 
             if (utcTime) {
                 // create a date object whose local time is the UTC time:
-                date = new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds());
+                date = this._createUTCDate(date);
             }
 
             var formatFn = this._getFormatFunction(pattern);

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -749,6 +749,13 @@ Aria.classDefinition({
             } catch (ex) {
                 this.fail("Date Null");
             }
+        },
+        /**
+         * Test UTC formatting during DST change.
+         */
+        testUTCFormat : function () {
+            var dt = new Date(Date.UTC(2014, 2, 30, 2, 15, 0, 0)); // 30/03/2014 02:15:00 UTC
+            this.assertEquals(aria.utils.Date.format(dt, 'HH:mm', true), "02:15", "30/03/2014 02:15:00 UTC should be formated to %2, got %1");
         }
     }
 });


### PR DESCRIPTION
This fixes this issue: 

var date = new Date("2014-03-30T02:15:00.000Z");
aria.utils.Date.format(date , 'HH:mm', true);

Expected output: "02:15"
Actual output: "01:15"
