### PR TITLE
fix #1002 Travis build failure due to npm SSL error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 0.8
 before_install:
+  - npm config set ca ""
   - phantomjs --version
 notifications:
   email:


### PR DESCRIPTION
Let's disable certificate check temporarily (before we migrate to Node 0.10).

Since it's just test builds, it's not a really big deal.
