### PR TITLE
fix - old opacity value is stored in fullValue property

### DIFF
--- a/src/aria/utils/css/Effects.js
+++ b/src/aria/utils/css/Effects.js
@@ -346,7 +346,7 @@
                         }, 0);
                     }
                 } else {
-                    endProps.opacity = oldValues.opacity || 1;
+                    endProps.opacity = (oldValues.opacity)? oldValues.opacity.fullValue : 1;
                 }
 
                 elem.style.display = display || "block";


### PR DESCRIPTION
old opacity value is stored in fullValue property
