### PR TITLE
Fixing auto-escaping issue in calendar widget

### DIFF
--- a/src/aria/widgets/calendar/CalendarTemplate.tpl
+++ b/src/aria/widgets/calendar/CalendarTemplate.tpl
@@ -112,7 +112,7 @@
     {macro renderDay(day, month)}
         {var jsDate=day.jsDate/}
         {if day.monthKey==month.monthKey}
-            <td ${day.isSelectable ? "data-date=\""+jsDate.getTime()+"\"":""}
+            <td {if day.isSelectable} data-date="${jsDate.getTime()}" {/if}
                 class="${getClassForDay(day)}"
             >${day.label}</td>
         {else/}


### PR DESCRIPTION
This pull request fixes the issue introduced by commit 6584f219fad148129fa6de28cc434e1303405f9d in the calendar template.
