### PR TITLE
feat #1044 add aria.core.IO.postHeaders

### DIFF
--- a/src/aria/core/CfgBeans.js
+++ b/src/aria/core/CfgBeans.js
@@ -254,35 +254,35 @@ Aria.beanDefinitions({
                             "REBIND"],
                     $sample : "POST"
                 },
-                /* Backward Compatibility begins here, use data property instead */
-                "postData" : {
-                    $type : "json:String",
-                    $description : "[DEPRECATED] Data to be sent in the body of the POST method. Ignored for GET requests. This property can be changed by filters."
-                },
-                /* Backward Compatibility ends here */
                 "data" : {
                     $type : "json:String",
                     $description : "Data to be sent in the body of the request methods. Ignored for GET requests. This property can be changed by filters."
                 },
-                /* Backward Compatibility begins here, use contentTypeHeader property instead */
+                /* BACKWARD-COMPATIBILITY-BEGINS GH-1044 POSTDATA */
+                "postData" : {
+                    $type : "json:String",
+                    $description : "[DEPRECATED, use 'data' instead] Data to be sent in the body of the POST method. Ignored for GET requests. This property can be changed by filters."
+                },
+                /* BACKWARD-COMPATIBILITY-END GH-1044 POSTDATA */
+                /* BACKWARD-COMPATIBILITY-BEGINS GH-1044 HEADERS */
                 "postHeader" : {
                     $type : "json:String",
-                    $description : "[DEPRECATED] Header 'Content-type' to be used for POST requests.",
+                    $description : "[DEPRECATED, use 'headers' object] Header 'Content-type' to be used for POST requests.",
                     $default : "application/x-www-form-urlencoded; charset=UTF-8"
                 },
-                /* Backward Compatibility ends here */
                 "contentTypeHeader" : {
                     $type : "json:String",
-                    $description : "Header 'Content-type' to be used for requests.",
+                    $description : "[DEPRECATED, use 'headers' object] Header 'Content-type' to be used for requests.",
                     $default : "application/x-www-form-urlencoded; charset=UTF-8"
                 },
