### PR TITLE
MultiAutoComplete wrong behavior when editing without changing entry.

### DIFF
--- a/src/aria/widgets/form/MultiAutoCompleteStyle.tpl.css
+++ b/src/aria/widgets/form/MultiAutoCompleteStyle.tpl.css
@@ -59,10 +59,12 @@
             width:${skinClass.closeSpriteWidth}px;
             display:inline-block;
             padding-left:2px;
+            cursor:pointer;
             {call background(skinClass.optionsBackgroundColor, skinClass.closeSpriteURL, "no-repeat -5px -25px")/}
         }
 
         .xMultiAutoComplete_${skinClassName}_options span.xMultiAutoComplete_Option_Text{
+            outline: none;
             margin:2px 5px;
             display:inline-block;
             cursor:pointer;
@@ -78,7 +80,6 @@
             background-position: -5px -5px;
         }
         .xMultiAutoComplete_${skinClassName}_options.highlight{
-            outline: none;
             border: ${skinClass.optionsHighlightBorderWidth}px solid ${skinClass.optionsHighlightBorderColor};
             background-color: ${skinClass.optionsHighlightBackgroundColor};
             color:${skinClass.optionsHighlightColor};

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
@@ -16,7 +16,7 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
     $extends : "aria.jsunit.TemplateTestCase",
-    $dependencies : ["aria.utils.Type", "aria.utils.FireDomEvent", "aria.utils.Math"],
+    $dependencies : ["aria.utils.Type", "aria.utils.Math"],
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
 
@@ -148,9 +148,12 @@ Aria.classDefinition({
             var suggestionToBeHighlighted = suggestionsContainer.children[index].firstChild;
             return suggestionToBeHighlighted;
         },
-        _fireClickOnSuggestion : function (index) {
+        _fireClickOnSuggestion : function (index, continueWith) {
             var suggestionToBeHighlighted = this._suggestionToBeHighlighted(index);
-            aria.utils.FireDomEvent.fireEvent('click', suggestionToBeHighlighted);
+            this.synEvent.click(suggestionToBeHighlighted, {
+                scope : this,
+                fn : continueWith
+            });
         },
         checkHighlightedElementsIndices : function (expectedHighlightedArray) {
             var widgetInstance = this._getWidgetInstance();

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -24,6 +24,10 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test3.MultiAutoDataCheck");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test4.MultiAutoPrefill");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEdit");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditChangedFreetext");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditChangedSuggestion");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditUnchangedFreetext");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditUnchangedSuggestion");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test6.MultiAutoRange1");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test6.MultiAutoRange2");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.test7.MultiAutoError");

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditChangedFreetext.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditChangedFreetext.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditChangedFreetext",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.clickAndType(["b", "[enter]", "a", "[enter]"], {
+                fn : this._editValues,
+                scope : this
+            }, 500);
+        },
+
+        _editValues : function () {
+            this.checkDataModel(2, ["b", "a"]);
+            this._fireClickOnSuggestion(0, "_afterFirstClick");
+        },
+
+        _afterFirstClick : function () {
+            this._fireClickOnSuggestion(0, "_afterSecondClick");
+        },
+
+        _afterSecondClick : function () {
+            aria.core.Timer.addCallback({
+                scope : this,
+                fn : this._afterWaitSomeTime,
+                delay : 10
+            });
+        },
+
+        _afterWaitSomeTime : function () {
+            this.checkDataModel(1, ["a"]);
+            this.type({
+                text : ["k", "[enter]"],
+                cb : {
+                    fn : this._afterChange,
+                    scope : this
+                },
+                delay : 500
+            });
+        },
+
+        _afterChange : function () {
+            this.checkDataModel(2, ["a", "k"]);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditChangedSuggestion.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditChangedSuggestion.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditChangedSuggestion",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.clickAndType(["a", "[down][down][enter]", "air", "[down][down][enter]"], {
+                fn : this._editValues,
+                scope : this
+            }, 500);
+        },
+
+        _editValues : function () {
+            this.checkDataModel(2, [{
+                        label : "Air France",
+                        code : "AF"
+                    }, {
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }]);
+            this._fireClickOnSuggestion(0, "_afterFirstClick");
+        },
+
+        _afterFirstClick : function () {
+            this._fireClickOnSuggestion(0, "_afterSecondClick");
+        },
+
+        _afterSecondClick : function () {
+            aria.core.Timer.addCallback({
+                scope : this,
+                fn : this._afterWaitSomeTime,
+                delay : 10
+            });
+        },
+
+        _afterWaitSomeTime : function () {
+            this.checkDataModel(1, [{
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }]);
+            this.type({
+                text : ["q", "[down][enter]"],
+                cb : {
+                    fn : this._afterChange,
+                    scope : this
+                },
+                delay : 500
+            });
+        },
+
+        _afterChange : function () {
+            this.checkDataModel(2, [{
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }, {
+                        label : "Qantas",
+                        code : "--"
+                    }]);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditUnchangedFreetext.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditUnchangedFreetext.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditUnchangedFreetext",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.clickAndType(["b", "[enter]", "a", "[enter]"], {
+                fn : this._editValues,
+                scope : this
+            }, 500);
+        },
+
+        _editValues : function () {
+            this.checkDataModel(2, ["b", "a"]);
+            this._fireClickOnSuggestion(0, "_afterFirstClick");
+        },
+
+        _afterFirstClick : function () {
+            this._fireClickOnSuggestion(0, "_afterSecondClick");
+        },
+
+        _afterSecondClick : function () {
+            aria.core.Timer.addCallback({
+                scope : this,
+                fn : this._afterWaitSomeTime,
+                delay : 10
+            });
+        },
+
+        _afterWaitSomeTime : function () {
+            this.checkDataModel(1, ["a"]);
+            this.focusOut({
+                scope : this,
+                fn : this._afterFocusOut
+            });
+        },
+
+        _afterFocusOut : function () {
+            this.checkDataModel(2, ["a", "b"]);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditUnchangedSuggestion.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/test5/MultiAutoEditUnchangedSuggestion.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.test5.MultiAutoEditUnchangedSuggestion",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.clickAndType(["a", "[down][down][enter]", "air", "[down][down][enter]"], {
+                fn : this._editValues,
+                scope : this
+            }, 500);
+        },
+
+        _editValues : function () {
+            this.checkDataModel(2, [{
+                        label : "Air France",
+                        code : "AF"
+                    }, {
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }]);
+            this._fireClickOnSuggestion(0, "_afterFirstClick");
+        },
+
+        _afterFirstClick : function () {
+            this._fireClickOnSuggestion(0, "_afterSecondClick");
+        },
+
+        _afterSecondClick : function () {
+            aria.core.Timer.addCallback({
+                scope : this,
+                fn : this._afterWaitSomeTime,
+                delay : 10
+            });
+        },
+
+        _afterWaitSomeTime : function () {
+            this.checkDataModel(1, [{
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }]);
+            this.focusOut({
+                scope : this,
+                fn : this._afterFocusOut
+            });
+        },
+
+        _afterFocusOut : function () {
+            this.checkDataModel(2, [{
+                        label : "Scandinavian Airlines System",
+                        code : "SK"
+                    }, {
+                        label : "Air France",
+                        code : "AF"
+                    }]);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/testHighlightMethods/MultiAutoHighlightNavigation.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/testHighlightMethods/MultiAutoHighlightNavigation.js
@@ -33,11 +33,17 @@ Aria.classDefinition({
             // initial test for all the suggestions added
             this.checkSelectedItems(4);
 
-            this._fireClickOnSuggestion(1);
+            this._fireClickOnSuggestion(1, "_afterFirstClick");
+        },
+
+        _afterFirstClick : function () {
             this.checkHighlightedElementsIndices([2]);
 
             // test for removal, and adding highlight again
-            this._fireClickOnSuggestion(2);
+            this._fireClickOnSuggestion(2, "_afterSecondClick");
+        },
+
+        _afterSecondClick : function () {
             this.checkHighlightedElementsIndices([3]);
 
             this.type({
@@ -71,13 +77,17 @@ Aria.classDefinition({
             this.checkHighlightedElementsIndices([2]);
 
             // since the element is already highlighted, it should now go to edit mode
-            this._fireClickOnSuggestion(1);
-            this.synEvent.click(this._getField(), {
-                fn : this._checkForEdit,
-                scope : this
-            });
-
+            this._fireClickOnSuggestion(1, "_afterEditSingapore");
         },
+
+        _afterEditSingapore : function () {
+            aria.core.Timer.addCallback({
+                fn : this._checkForEdit,
+                scope : this,
+                delay : 10
+            });
+        },
+
         _checkForEdit : function () {
             this.type({
                 text : ["p1-3", "[enter]"],
@@ -100,7 +110,10 @@ Aria.classDefinition({
                         label : 'P3.red',
                         code : 'P3'
                     }]);
-            this._fireClickOnSuggestion(3);
+            this._fireClickOnSuggestion(3, "_afterClickOnP3");
+        },
+
+        _afterClickOnP3 : function () {
             this.checkHighlightedElementsIndices([4]);
             this.type({
                 text : ["[delete]"],
@@ -113,7 +126,10 @@ Aria.classDefinition({
         },
         _afterDeleteLastSuggestion : function () {
             this.checkHighlightedElementsIndices([]);
-            this._fireClickOnSuggestion(0);
+            this._fireClickOnSuggestion(0, "_afterClickOnIndia");
+        },
+
+        _afterClickOnIndia : function () {
             this.type({
                 text : ["[backspace]"],
                 cb : {


### PR DESCRIPTION
This pull request fixes some issues linked to the edit mode in the MultiAutoComplete.
Especially, when editing an entry and, immediately after, focusing something else, the entry stays in edit mode until the field is focused again.
Also, this pull request fixes some errors logged in the console when editing free text entries.
