### PR TITLE
MultiAutoComplete invalid entries and range highlighting

### DIFF
--- a/src/aria/resources/handlers/LCRangeResourceHandler.js
+++ b/src/aria/resources/handlers/LCRangeResourceHandler.js
@@ -50,8 +50,8 @@
         },
         $prototype : {
             rangePattern : {
-                pattern1 : /^[a-z]{1}\d+-\d*/,
-                pattern2 : /^[a-z]{1}\d+,\d+/
+                pattern1 : /^[a-z]{1}\d+-\d*$/,
+                pattern2 : /^[a-z]{1}\d+,\d*/
             },
 
             /**
@@ -88,7 +88,7 @@
                     }
                     var results = {
                         suggestions : [],
-                        multipleValues : true
+                        multipleValues : rangeV.length > 1
                     };
                     for (var k = 0, len = rangeV.length; k < len; k++) {
                         var searchEntry = firstLetter + rangeV[k];

--- a/src/aria/widgets/controllers/MultiAutoCompleteController.js
+++ b/src/aria/widgets/controllers/MultiAutoCompleteController.js
@@ -270,15 +270,15 @@
 
                     // update datamodel through setValue to update the list has well
                     jsonUtils.setValue(dataModel, 'listContent', suggestions);
-                    jsonUtils.setValue(dataModel, 'selectedIdx', matchValueIndex);
-
-                    var report = new aria.widgets.controllers.reports.DropDownControllerReport();
-                    report.text = nextValue;
-                    report.caretPosStart = args.caretPosStart;
-                    report.caretPosEnd = args.caretPosEnd;
 
                     if (this._isRangeValue) {
                         dataModel.value = nextValue;
+                        var selectedValues = [];
+                        for (var i = 0; i < dataModel.listContent.length; i++) {
+                            selectedValues.push(dataModel.listContent[i].value);
+                        }
+                        jsonUtils.setValue(dataModel, 'isRangeValue', this._isRangeValue);
+                        jsonUtils.setValue(dataModel, 'selectedValues', selectedValues);
                     } else {
                         if (matchValueIndex != -1) {
                             dataModel.value = dataModel.listContent[matchValueIndex].value;
@@ -290,7 +290,13 @@
                                 dataModel.value = null;
                             }
                         }
+                        jsonUtils.setValue(dataModel, 'selectedIdx', matchValueIndex);
                     }
+
+                    var report = new aria.widgets.controllers.reports.DropDownControllerReport();
+                    report.text = nextValue;
+                    report.caretPosStart = args.caretPosStart;
+                    report.caretPosEnd = args.caretPosEnd;
 
                     report.value = dataModel.value;
                     report.cancelKeyStroke = true;

--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -897,8 +897,11 @@ Aria.classDefinition({
          * @param {Array} newlyUnselectedIndexes array of newly unselected indexes
          */
         _raiseOnChangeEvent : function (newlySelectedIndexes, newlyUnselectedIndexes) {
-            var preselect = this._checkPreselect();
-            newlySelectedIndexes = (preselect === undefined) ? newlySelectedIndexes : [preselect];
+            if (newlySelectedIndexes.length === 0) {
+                var preselect = this._checkPreselect();
+                newlySelectedIndexes = (preselect === undefined) ? newlySelectedIndexes : [preselect];
+            }
+
             this.$raiseEvent({
                 name : "onChange",
                 selectedIndexes : newlySelectedIndexes,

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test7.MultiAutoError");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test8.MultiAutoMaxOptions");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test9.MultiAutoBackSpace");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test10.MultiAutoRangeHighlighted");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.testHighlightMethods.MultiAutoHighlightTest");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.duplicateValuesAfterError.DuplicateValuesAfterError");
     }

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test10/MultiAutoRangeHighlighted.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test10/MultiAutoRangeHighlighted.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test10.MultiAutoRangeHighlighted",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+            if (!aria.core.Browser.isPhantomJS) {
+                this.clickAndType(["p1-4"], {
+                    fn : this._afterType,
+                    scope : this
+                }, 800);
+            } else {
+                this.end();
+            }
+        },
+
+        _afterType : function () {
+            var mac = this._getWidgetInstance();
+            var elt = mac.controller._listWidget._domElt;
+            var selected = this.getElementsByClassName(elt, "xListSelectedItem_std");
+
+            this.assertEquals(selected.length, 4, "The suggestions are not highlighted.");
+
+            this.clickAndType(["[backspace]", "[backspace]", "[backspace]", "[backspace]", "p1-4", "[enter]"], {
+                fn: this._afterEnter,
+                scope: this
+            }, 800);
+        },
+
+        _afterEnter : function () {
+            this.checkSelectedItems(4, ['P1.some', 'P2.kon', 'P3.red', 'P4.redd']);
+
+            this.clickAndType(["p"], {
+                fn: this._afterLastEntry,
+                scope: this
+            }, 800);
+        },
+
+        _afterLastEntry : function () {
+            var mac = this._getWidgetInstance();
+            var elt = mac.controller._listWidget._domElt;
+            var selected = this.getElementsByClassName(elt, "xListSelectedItem_std");
+            this.assertEquals(selected.length, 0, "There's some suggestions wrongly highlighted.");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test3/MultiAutoDataCheck.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test3/MultiAutoDataCheck.js
@@ -19,7 +19,7 @@ Aria.classDefinition({
     $prototype : {
 
         runTemplateTest : function () {
-            this.clickAndType(["air", "[down][down][enter]", "a", "[down][down][enter]"], {
+            this.clickAndType(["a", "[down][down][enter]", "air", "[down][down][enter]"], {
                 fn : this._afterType,
                 scope : this
             }, 500);
@@ -27,11 +27,11 @@ Aria.classDefinition({
 
         _afterType : function () {
             this.checkDataModel(2, [{
-                        label : 'Air Canada',
-                        code : "AC"
-                    }, {
                         label : 'Air France',
                         code : "AF"
+                    }, {
+                        label : 'Scandinavian Airlines System',
+                        code : "SK"
                     }]);
             this.end();
         }

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEdit.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEdit.js
@@ -20,7 +20,7 @@ Aria.classDefinition({
     $prototype : {
 
         runTemplateTest : function () {
-            this.clickAndType(["air", "[down][down][enter]", "a", "[down][down][enter]"], {
+            this.clickAndType(["a", "[down][down][enter]", "air", "[down][down][enter]"], {
                 fn : this._editValues,
                 scope : this
             }, 500);
@@ -50,7 +50,7 @@ Aria.classDefinition({
         },
 
         _checkValue : function () {
-            this.checkSelectedItems(2, ["Scandinavian Airlines System", "Air France"]);
+            this.checkSelectedItems(2, ["Air Canada", "Scandinavian Airlines System"]);
             this.end();
         }
 


### PR DESCRIPTION
This PR aims to fix a problem when you have a suggestion as 'TEST' and you type 'TE' and press enter and the MAC displays an error tooltip.

It also add the highlight feature to the suggestions filtered by the range patter (e.g. p1-4)
