### PR TITLE
Removing wrong lines in the MultiAutoComplete.

### DIFF
--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -414,8 +414,6 @@ Aria.classDefinition({
                                 this._makeInputFieldLastChild();
                                 this.setHelpText(false);
                                 inputField.focus();
-                                var newSuggestions = aria.utils.Json.copy(this.controller.selectedSuggestions);
-                                this.setProperty("value", newSuggestions);
                             }
                         }
                     }


### PR DESCRIPTION
This pull request removes two lines which set a new value in the data model when pressing tab if the field is empty and not positioned at the end of the options (i.e. when leaving the edit mode through tab if the field is empty).

There is no reason to set the value at that time as the value has not changed, and this can lead to the onchange handler being called later when the value has not changed.
