### PR TITLE
feat #1034 Disable method events by default

### DIFF
--- a/src/aria/pageEngine/SiteRootModule.js
+++ b/src/aria/pageEngine/SiteRootModule.js
@@ -23,8 +23,6 @@ Aria.classDefinition({
     $implements : ["aria.pageEngine.SiteRootModuleInterface"],
     $dependencies : ["aria.utils.Path", "aria.pageEngine.utils.PageEngineUtils"],
     $constructor : function () {
-        this._enableMethodEvents = false;
-
         this.$ModuleCtrl.constructor.call(this);
 
         /**

--- a/src/aria/templates/IModuleCtrl.js
+++ b/src/aria/templates/IModuleCtrl.js
@@ -21,19 +21,19 @@ Aria.interfaceDefinition({
     $classpath : 'aria.templates.IModuleCtrl',
     $events : {
         "methodCallBegin" : {
-            description : "Raised before a method from the module controller public interface is called.",
+            description : "Raised before a method from the module controller public interface is called (raised only if you set this._enableMethodEvents = true).",
             properties : {
                 method : "Name of the method about to be called."
             }
         },
         "methodCallEnd" : {
-            description : "Raised after a method from the module controller public interface has been called.",
+            description : "Raised after a method from the module controller public interface has been called (raised only if you set this._enableMethodEvents = true).",
             properties : {
                 method : "Name of the method which was called."
             }
         },
         "methodCallback" : {
-            description : "Raised when a method from the module controller public interface calls its callback.",
+            description : "Raised when a method from the module controller public interface calls its callback (raised only if you set this._enableMethodEvents = true).",
             properties : {
                 method : "Name of the method which was called."
             }

--- a/src/aria/templates/ModuleCtrl.js
+++ b/src/aria/templates/ModuleCtrl.js
@@ -83,21 +83,15 @@ Aria.classDefinition({
          */
         this.$requestJsonSerializer = null;
 
-        /* Backward compatability code starts */
-        if (this._enableMethodEvents == null) {
-            this.$logWarn(this.DEPRECATED_METHOD_EVENTS);
-            this._enableMethodEvents = true;
-        }
-        /* Backward compatability code ends */
-
         /**
-         * The enableMethodEvents is set to true to enable method events (methodCallBegin, methodCallEnd,
-         * methodCallback), it is currently defaults to true for backward compatibility and will default to false in a
-         * future release.
+         * The _enableMethodEvents setting defaults to false, it should be set to true to enable method events
+         * (methodCallBegin, methodCallEnd, methodCallback). Note that if you want to enable this feature, you must set
+         * this._enableMethodEvents to true in your module controller's constructor <em>before</em> calling parent
+         * constructor. Turning this setting on has an impact on the performance of your application.
          * @protected
          * @type Boolean
          */
-        this._enableMethodEvents = (this._enableMethodEvents !== true) ? false : this._enableMethodEvents;
+        this._enableMethodEvents = (this._enableMethodEvents === true);
 
         if (this._enableMethodEvents) {
             // Add the interceptor to send generic events
@@ -129,9 +123,7 @@ Aria.classDefinition({
     $statics : {
         // ERROR MESSAGES
         INIT_CALLBACK_ERROR : "An error occured while processing a Module init callback in class %1",
-        DATA_CONTENT_INVALID : "Content of datamodel does not match databean:\nbean name: %1,\nmodule class: %2",
-        DEPRECATED_METHOD_EVENTS : "Generic method events (methodCallBegin, methodCallEnd, methodCallback) will be turned off by default in a future release. If the application relies on those events please set the enableMethodEvents variable to true. To already benefit from performance improvements by disabling them, you can set this variable to false."
-
+        DATA_CONTENT_INVALID : "Content of datamodel does not match databean:\nbean name: %1,\nmodule class: %2"
     },
     $prototype : {
         /**

--- a/test/aria/pageEngine/pageEngine/site/modules/BaseSimpleModule.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/BaseSimpleModule.js
@@ -27,9 +27,6 @@ Aria.classDefinition({
 
         isInPage : function () {
             return this.pageEngine.isModuleInPage(this);
-        },
-
-        _enableMethodEvents : false
-
+        }
     }
 });

--- a/test/aria/templates/EnableMethodEventInterceptorTest.js
+++ b/test/aria/templates/EnableMethodEventInterceptorTest.js
@@ -39,10 +39,9 @@ Aria.classDefinition({
             try {
                 var mc = res.moduleCtrlPrivate;
                 this.assertTrue(mc.__$interceptors != null);
-                this.assertErrorInLogs(mc.DEPRECATED_METHOD_EVENTS);
                 mc.incrementCount();
                 aria.core.Timer.addCallback({
-                    fn : this._endTestAsyncEnableInterceptor,
+                    fn : this._endTestAsyncDisableInterceptor,
                     scope : this,
                     args : {
                         "mc" : mc,
@@ -82,8 +81,8 @@ Aria.classDefinition({
             }
         },
         _endTestAsyncDisableInterceptor : function (args) {
-            this.assertFalse(args.mc.unexpectedMethodCallBegin);
-            this.assertFalse(args.mc.unexpectedMethodCallEnd);
+            this.assertFalse(args.mc.eventCallBeginRaised);
+            this.assertFalse(args.mc.eventCallEndRaised);
             args.mc.$dispose();
             this.notifyTestEnd("testAsyncDisableInterceptor");
         },

--- a/test/aria/templates/autorefresh/AutorefreshTestCase4.js
+++ b/test/aria/templates/autorefresh/AutorefreshTestCase4.js
@@ -53,6 +53,9 @@ Aria.classDefinition({
         this._refreshesTemplateC = 0;
         this._refreshesTemplateD = 0;
 
+        this._expectedRefreshesSync = 1;
+        this._expectedRefreshesAsync = 1;
+
         this.defaultTestTimeout = 30000;
 
     },
@@ -83,7 +86,8 @@ Aria.classDefinition({
             this.mc.syncRefreshes(this._templateA);
 
             // test Template A was refreshed just once
-            this.assertTrue(this._refreshesTemplateA == 1);
+            this._gotRefreshesSync = this._refreshesTemplateA;
+            this.assertEquals(this._gotRefreshesSync, this._expectedRefreshesSync, "Expected %2 sync refreshes but got %1");
 
             this._testAsyncMethod();
 
@@ -98,7 +102,8 @@ Aria.classDefinition({
 
         _testAsyncMethodCB : function () {
             // test Template A was refreshed jsut once since the last time!
-            this.assertTrue(this._refreshesTemplateA == 2);
+            var gotRefreshesAsync = this._refreshesTemplateA - this._gotRefreshesSync;
+            this.assertEquals(gotRefreshesAsync, this._expectedRefreshesAsync, "Expected %2 async refreshes but got %1");
             this.finishTest();
         },
 

--- a/test/aria/templates/autorefresh/RefreshModule.js
+++ b/test/aria/templates/autorefresh/RefreshModule.js
@@ -20,16 +20,21 @@ Aria.classDefinition({
     $classpath : "test.aria.templates.autorefresh.RefreshModule",
     $extends : "aria.templates.ModuleCtrl",
     $implements : ["test.aria.templates.autorefresh.IRefreshModule"],
+    $constructor : function () {
+        this._enableMethodEvents = true;
+        this.$ModuleCtrl.constructor.call(this);
+    },
     $prototype : {
         $publicInterfaceName : "test.aria.templates.autorefresh.IRefreshModule",
 
         syncRefreshes : function (tplCtxt) {
+            // here we expect to have just 1 refresh due to _enableMethodEvents=true which causes the RefreshMgr to stop
+            // before each call to the module's public method
             this.tplCtxt = tplCtxt;
             tplCtxt.$refresh();
             tplCtxt.$refresh();
             tplCtxt.$refresh();
         },
-
         asyncRefreshes : function (argCB) {
             var cb = {
                 scope : this,
@@ -44,6 +49,8 @@ Aria.classDefinition({
         },
 
         _asyncRefreshesCB : function (res, args) {
+            // here we expect to have just 1 refresh due to submitJsonRequest internally pausing RefreshMgr in
+            // _submitJsonRequestCB
             this.tplCtxt.$refresh();
             this.tplCtxt.$refresh();
             this.tplCtxt.$refresh();

--- a/test/aria/templates/test/DisableMethodEventsModuleCtrl.js
+++ b/test/aria/templates/test/DisableMethodEventsModuleCtrl.js
@@ -31,8 +31,8 @@ Aria.classDefinition({
             "methodCallEnd" : this.onMethodCallEnd,
             scope : this
         });
-        this.unexpectedMethodCallBegin = false;
-        this.unexpectedMethodCallEnd = false;
+        this.eventCallBeginRaised = false;
+        this.eventCallEndRaised = false;
     },
     $destructor : function () {
         this.$publicInterface().DisableMethodEventsModuleCtrDisposed = true;
@@ -47,10 +47,10 @@ Aria.classDefinition({
 
         },
         onMethodCallBegin : function () {
-            this.unexpectedMethodCallBegin = true;
+            this.eventCallBeginRaised = true;
         },
         onMethodCallEnd : function () {
-            this.unexpectedMethodCallEnd = true;
+            this.eventCallEndRaised = true;
         }
     }
 });


### PR DESCRIPTION
TODO 
- [x] update documentation: https://github.com/ariatemplates/usermanual/pull/69

Backward-incompatible

This commit changes the default value of `this._enableMethodEvents` to
`false` in the `ModuleCtrl` class. The implications of this change are the
new default behaviors when calling any module's public method, as follows:
- no interceptors are added, the methods are called directly
- no events `methodCallBegin`, `methodCallEnd`, `methodCallback` are
  raised
- RefreshMgr is not automatically paused for the span of the call to
  the module controller's method

This commit should bring some performance gains.

In case the developer wants to continue having the old behaviors, he
should set `this._enableMethodEvents = false;` in the constructor of his
module controller, _before_ calling the parent constructor.

This commit also removes the calls setting the mentioned variable to
false, since they're not needed anymore.
