### PR TITLE
fix #1076 onblur called too often by MAC

### DIFF
--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -329,8 +329,41 @@ Aria.classDefinition({
             } else if (blurredElement.parentNode.className.indexOf("highlight") != -1) {
                 this.unhighlightOption(blurredElement.parentNode);
             }
+            // call TextInput onblur handler with avoidCallback set to true
+            this.$TextInput._dom_onblur.call(this, event, true);
 
-            this.$TextInput._dom_onblur.call(this, event);
+            if (this._cfg.onblur) {
+                // timeout is needed to retrieve (on every browser) the activeElement
+                aria.core.Timer.addCallback({
+                    fn : function () {
+                        var isAncestor = aria.utils.Dom.isAncestor;
+                        var focusedEl = Aria.$window.document.activeElement;
+
+                        // if onblur is defined and window lost focus ( ==null ) or if focus is not in the widget or
+                        // dropdown element
+                        if (this._cfg
+                                && (focusedEl == null || ((this._dropdownPopup == null || !isAncestor(focusedEl, this._dropdownPopup.domElement)) && !isAncestor(focusedEl, this._domElt)))) {
+                            this.evalCallback(this._cfg.onblur);
+                        }
+                    },
+                    scope : this,
+                    delay : 100
+                });
+            }
+        },
+
+        /**
+         * Handling focus event
+         * @param {aria.utils.Event} event
+         * @protected
+         */
+        _dom_onfocus : function (event) {
+            // flag that avoids to trigger the user callback when browsing the checkbox list
+            var avoidCallback = (this._hasFocus || this._keepFocus);
+            this.$TextInput._dom_onfocus.call(this, event, true);
+            if (this._cfg.onfocus && !avoidCallback) {
+                this.evalCallback(this._cfg.onfocus);
+            }
         },
         /**
          * Make the inputfield as last child of widget

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -861,7 +861,7 @@ Aria.classDefinition({
          * @param {aria.DomEvent} event Focus event
          * @protected
          */