+                /* BACKWARD-COMPATIBILITY-END GH-1044 HEADERS */
                 "headers" : {
                     $type : "json:Map",
                     $contentType : {
                         $type : "json:String",
                         $description : "HTTP request header"
                     },
-                    $description : "HTTP message headers",
+                    $description : "HTTP headers to be included with this request. This array will be merged with `aria.core.IO.headers` and, in case of POST / PUT requests, also with `aria.core.IO.postHeaders`. You can override those properties of aria.core.IO to establish your application's defaults.",
                     $sample : {
                         "Content-Type" : "text/plain",
                         "Connection" : "keep-alive"

--- a/src/aria/core/log/AjaxAppender.js
+++ b/src/aria/core/log/AjaxAppender.js
@@ -87,7 +87,7 @@ Aria.classDefinition({
                 },
                 url : this.url,
                 method : "POST",
-                postData : data,
+                data : data,
                 callback : {
                     fn : this._stackSent,
                     scope : this

--- a/src/aria/modules/RequestBeans.js
+++ b/src/aria/modules/RequestBeans.js
@@ -68,12 +68,12 @@ Aria.beanDefinitions({
                     $type : "json:Integer",
                     $description : "Timeout in milliseconds (after which the request is canceled if no answer was received before). If this parameter is not set, the default timeout applies (specified in aria.core.IO.defaultTimeout). This property can be changed by filters."
                 },
-                /* Backward Compatibility begins here */
+                /* BACKWARD-COMPATIBILITY-BEGIN GH-1044 HEADERS */
                 "postHeader" : {
                     $type : "json:String",
-                    $description : "[DEPRECATED] Header 'Content-type' to be used for POST requests, please use headers"
+                    $description : "[DEPRECATED, use 'headers' object] Header 'Content-type' to be used for POST requests"
                 },
-                /* Backward Compatibility ends here */
+                /* BACKWARD-COMPATIBILITY-END GH-1044 HEADERS */
                 "headers" : {
                     $type : "json:Map",
                     $contentType : {

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -380,7 +380,7 @@ Aria.classDefinition({
                 sender : senderObject,
                 url : req.url,
                 method : req.method,
-                postData : req.data,
+                data : req.data,
                 headers : req.headers,
                 timeout : req.timeout,
                 callback : {
@@ -398,11 +398,11 @@ Aria.classDefinition({
                     }
                 }
             };
-            /* Backward Compatibility begins here */
+            /* BACKWARD-COMPATIBILITY-BEGIN HEADERS */
             if (req.postHeader) {
                 requestObject.postHeader = req.postHeader;
             }
-            /* Backward Compatibility ends here */
+            /* BACKWARD-COMPATIBILITY-END HEADERS */
             if (handler.expectedResponseType) {
                 requestObject.expectedResponseType = handler.expectedResponseType;
             }

--- a/test/aria/core/io/IOFilterTest.js
+++ b/test/aria/core/io/IOFilterTest.js
@@ -26,7 +26,7 @@ Aria.classDefinition({
             var req = {
                 url : aria.core.DownloadMgr.resolveURL("test/aria/core/test/TestFile.txt", true),
                 method : "POST",
-                postData : "notChanged"
+                data : "notChanged"
             };
             filter.setJsonPostData(req, {});
             this.assertTrue(req.data == "{}");
@@ -37,7 +37,7 @@ Aria.classDefinition({
             req = {
                 url : aria.core.DownloadMgr.resolveURL("test/aria/core/test/TestFile.txt", true),
                 method : "POST",
-                postData : "notChanged"
+                data : "notChanged"
             };
             filter.setJsonPostData(req, {
                 a : {
@@ -59,7 +59,7 @@ Aria.classDefinition({
             var req = {
                 url : aria.core.DownloadMgr.resolveURL("test/aria/core/test/TestFile.txt", true),
                 method : "GET",
-                postData : "notChanged",
+                data : "notChanged",
                 callback : {
                     fn : function () {
                         this.notifyTestEnd("testAsyncEndToEndJsonPostData");

--- a/test/aria/core/io/IOTest.js
+++ b/test/aria/core/io/IOTest.js
@@ -205,13 +205,82 @@ Aria.classDefinition({
         },
 
         /**
+         * The Content-Type header should be taken from aria.core.IO.postHeaders if not present directly in the request
+         */
+        testAsyncDefaultHeaders_ContentType : function () {
+            var request = {
+                url : this.urlRoot + "aria/core/test/TestFile.txt",
+                method : "POST",
+                data : "my post data",
+                callback : {
+                    fn : this._defaultHeaders_ContentType_Response,
+                    scope : this
+                }
+            };
+            var valid = aria.core.JsonValidator.normalize({
+                json : request,
+                beanName : "aria.core.CfgBeans.IOAsyncRequestCfg"
+            }, true);
+            this.assertTrue(valid);
+
+            // asyncRequest will normalize the request internally, let's check it on a clone ourselves
+            var normalizedRequest = aria.utils.Json.copy(request, false);
+            aria.core.IO.__normalizeRequest(normalizedRequest);
+            this.assertEquals(normalizedRequest.headers["Content-Type"], "application/x-www-form-urlencoded; charset=UTF-8");
+
+            aria.core.IO.asyncRequest(request);
+        },
+
+        _defaultHeaders_ContentType_Response : function (res) {
+            this.assertEquals(res.status, 200);
+            this.notifyTestEnd("testAsyncDefaultHeaders_ContentType");
+        },
+
+        /**
+         * Test overriding Content-Type in headers property in aria.core.CfgBeans.IOAsyncRequestCfg.<br>
+         * This should override the default value from aria.core.IO.postHeaders
+         */
+        testAsyncConfigureHeaders_ContentType : function () {
+            var request = {
+                url : this.urlRoot + "aria/core/test/TestFile.txt",
+                method : "POST",
+                data : "my post data",
+                headers : {
+                    "Content-Type" : "text/plain"
+                },
+                callback : {
+                    fn : this._configureHeaders_ContentType_Response,
+                    scope : this
+                }
+            };
+            var valid = aria.core.JsonValidator.normalize({
+                json : request,
+                beanName : "aria.core.CfgBeans.IOAsyncRequestCfg"
+            }, true);
+            this.assertTrue(valid);
+            this.assertEquals(request.headers["Content-Type"], "text/plain");
+
+            // asyncRequest will normalize the request internally, let's check it on a clone ourselves
+            var normalizedRequest = aria.utils.Json.copy(request, false);
+            aria.core.IO.__normalizeRequest(normalizedRequest);
+            this.assertEquals(normalizedRequest.headers["Content-Type"], "text/plain");
+
+            aria.core.IO.asyncRequest(request);
+        },
+        _configureHeaders_ContentType_Response : function (res) {
+            this.assertEquals(res.status, 200);
+            this.notifyTestEnd("testAsyncConfigureHeaders_ContentType");
+        },
+
+        /* BACKWARD-COMPATIBILITY-BEGIN GH-1044 HEADERS */
+        /**
          * Test postHeader property in aria.core.CfgBeans.IOAsyncRequestCfg.
          */
         testAsyncConfigurePostHeader : function () {
             var request = {
                 url : this.urlRoot + "aria/core/test/TestFile.txt",
                 method : "POST",
-                postData : "my post data",
+                data : "my post data",
                 postHeader : "text/plain",
                 callback : {
                     fn : this._configurePostHeaderResponse,
@@ -234,7 +303,7 @@ Aria.classDefinition({
             var request = {
                 url : this.urlRoot + "aria/core/test/TestFile.txt",
                 method : "POST",
-                postData : "my post data",
+                data : "my post data",
                 callback : {
                     fn : this._noPostHeaderResponse,
                     scope : this
@@ -296,6 +365,8 @@ Aria.classDefinition({
             this.assertTrue(res.status === 200);
             this.notifyTestEnd("testAsyncConfigureContentTypeHeader");
         },
+        /* BACKWARD-COMPATIBILITY-END GH-1044 HEADERS */
+
         /**
          * Test HEAD Request Method.
          */

--- a/test/aria/modules/RequestMgrTest.js
+++ b/test/aria/modules/RequestMgrTest.js
@@ -502,7 +502,7 @@ Aria.classDefinition({
                 // The assert must be done on the right request, which comes from the request manager)
                 if (args.sender.classpath == "aria.modules.RequestMgr") {
                     requestMgrSentRequest++;
-                    currentTest.assertEquals(-1, args.postData.indexOf(Aria.FRAMEWORK_PREFIX), "Metadata in json request");
+                    currentTest.assertEquals(-1, args.data.indexOf(Aria.FRAMEWORK_PREFIX), "Metadata in json request");
                 }
             };
             try {

--- a/test/aria/modules/requestHandler/RequestHandlerTest.js
+++ b/test/aria/modules/requestHandler/RequestHandlerTest.js
@@ -95,6 +95,7 @@ Aria.classDefinition({
             handler.$dispose();
         },
 
+        /* BACKWARD-COMPATIBILITY-BEGIN HEADERS */
         /**
          * Test to configure post data header.
          */
@@ -112,6 +113,29 @@ Aria.classDefinition({
             }, true);
             this.assertTrue(valid);
             this.assertTrue(request.postHeader === "text/plain");
+            handler.$dispose();
+        },
+        /* BACKWARD-COMPATIBILITY-END HEADERS */
+
+        /**
+         * Test to configure custom headers.
+         */
+        testConfigureContentTypeHeader : function () {
+            var handler = new aria.modules.requestHandler.RequestHandler();
+            var request = {
+                moduleName : "test",
+                actionName : "testConfigureContentTypeHeader",
+                headers : {
+                    "Content-Type" : "text/plain"
+                },
+                requestHandler : handler
+            };
+            var valid = aria.core.JsonValidator.normalize({
+                json : request,
+                beanName : "aria.modules.RequestBeans.RequestObject"
+            }, true);
+            this.assertTrue(valid);
+            this.assertEquals(request.headers["Content-Type"], "text/plain");
             handler.$dispose();
         },
 

--- a/test/aria/modules/test/AnotherSampleRequestFilter.js
+++ b/test/aria/modules/test/AnotherSampleRequestFilter.js
@@ -29,7 +29,7 @@ Aria.classDefinition({
             // For test purpose only
             req.url = Aria.rootFolderPath + "test/aria/modules/test/SampleResponse.xml";
             req.method = "POST";
-            this.__jsonData = req.postData;
+            this.__jsonData = req.data;
         },
 
         /**

--- a/test/aria/modules/test/JsonSerializerTestFilter.js
+++ b/test/aria/modules/test/JsonSerializerTestFilter.js
@@ -25,7 +25,7 @@ Aria.classDefinition({
     $prototype : {
         onRequest : function (req) {
             if (req.sender.requestObject && req.sender.requestObject.actionName == "serializerTestAction") {
-                this.__postData = req.postData;
+                this.__postData = req.data;
                 this.redirectToFile(req, "test/aria/modules/test/TestFile.txt", false);
             }
         },


### PR DESCRIPTION
This commit adds `aria.core.IO.postHeaders` array in order to add more
flexibility to the users and facilitate code simplification in 1.6.1.

It also properly deprecates certain features intially deprecated in 1.2.6
and 1.3.1 by improving documentation and adding deprecation warnings.

The code has been also slightly refactored to facilitate removal of
deprecated items in 1.6.1.

---

This branch is based on 1052 which will be integrated soon (in order to not unnecessarily rebase).
The commit is **backward compatible** and can land in master once reviewed.

The removal commit   https://github.com/ariatemplates/ariatemplates/pull/1057 is to be integrated in 1.6.1.
