### PR TITLE
Check the skin when normalizing it

### DIFF
--- a/build/grunt-config/config-atpackager-bootstrap.js
+++ b/build/grunt-config/config-atpackager-bootstrap.js
@@ -31,6 +31,7 @@ module.exports = function (grunt) {
 
     grunt.config.set('atpackager.bootstrap', {
         options : {
+            ATDebug : true,
             sourceDirectories : ['src'],
             sourceFiles : ['aria/**/*', '!aria/node.js', '!aria/bootstrap.js'],
             defaultBuilder : {
@@ -63,7 +64,8 @@ module.exports = function (grunt) {
                     }, {
                         type : 'ATNormalizeSkin',
                         cfg : {
-                            files : ['aria/css/*.js']
+                            files : ['aria/css/*.js'],
+                            strict : true
                         }
                     }, {
                         type : 'CopyUnpackaged',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run-script lint && npm run-script grunt && npm run-script mocha && npm run-script attester"
   },
   "devDependencies": {
-    "atpackager": "0.2.2",
+    "atpackager": "0.2.3",
     "attester": "1.3.0",
     "express": "3.4.8",
     "grunt": "0.4.2",


### PR DESCRIPTION
This pull request updates the version of `atpackager`, and updates the configuration of the `ATNormalizeSkin` visitor to check the skin properties while normalizing them. In case a skin property is not correct (if it does not match the bean in `aria.widgets.AriaSkinBeans`), the build fails.