-        _dom_onfocus : function (event) {
+        _dom_onfocus : function (event, avoidCallback) {
             this._hasFocus = true;
 
             if (!this._keepFocus) {
@@ -899,7 +899,7 @@ Aria.classDefinition({
                     this.setCaretPosition(caretPosition.start, caretPosition.end);
                 }
             }
-            if (!!this._cfg.onfocus) {
+            if (!!this._cfg.onfocus && !avoidCallback) {
                 this.evalCallback(this._cfg.onfocus);
             }
         },
@@ -911,7 +911,7 @@ Aria.classDefinition({
          * @param {aria.DomEvent} event Blur event
          * @protected
          */
-        _dom_onblur : function (event) {
+        _dom_onblur : function (event, avoidCallback) {
             if (!this._hasFocus) {
                 return;
             }
@@ -971,7 +971,7 @@ Aria.classDefinition({
                 // this._hasFocus = false must be after the call of this.getCaretPosition()
                 this._hasFocus = false;
             }
-            if (this._cfg.onblur) {
+            if (this._cfg.onblur && !avoidCallback) {
                 this.evalCallback(this._cfg.onblur);
             }
         },
@@ -1195,7 +1195,7 @@ Aria.classDefinition({
             if (!fromSelf) {
                 // IE FIX: the focus() can be asynchronous, so let's add a timeout to manage the autoselect
                 aria.core.Timer.addCallback({
-                    fn : function() {
+                    fn : function () {
                         this._autoselect();
                     },
                     scope : this,

--- a/src/aria/widgets/form/templates/TemplateMultiSelectScript.js
+++ b/src/aria/widgets/form/templates/TemplateMultiSelectScript.js
@@ -62,8 +62,7 @@ Aria.tplScriptDefinition({
 
                 if (evt.keyCode == aria.DomEvent.KC_ARROW_UP && evt.focusIndex === 0) {
                     evt.cancelDefault = true;
-                    // var idToFocus = 'listItem'+evt.focusIndex;
-                    var viewFocusIndex = this.data.itemsView.items[focusIndex].value.index;
+                    var viewFocusIndex = this.data.itemsView.items[evt.focusIndex].value.index;
 
                     var idToFocus = 'listItem' + viewFocusIndex;
 

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/BaseMultiAutoCompleteTestCase.js
@@ -23,7 +23,9 @@ Aria.classDefinition({
         this.data = this.data || {
             ac_airline_values : [],
             freeText : true,
-            onChangeCalls : 0
+            onChangeCalls : 0,
+            onBlurCalls : 0,
+            onFocusCalls : 0
         };
         this.setTestEnv({
             template : "test.aria.widgets.form.autocomplete.multiautocomplete.template.MultiAutoTpl",

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -44,5 +44,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.onChangeHandler.MultiAutoOnChangeTest");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.navigation.MultiAutoCompleteNavigationTestSuite");
         this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.testDataModelOnEdit.MultiAutoDataModelTest");
-    }
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.issue1076.blur.OnBlurTest");
+        this.addTests("test.aria.widgets.form.autocomplete.multiautocomplete.issue1076.focus.OnFocusTest");    }
 });

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/issue1076/blur/OnBlurTest.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/issue1076/blur/OnBlurTest.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.issue1076.blur.OnBlurTest",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+        this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
+
+        this.data.expandButton = true;
+
+    },
+    $prototype : {
+
+        _waitAndExecute : function (fn, scope) {
+            aria.core.Timer.addCallback({
+                fn : fn,
+                scope : scope,
+                delay : 300
+            });
+        },
+
+        runTemplateTest : function () {
+            this.clickAndType(["[down]"], {
+                fn : this._wait1,
+                scope : this
+            }, 1);
+        },
+
+        _wait1 : function () {
+            this.waitFor({
+                condition : function () {
+                    return this.getElementsByClassName(Aria.$window.document.body, "xWidget xICNcheckBoxes").length !== 0;
+                },
+                callback : this._checkNoBlurOnOpenPopup
+            });
+        },
+
+        _checkNoBlurOnOpenPopup : function () {
+            this.assertEquals(this.data.onBlurCalls, 0, "The number of blur events %2. It is %1 instead.");
+            this.synEvent.type(Aria.$window.document.activeElement, "[down]", {
+                fn : this._wait2,
+                scope : this
+            });
+        },
+
+        _wait2 : function () {
+            this._waitAndExecute(this._checkNoBlurOnFocusPopup, this);
+        },
+
+        _checkNoBlurOnFocusPopup : function () {
+            this.assertEquals(this.data.onBlurCalls, 0, "The number of blur events %2. It is %1 instead.");
+            this.synEvent.type(Aria.$window.document.activeElement, "[space]", {
+                fn : this._wait3,
+                scope : this
+            });
+        },
+
+        _wait3 : function () {
+            this._waitAndExecute(this._checkNoBlurOnNavigatingPopup, this);
+        },
+
+        _checkNoBlurOnNavigatingPopup : function () {
+            this.assertEquals(this.data.onBlurCalls, 0, "The number of blur events %2. It is %1 instead.");
+            this.focusOut({
+                fn : this._checkFirstBlur,
+                scope : this,
+                delay : 300
+            });
+        },
+
+        _checkFirstBlur : function () {
+            this.assertEquals(this.data.onBlurCalls, 1, "The number of blur events should be %2. It is %1 instead");
+
+            this.removeByCrossClick(0, {
+                fn : this._wait5,
+                scope : this
+            });
+        },
+
+        _wait5 : function () {
+            this._waitAndExecute(this._checkNoBlurOnCrossClick, this);
+        },
+
+        _checkNoBlurOnCrossClick : function () {
+            this.assertEquals(this.data.onBlurCalls, 1, "The number of blur events should be %2. It is %1 instead.");
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/issue1076/focus/OnFocusTest.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/issue1076/focus/OnFocusTest.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.multiautocomplete.issue1076.focus.OnFocusTest",
+    $extends : "test.aria.widgets.form.autocomplete.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+        this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
+
+        this.data.expandButton = true;
+
+    },
+    $prototype : {
+
+        _waitAndExecute : function (fn, scope) {
+            aria.core.Timer.addCallback({
+                fn : fn,
+                scope : scope,
+                delay : 100
+            });
+        },
+
+        runTemplateTest : function () {
+            this.clickAndType(["[down]"], {
+                fn : this._wait1,
+                scope : this
+            }, 1);
+        },
+
+        _wait1 : function () {
+            this.assertEquals(this.data.onFocusCalls, 1, "The number of focus events %2. It is %1 instead.");
+            this.waitFor({
+                condition : function () {
+                    return this.getElementsByClassName(Aria.$window.document.body, "xWidget xICNcheckBoxes").length !== 0;
+                },
+                callback : this._checkNoFocusOnOpenPopup
+            });
+        },
+
+        _checkNoFocusOnOpenPopup : function () {
+            this.assertEquals(this.data.onFocusCalls, 1, "The number of focus events %2. It is %1 instead.");
+            this.synEvent.type(Aria.$window.document.activeElement, "[down]", {
+                fn : this._wait2,
+                scope : this
+            });
+        },
+
+        _wait2 : function () {
+            this._waitAndExecute(this._checkNoFocusCallbackOnFocusPopup, this);
+        },
+
+        _checkNoFocusCallbackOnFocusPopup : function () {
+            this.assertEquals(this.data.onFocusCalls, 1, "The number of focus events %2. It is %1 instead.");
+            this.synEvent.type(Aria.$window.document.activeElement, "[space]", {
+                fn : this._wait3,
+                scope : this
+            });
+        },
+
+        _wait3 : function () {
+            this._waitAndExecute(this._checkNoFocusOnSelectingOption, this);
+        },
+
+        _checkNoFocusOnSelectingOption : function () {
+            this.assertEquals(this.data.onFocusCalls, 1, "The number of focus events %2. It is %1 instead.");
+            this.focusOut({
+                fn : this._afterBlur,
+                scope : this,
+                delay : 100
+            });
+        },
+
+        _afterBlur : function () {
+            this.assertEquals(this.data.onFocusCalls, 1, "The number of focus events should be %2. It is %1 instead");
+
+            this.removeByCrossClick(0, {
+                fn : this._wait5,
+                scope : this
+            });
+        },
+
+        _wait5 : function () {
+            this._waitAndExecute(this._checkFirstFocus, this);
+        },
+
+        _checkFirstFocus : function () {
+            this.assertEquals(this.data.onFocusCalls, 2, "The number of focus events should be %2. It is %1 instead.");
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTpl.tpl
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTpl.tpl
@@ -21,35 +21,44 @@
 
 
 
-	{macro main()}
+    {macro main()}
 
-		 <h2>AutoComplete with Multi Options</h2>
-		 <br />
-		{@aria:MultiAutoComplete{
-			label:"Choose your city: ",
-			id:"MultiAutoId",
-			labelPos:"left",
-			labelAlign:"right",
-			width:400,
-			block:false,
-			labelWidth:180,
-			maxOptions: data.maxOptions || 8,
-			freeText: (data.freeText !== false),
-			resourcesHandler: getAirLinesHandler(),
-			onchange: {
-				fn : this.onChangeHandler,
-				scope : this
-			},
-			bind:{
-			  	"value" : {
-			  		inside : data,
-			  		to : 'ac_airline_values'
-		  		}
-			},
-			spellCheck: false
-		}/}
-		 <br />
-		 <input {id "justToFocusOut"/}>
-	{/macro}
+         <h2>AutoComplete with Multi Options</h2>
+         <br />
+        {@aria:MultiAutoComplete{
+            label:"Choose your city: ",
+            id:"MultiAutoId",
+            labelPos:"left",
+            labelAlign:"right",
+            width:400,
+            block:false,
+            labelWidth:180,
+            expandButton: (data.expandButton == true),
+            maxOptions: data.maxOptions || 8,
+            freeText: (data.freeText !== false),
+            resourcesHandler: getAirLinesHandler(),
+            onchange: {
+                fn : this.onChangeHandler,
+                scope : this
+            },
+            onblur: {
+                fn : this.onBlurHandler,
+                scope : this
+            },
+            onfocus: {
+                fn : this.onFocusHandler,
+                scope : this
+            },
+            bind:{
+                  "value" : {
+                      inside : data,
+                      to : 'ac_airline_values'
+                  }
+            },
+            spellCheck: false
+        }/}
+         <br />
+         <input {id "justToFocusOut"/}>
+    {/macro}
 
 {/Template}

--- a/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTplScript.js
+++ b/test/aria/widgets/form/autocomplete/multiautocomplete/template/MultiAutoTplScript.js
@@ -69,6 +69,12 @@ Aria.tplScriptDefinition({
         },
         onChangeHandler : function () {
             this.data.onChangeCalls++;
+        },
+        onBlurHandler : function () {
+            this.data.onBlurCalls++;
+        },
+        onFocusHandler : function () {
+            this.data.onFocusCalls++;
         }
     }
 });

--- a/test/aria/widgets/form/textinput/onblur/OnBlurTest.js
+++ b/test/aria/widgets/form/textinput/onblur/OnBlurTest.js
@@ -24,7 +24,6 @@ Aria.classDefinition({
                 action : 0
             }
         });
-        this._delay = 10;
     },
     $prototype : {
         runTemplateTest : function () {


### PR DESCRIPTION
onblur custom event is called every time an element inside the MAC is blurred.
Same thing happens for the onfocus custom event.
