### PR TITLE
[on hold] feat #1015 Check Git commit message during Travis build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ Before you start coding, take this advice: [__Test Driven Development (TDD)__](h
 
 At any stage of development, feel free to contact us for suggestions, code review or general support, we're here to help.
 
+## Git workflow & opening pull requests
+
 Done with testing + coding? Create a __pull request__ from your forked repository.
 
 Here's the process we follow in the team. We believe it'll be good for you as well:
@@ -94,6 +96,8 @@ Here's the process we follow in the team. We believe it'll be good for you as we
 >
 > Please provide a detailed description of your changes. Your code should be self-explanatory, but a good pull request description is always appreciated.
 
+## Commit message
+
 When you commit make sure to provide a good commit message. Messages should be informative and easy to understand.
 
 __DON'T__:
@@ -110,9 +114,15 @@ __BETTER__:
 
 Remember:
 
-- The first line is a short description. It should start with "fix #123" for a bugfix, "feat #123" for a new feature, or "refactor" (#123 is the GitHub issue ID).
+- The first line is a short description. It should start with "fix #123" for a bugfix, "feat #123" for a new feature,
+  (#123 is the GitHub issue ID) "refactor" if it just refactors/reformats the code or "doc" if it adds documentation.
 - The next paragraphs provide more explanation if necessary.
 - In the last line, add "Close #456" as many times as necessary, to [close the related issues / a pull request once the commits lands in master](https://github.com/blog/1386-closing-issues-via-commit-messages). If the first starts with "feat #123", you should duplicate that ID here.
+
+We have a build-time checker that verifies that commit message format, you can also install a Git hook to do it for you
+at commit time. You can install it with this command in your repository's root folder:
+
+    npm install -g grunt grunt-commit-message-verify; cp ./hooks/* ./.git/hooks/
 
 For brand new features, make sure to write some documentation.
 You'll see how in the [next chapter](#improve-documentation).

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,11 +22,13 @@ module.exports = function (grunt) {
 
     grunt.registerTask('clean', ['removedirs:bootstrap', 'removedirs:prod']);
     grunt.registerTask('release', ['clean', 'bootstrap', 'prod', 'gzipStats:prod']);
-    grunt.registerTask('default', ['gruntTimeHookStart', 'release', 'gruntTimeHookEnd']);
+    grunt.registerTask('git', ['grunt-commit-message-verify']);
+    grunt.registerTask('default', ['gruntTimeHookStart', 'release', 'git', 'gruntTimeHookEnd']);
 
     grunt.loadTasks('./build/grunt-tasks');
     grunt.loadNpmTasks('atpackager');
     grunt.loadNpmTasks('grunt-verifylowercase');
+    grunt.loadNpmTasks('grunt-commit-message-verify');
     grunt.loadNpmTasks('grunt-leading-indent');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadTasks('./build/grunt-config');

--- a/build/grunt-config/config-checkCommitMessage.js
+++ b/build/grunt-config/config-checkCommitMessage.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Commit message checking grunt configuration.
+ * @param {Object} grunt
+ */
+module.exports = function (grunt) {
+
+    // https://help.github.com/articles/closing-issues-via-commit-messages
+    var githubCloseIssueRegex = /(((close|resolve)(s|d)?)|fix(e(s|d))?) #\d+/i;
+
+    // the commit is either a fix, a feature, a documentation fix, a refactoring, new release commit, or
+    // Work-In-Progress temporary commit
+    var msgStartRegex = /^((refactor|doc) |((fix|feat) #\d+ )|(v?\d+\.\d+\.\d+)|WIP)/;
+
+    grunt.config.set('grunt-commit-message-verify', {
+        minLength : 0,
+        maxLength : 3000,
+        minFirstLineLength : 20, // first line should be both concise and informative
+        maxFirstLineLength : 0,  // use global below
+        maxLineLength : 80,      // this is to prevent overflows in console and Github UI
+        regexes : {
+            "check start of the commit" : {
+                regex : msgStartRegex,
+                explanation : "The commit should start with sth like fix #123, feat #123, doc, refactor, or WIP for test commits"
+            },
+            "is github compliant" : {
+                regex : githubCloseIssueRegex,
+                explanation : "The commit should contain sth like fix #123 or close #123 somewhere"
+            }
+        }
+    });
+};

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+// we want to reuse the config from the build cfg instead of having to keep it in sync
+// assuming we're in <PROJECT_DIR>/.git/hooks
+var cfgOrigin = '../../build/grunt-config/config-checkCommitMessage.js';
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+var fs = require('fs');
+var checkCommit = require('grunt-commit-message-verify/lib/check-commit-message.js');
+
+var commitMsgFile = process.argv[2];
+var commitMsg = fs.readFileSync(commitMsgFile).toString(); // passing "encoding" : "utf8" throws for some reason
+
+var cfg = gruntReadConfigHack(cfgOrigin);
+
+var report = checkCommit.performChecks(commitMsg, cfg);
+
+var errors = report.errors;
+var hasError = (errors.length > 0);
+if (hasError) {
+    var errMsg = ["\nCommit message verification has failed:"];
+    errors.forEach(function (err, idx) {
+        errMsg.push("\n");
+        errMsg.push((idx + 1) + ". " + err + "\n");
+    });
+    writeError(errMsg.join(""));
+}
+process.exit(hasError ? 1 : 0);
+
+/**
+ * This function reads and executes the Grunt config file from the given path and tries to read commit message config.<br>
+ * It requires that the input file has the following structure:<br>
+ * <code>
+ *   module.exports = function (grunt) { grunt.config.set('grunt-commit-message-verify', {...}) }
+ * </code>
+ * @param {String} cfgOrigin Path to the JS file
+ * @return {Object}
+ */
+function gruntReadConfigHack (cfgOrigin) {
+    var cfg;
+
+    // pass the mock object which will fake being grunt and read the config to a local var
+    require(cfgOrigin)({
+        config : {
+            set : function (sEntryName, cfgObj) {
+                if(sEntryName === "grunt-commit-message-verify") {
+                    cfg = cfgObj;
+                }
+            }
+        }
+    });
+
+    if (!cfg) {
+        writeError("Can't read 'grunt-commit-message-verify' config from " + cfgOrigin);
+        process.exit(1);
+    }
+    return cfg;
+}
+
+function writeError (msg) {
+    process.stdout.write(""); // without this, Git GUI doesn't display the message sometimes, don't ask
+    process.stderr.write(msg);
+}

--- a/package.json
+++ b/package.json
@@ -14,19 +14,22 @@
     "phantomjsInstances": 2
   },
   "scripts": {
-    "start": "node scripts/server.js",
-    "prestart": "npm install && npm run-script grunt",
-    "grunt": "node build/grunt-cli.js",
     "attester": "node node_modules/attester/bin/attester.js test/attester.yml",
+    "grunt": "node build/grunt-cli.js",
+    "grunt-git": "node build/grunt-cli.js grunt-commit-message-verify",
+    "install-hooks" : "npm install -g grunt grunt-commit-message-verify && cp ./hooks/* ./.git/hooks/",
     "lint": "node build/grunt-cli.js checkStyle",
     "mocha": "mocha --recursive test/node",
-    "test": "npm run-script lint && npm run-script grunt && npm run-script mocha && npm run-script attester"
+    "prestart": "npm install && npm run-script grunt",
+    "start": "node scripts/server.js",
+    "test": "npm run lint && npm run grunt && npm run mocha && npm run attester && npm run grunt-git"
   },
   "devDependencies": {
     "atpackager": "0.2.2",
     "attester": "1.3.0",
     "express": "3.4.8",
     "grunt": "0.4.2",
+    "grunt-commit-message-verify" : "0.1.0",
     "grunt-contrib-jshint": "0.8.0",
     "grunt-leading-indent": "0.1.0",
     "grunt-verifylowercase": "0.2.0",


### PR DESCRIPTION
[TODO] I still have some things to change, I'll do it soon 

This commit enables checking if commit message of the latest non-merge Git commit is of good length (not too short, not too long) and if it adheres to certain team's conventions.

To quickly verify the commit message locally, after the commit, the developers can use the following commands in their shell:

```
 grunt git           # (if they have Grunt installed globally)
```

or

```
 npm run grunt-git   # local Grunt installation is enough
```

This commit also provides a commit-time Git hook that can be installed using this one-liner in the root folder of AT:

```
 npm run install-hooks
```

 Once the hook is installed locally, if for some reason a developer wants to bypass the hook, he can commit using the `--no-verify` (`-n`) flag.
