### PR TITLE
feat #1042 deterministic hash for builds; change md5 to murmurhash3

### DIFF
--- a/build/grunt-config/config-atpackager-bootstrap.js
+++ b/build/grunt-config/config-atpackager-bootstrap.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
             defaultBuilder : {
                 type : 'ATMultipart',
                 cfg : {
-                    header : '<%= packaging.license %>'
+                    header : '<%= packaging.license_min %>'
                 }
             },
             outputDirectory : '<%= packaging.bootstrap.outputdir %>',
@@ -74,7 +74,7 @@ module.exports = function (grunt) {
                             builder : {
                                 type : 'Concat',
                                 cfg : {
-                                    header : '<%= packaging.license %>'
+                                    header : '<%= packaging.license_min %>'
                                 }
                             }
                         }

--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
             defaultBuilder : {
                 type : 'ATMultipart',
                 cfg : {
-                    header : '<%= packaging.license %>'
+                    header : '<%= packaging.license_min %>'
                 }
             },
             outputDirectory : '<%= packaging.prod.outputdir %>',
@@ -66,6 +66,7 @@ module.exports = function (grunt) {
                     }, {
                         type : 'Hash',
                         cfg : {
+                            hash : "murmur3",
                             files : hashFiles
                         }
                     }, {
@@ -80,11 +81,22 @@ module.exports = function (grunt) {
                     }, {
                         type : 'CopyUnpackaged',
                         cfg : {
-                            files : [mainATFile, 'aria/css/*.js', '<%= packaging.prod.allow_unpackaged_files %>'],
+                            files : [mainATFile, 'aria/css/*.js'],
                             builder : {
                                 type : 'ATMultipart',
                                 cfg : {
                                     header : '<%= packaging.license %>'
+                                }
+                            }
+                        }
+                    }, {
+                        type : 'CopyUnpackaged',
+                        cfg : {
+                            files : ['<%= packaging.prod.allow_unpackaged_files %>'],
+                            builder : {
+                                type : 'ATMultipart',
+                                cfg : {
+                                    header : '<%= packaging.license_min %>'
                                 }
                             }
                         }

--- a/build/grunt-config/config-packaging.js
+++ b/build/grunt-config/config-packaging.js
@@ -24,5 +24,6 @@ module.exports = function (grunt) {
     grunt.config.set('packaging.prod.localization_files', require('../config/files-prod-localization.json'));
     grunt.config.set('packaging.prod.hash_include_files', []);
     grunt.config.set('packaging.license', grunt.file.read('build/templates/LICENSE'));
+    grunt.config.set('packaging.license_min', grunt.file.read('build/templates/LICENSE-MIN'));
     grunt.config.set('pkg', require('../../package.json'));
 };

--- a/build/templates/LICENSE-MIN
+++ b/build/templates/LICENSE-MIN
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2009-<%= grunt.template.today('yyyy') %> Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run-script lint && npm run-script grunt && npm run-script mocha && npm run-script attester"
   },
   "devDependencies": {
-    "atpackager": "0.2.3",
+    "atpackager": "0.2.4",
     "attester": "1.3.0",
     "express": "3.4.8",
     "grunt": "0.4.2",


### PR DESCRIPTION
TODO
- [x]  apply the same changes in CC stream

1) Let all the files except bootstrap not include build date and version,
making it possible to have (nearly) deterministic hashes of packages
(they'll only change once a year if no content changes).

2) Change hash appended to built files' names from 128 bit (32 bytes) MD5
to 32 bits base36-encoded (<=7 bytes) MurmurHash v3.

In practice, the risk of collision is still extremely low yet we gain a
few kilobytes less in output code size due to urlMap entries being shorter.

Close #1042.
