### PR TITLE
Auto-escaping now takes into account the case insensitivity of modifiers

### DIFF
--- a/src/aria/templates/Statements.js
+++ b/src/aria/templates/Statements.js
@@ -108,8 +108,12 @@ Aria.classDefinition({
                     if (escapeModifierName == null) {
                         automaticEscape = false;
                     } else {
+                        escapeModifierName = escapeModifierName.toLowerCase();
+
                         for (var i = parts.length - 1; i >= 1; i--) {
                             var part = parts[i];
+                            part = part.toLowerCase();
+
                             if (part.indexOf(escapeModifierName) === 0) {
                                 automaticEscape = false;
                                 break;

--- a/test/aria/templates/statements/ExpressionEscapeTestTpl.tpl
+++ b/test/aria/templates/statements/ExpressionEscapeTestTpl.tpl
@@ -28,24 +28,24 @@
 </div>
 
 <div {id "all-boolean"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:true}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforHTML:true}
 </div>
 <div {id "all-object"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:{text: true, attr: true}}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForhtml:{text: true, attr: true}}
 </div>
 
 <div {id "nothing-boolean"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:false}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHtml:false}
 </div>
 <div {id "nothing-object"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:{text: false, attr: false}}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforHtml:{text: false, attr: false}}
 </div>
 
 <div {id "attr"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:{attr: true}}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforhtml:{attr: true}}
 </div>
 <div {id "text"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML:{text: true}}
+    ${"<div class='output' style=\"color:blue\">&amp;</div>"|ESCAPEFORHTML:{text: true}}
 </div>
 
 


### PR DESCRIPTION
Modifiers are all defined with a lower case name in the framework, but the invokation of one of them can be done by specifying a name with any case: this name gets converted to lower case just before retrieving the actual modifier.

This means that users can write the name of the modifiers with any case, and the automatic escaping feature didn't handle that, thinking that escaping was not controlled by the user when the modifier was used with a case different that the hard-coded one.
