### PR TITLE
Data model undefined when MAC widget in error state

### DIFF
--- a/src/aria/widgets/controllers/reports/ControllerReport.js
+++ b/src/aria/widgets/controllers/reports/ControllerReport.js
@@ -53,6 +53,12 @@ Aria.classDefinition({
         this.value;
 
         /**
+         * Internal value associated to the display when report is ko
+         * @type Object
+         */
+        this.errorValue;
+
+        /**
          * used to return any error messages associated to an internal validation
          * @type Array
          */

--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -82,6 +82,9 @@ Aria.classDefinition({
          * @param {Object} arg Optional parameters
          */
         _reactToControllerReport : function (report, arg) {
+            if (report && report.ok === false) {
+                report.errorValue =  this.controller.selectedSuggestions;
+            }
             this.$AutoComplete._reactToControllerReport.call(this, report, arg);
             if (report && report.value !== null) {
                 this._addMultiselectValues(report, arg);

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -553,7 +553,7 @@ Aria.classDefinition({
                         }
                         // if the text is incorrect, the bound property should
                         // be set to 'undefined'
-                        hasChange = this.setProperty("value", undefined);
+                        hasChange = this.setProperty("value", report.errorValue);
                     }
                 }
 

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -30,6 +30,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test8.MultiAutoMaxOptions");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test9.MultiAutoBackSpace");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test10.MultiAutoRangeHighlighted");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test11.MultiAutoInvalidDataModel");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.testHighlightMethods.MultiAutoHighlightTest");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.testHighlightMethods.MultiAutoHighlightNavigation");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.duplicateValuesAfterError.DuplicateValuesAfterError");

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test11/MultiAutoInvalidDataModel.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test11/MultiAutoInvalidDataModel.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test11.MultiAutoInvalidDataModel",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+        this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
+
+        this.data.freeText = false;
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            var dataBind = this.data.ac_airline_values;
+            this.clickAndType(["Air Canada", "[enter]", "Air France", "[enter]", "z", "[enter]"], {
+                fn : this._afterEnter,
+                scope : this
+            }, 800);
+        },
+
+        _afterEnter : function () {
+            var dataBind = this.data.ac_airline_values;
+            this.assertTrue(dataBind !== undefined, "The data model should contain 2 items, but it is undefined instead.");
+            this.assertTrue(dataBind.length === 2, "The data model should contain 2 items.");
+
+            this.clickAndType(["[backspace]", "z", "[tab]"], {
+                fn: this._afterTab,
+                scope: this
+            }, 800);
+        },
+
+        _afterTab : function () {
+            var dataBind = this.data.ac_airline_values;
+            this.assertTrue(dataBind !== undefined, "The data model should contain 2 items, but it is undefined instead.");
+            this.assertTrue(dataBind.length === 2, "The data model should contain 2 items.");
+
+            this.clickAndType(["[backspace]", "z"], {
+                fn: this._afterType,
+                scope: this
+            }, 800);
+        },
+
+        _afterType : function () {
+            this.synEvent.click(this.getElementById("justToFocusOut"), {
+                fn : this._afterClick,
+                scope : this,
+                delay : 800
+            });
+        },
+
+        _afterClick : function () {
+            var dataBind = this.data.ac_airline_values;
+            this.assertTrue(dataBind !== undefined, "The data model should contain 2 items, but it is undefined instead.");
+            this.assertTrue(dataBind.length === 2, "The data model should contain 2 items.");
+            this.end();
+        }
+    }
+});


### PR DESCRIPTION
This commit fix a problem with the MAC that was resetting the data model to undefined when the user was inserting an invalid item.
