### PR TITLE
Fixes the test for expression escaping on IE8.

### DIFF
--- a/test/aria/templates/statements/ExpressionEscapeTest.js
+++ b/test/aria/templates/statements/ExpressionEscapeTest.js
@@ -152,6 +152,7 @@ Aria.classDefinition({
 
             var textContent = element.textContent || element.innerText || element.nodeValue || "";
             textContent = textContent.replace(/\n/g, '');
+            textContent = textContent.replace(/^\s+|\s+$/g, '');
 
             // --------------- number of children nodes which are not text nodes
 


### PR DESCRIPTION
Now trailing white spaces are removed since they are not relevant for content comparison.

Those white spaces were appearing on Internet Explorer 8 after the template file associated to the test has been reformatted.
