### PR TITLE
Automatic escaping is now done at the end.

### DIFF
--- a/src/aria/templates/Modifiers.js
+++ b/src/aria/templates/Modifiers.js
@@ -112,21 +112,15 @@
             /**
              * <span style="font-weight: bold">MODIFIER</span>
              * <br/>
-             * if str is not defined or empty string "" return the default value
+             * if str is null or undefined return the default value
              * @name aria.templates.Modifiers.prototype.default
              * @param {String} str the entry
              * @param {String} defaultValue the default value
-             * @param {String} escapeModifierName the name of the escaping modifier function to use to process the given default
-             * value. When empty, this value is left as is.
              * @return {String}
              */
-            fn : function (str, defaultValue, escapeModifierName) {
+            fn : function (str, defaultValue) {
                 if (str != null) {
                     return str;
-                }
-
-                if (modifierExists(escapeModifierName)) {
-                    return aria.templates.Modifiers.callModifier(escapeModifierName, [defaultValue]);
                 }
 
                 return defaultValue;
@@ -140,17 +134,11 @@
              * @name aria.templates.Modifiers.prototype.empty
              * @param {String} str the entry
              * @param {String} defaultValue the default value
-             * @param {String} escapeModifierName the name of the escaping modifier function to use to process the given default
-             * value. When empty, this value is left as is.
              * @return {String}
              */
-            fn : function (str, defaultValue, escapeModifierName) {
+            fn : function (str, defaultValue) {
                 if (!!str && !/^\s*$/.test(str)) {
                     return str;
-                }
-
-                if (modifierExists(escapeModifierName)) {
-                    return aria.templates.Modifiers.callModifier(escapeModifierName, [defaultValue]);
                 }
 
                 return defaultValue;
@@ -163,7 +151,7 @@
              * Pad the string with the provided padding character(s) or non-breaking spaces
              * @name aria.templates.Modifiers.prototype.pad
              * @param {String} str the entry
-             * @param {Integer} sz the targetted size for the result string
+             * @param {Integer} sz the targeted size for the result string
              * @param {Boolean} begin tells if the padding must be added at the beginning (true) or at the end (false)
              * of the string - Default is false
              * @param {String} padStr the HTML string to be used for padding. Default is '&nbsp;'. Note that if this
@@ -328,8 +316,8 @@
             /**
              * <span style="font-weight: bold">MODIFIER</span>
              * <br/>
-             * Will highlight with &lt;strong&gt; tag the begining of a word that matches any of the words in the
-             * highligh value.
+             * Will highlight with &lt;strong&gt; tag the beginning of a word that matches any of the words in the
+             * highlight value.
              * @example
              * Given the input string, str: "Using highlight"
              * and the matching string, highlight: "us hi"
@@ -375,17 +363,6 @@
             }
         }
     };
-
-    /**
-     * Tests whether or not the specified modifier is available.
-     *
-     * @param {String} name The name of the modifier. Should be a String but any value is handled.
-     *
-     * @return true is the modifier exists, false otherwise.
-     */
-    function modifierExists(name) {
-        return name != null && __modifiers.hasOwnProperty(('' + name).toLowerCase());
-    }
 
     /**
      * Template modifiers. Modifiers can be used inside the template syntax

--- a/src/aria/templates/Statements.js
+++ b/src/aria/templates/Statements.js
@@ -96,42 +96,25 @@ Aria.classDefinition({
                     }
                     parts.push(param);
 
-                    // Automatic escape detection ------------------------------
+                    // Automatic escape ----------------------------------------
 
                     // We automatically escape expressions if needed, using the feature of modifiers, since the escape is already handled by a modifier itself.
+                    // For safety and logical reasons, the escaping is done at the end, so the modifier is added as the last one.
                     // There are two cases where we don't do it automatically:
                     // - in CSS templates
-                    // - if the modifier is already used, in which case the user has full control on how to apply the escape
-                    var automaticEscape = true;
+                    // - if the modifier is already present at the end of the list, in which case the user gets control back on how to apply the final escape
 
                     var escapeModifierName = classGenerator.escapeModifier; // Gets the actual name of the modifier in this context
-                    if (escapeModifierName == null) {
-                        automaticEscape = false;
-                    } else {
+
+                    if (escapeModifierName != null) {
                         escapeModifierName = escapeModifierName.toLowerCase();
 
-                        for (var i = parts.length - 1; i >= 1; i--) {
-                            var part = parts[i];
-                            part = part.toLowerCase();
-
-                            if (part.indexOf(escapeModifierName) === 0) {
-                                automaticEscape = false;
-                                break;
-                            }
+                        if (parts[parts.length - 1].toLowerCase().indexOf(escapeModifierName) < 0) {
+                            parts.push(escapeModifierName);
                         }
                     }
 
-                    // end of: automatic escape detection ----------------------
-
-                    // Automatic escape application - part 1 -------------------
-
-                    // If the escape must be done automatically, we add the modifier at the beginning of the list.
-
-                    if (automaticEscape) {
-                        parts.splice(1, 0, escapeModifierName);
-                    }
-
-                    // end of: automatic escape application - part 1 -----------
+                    // end of: automatic escape --------------------------------
 
                     var beginexpr = [], endexpr = [];
                     var expr;
@@ -148,19 +131,7 @@ Aria.classDefinition({
                         beginexpr.push("this.$modifier('" + modifierName + "',[");
                         expr = match[2]; // parameters of the modifier
                         if (expr) {
-                            endexpr[i] = ", " + expr;
-                            // Automatic escape application - part 2 -----------
-
-                            // We automatically pass to any modifier the name of the escaping modifier as last parameter.
-
-                            // This is done so that the other modifiers know that we are in automatic escape mode, and so that they know which modifier to use to do the escape. Useful for the implementation of modifiers receiving possibly untrusted data.
-
-                            if (automaticEscape) {
-                                endexpr[i] += ", '" + escapeModifierName + "'";
-                            }
-
-                            // end of: Automatic escape application - part 2 ---
-                            endexpr[i] += "])";
+                            endexpr[i] = ", " + expr + "])";
                         } else {
                             endexpr[i] = "])";
                         }

--- a/src/aria/widgets/calendar/CalendarTemplate.tpl
+++ b/src/aria/widgets/calendar/CalendarTemplate.tpl
@@ -50,7 +50,7 @@
         {/for}
         {if settings.showShortcuts}
             <div style="text-align: center; margin: 1px;">
-                <a title="${calendar.today|dateformat:settings.completeDateLabelFormat|escapeForHTML:{attr: true}}" tabIndex="-1" href="javascript:;" {on click {fn: "navigate", scope: moduleCtrl, args: {date:calendar.today}}/}>${res.today}</a>
+                <a title="${calendar.today|dateformat:settings.completeDateLabelFormat}" tabIndex="-1" href="javascript:;" {on click {fn: "navigate", scope: moduleCtrl, args: {date:calendar.today}}/}>${res.today}</a>
                 {section {
                     id : "selectedDay",
                     macro : "selectedDay"
@@ -61,7 +61,7 @@
 
     {macro selectedDay()}
         {if settings.value}
-            &nbsp;|&nbsp; <a title="${settings.value|dateformat:settings.completeDateLabelFormat|escapeForHTML:{attr: true}}" tabIndex="-1" href="javascript:;" {on click {fn: "navigate", scope: moduleCtrl, args: {date:settings.value}}/}>${res.selectedDate}</a>
+            &nbsp;|&nbsp; <a title="${settings.value|dateformat:settings.completeDateLabelFormat}" tabIndex="-1" href="javascript:;" {on click {fn: "navigate", scope: moduleCtrl, args: {date:settings.value}}/}>${res.selectedDate}</a>
         {/if}
     {/macro}
 

--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -27,9 +27,9 @@
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}
-                ${item.label|escapeForHTML:{text: true}|highlightfromnewword:entry}
+                ${item.label|escapeForHTML:{text:true}|highlightfromnewword:entry|escapeForHTML:false}
             {else/}
-                ${item.label|escapeForHTML:{text: true}|starthighlight:entry}
+                ${item.label|escapeForHTML:{text:true}|starthighlight:entry|escapeForHTML:false}
             {/if}
         </a>
     {/macro}

--- a/test/aria/templates/ModifiersTest.js
+++ b/test/aria/templates/ModifiersTest.js
@@ -144,61 +144,6 @@ Aria.classDefinition({
             });
         },
 
-        __testModifierWithEscaping : function(modifierName, cases) {
-            for (var i = 0, length = cases.length; i < length; i++) {
-                var _case = cases[i];
-
-                var input = _case.input;
-                var expected = _case.expected;
-
-                var actual = aria.templates.Modifiers.callModifier(modifierName, input);
-
-                var message = "Expected output was: " + aria.utils.String.escapeForHTML(expected, {text: true}) + " | Actual output is: " + aria.utils.String.escapeForHTML(actual, {text: true});
-
-                this.assertEquals(actual, expected, message);
-            }
-        },
-
-        /**
-         * Tests the "default" modifier in the context of escaping.
-         */
-        testDefaultEscape : function () {
-            this.__testModifierWithEscaping("default", [
-                {
-                    input: [null, "<div id='id' class=\"class\">/</div>"],
-                    expected: "<div id='id' class=\"class\">/</div>"
-                },
-                {
-                    input: [null, "<div id='id' class=\"class\">/</div>", ''],
-                    expected: "<div id='id' class=\"class\">/</div>"
-                },
-                {
-                    input: [null, "<div id='id' class=\"class\">/</div>", "escapeForHTML"],
-                    expected: "&lt;div id=&#x27;id&#x27; class=&quot;class&quot;&gt;&#x2F;&lt;&#x2F;div&gt;"
-                }
-            ]);
-        },
-
-        /**
-         * Tests the "empty" modifier in the context of escaping.
-         */
-        testEmptyEscape : function () {
-            this.__testModifierWithEscaping("empty", [
-                {
-                    input: ['', "<div id='id' class=\"class\">/</div>"],
-                    expected: "<div id='id' class=\"class\">/</div>"
-                },
-                {
-                    input: ['', "<div id='id' class=\"class\">/</div>", ''],
-                    expected: "<div id='id' class=\"class\">/</div>"
-                },
-                {
-                    input: ['', "<div id='id' class=\"class\">/</div>", "escapeForHTML"],
-                    expected: "&lt;div id=&#x27;id&#x27; class=&quot;class&quot;&gt;&#x2F;&lt;&#x2F;div&gt;"
-                }
-            ]);
-        },
-
         // ---------------------------------------------------------------------
 
         testPad : function () {

--- a/test/aria/templates/statements/ExpressionEscapeTest.js
+++ b/test/aria/templates/statements/ExpressionEscapeTest.js
@@ -13,53 +13,73 @@
  * limitations under the License.
  */
 
+
+
 Aria.classDefinition({
     $classpath: "test.aria.templates.statements.ExpressionEscapeTest",
     $extends: "aria.jsunit.TemplateTestCase",
-    $dependencies: ["aria.utils.Dom", "aria.utils.String"],
+    $dependencies: ["aria.utils.Dom", "aria.utils.String", "aria.utils.Date", "aria.utils.Type"],
 
-    $statics: {
-        /***********************************************************************
-         * Use cases
-         **********************************************************************/
+    $constructor : function() {
+        this.$TemplateTestCase.constructor.call(this);
 
-        USE_CASES: {
-            // The following use cases test the standard application of the escaping both with a default application
-            // and an explicit use of the modifier
-            'default': {
-                outputText: "<div class='output' style=\"color:blue\">&amp;</div>"
-            },
+        // ---------------------------------------------------------------------
 
-            'implicit': {
-                outputText: "<div class='output' style=\"color:blue\">&amp;</div>"
-            },
+        this.date = new Date();
+        this.dateformat = "dd MMMM yyyy";
+
+        var formattedDate = aria.utils.Date.format(this.date, this.dateformat);
+
+        // Please refer to the associated template to understand the following
+        // The keys of the object correspond to the ids of the "div"s encapsulating each tested use case
+        // By looking at the template, you will know what the use case is about (the id gives a hint about it too). You will also see what is the input and when the escaping is expected to be done.
+        // Below, you will see for each of these cases what is the expected content in the resulting HTML Text Node (inside the div), as well as the number of possibly other generated HTML nodes.
+
+        var useCasesSpecs = {
+            'automatic': "<div class='output' style=\"color:blue\">&amp;</div>",
+
+            // -----------------------------------------------------------------
+
+            'all-implicit': "<div class='output' style=\"color:blue\">&amp;</div>",
 
             'all-boolean': {
-                outputText: "<div class='output' style=\"color:blue\">&amp;</div>"
-            },
-            'all-object': {
-                outputText: "<div class='output' style=\"color:blue\">&amp;</div>"
+                input: "<div class='output' style=\"color:blue\">&amp;</div>",
+                escape: true
             },
 
+            'all-object': {
+                input: "<div class='output' style=\"color:blue\">&amp;</div>",
+                escape: {text: true, attr: true}
+            },
+
+            // -----------------------------------------------------------------
+
             'nothing-boolean': {
+                input: "<div class='output' style=\"color:blue\">&amp;</div>",
+                escape: false,
                 outputText: "&",
                 outputNodesNumber: 1
 
             },
             'nothing-object': {
+                input: "<div class='output' style=\"color:blue\">&amp;</div>",
+                escape: {text: false, attr: false},
                 outputText: "&",
                 outputNodesNumber: 1
             },
+
+            // -----------------------------------------------------------------
 
             'attr': {
+                input: "<div class='output' style=\"color:blue\">&amp;</div>",
+                escape: {attr: true},
                 outputText: "&",
                 outputNodesNumber: 1
             },
-            'text': {
-                outputText: "<div class='output' style=\"color:blue\">&amp;</div>"
-            },
+            'text': "<div class='output' style=\"color:blue\">&amp;</div>",
 
-            'special-attr': {
+            'attr-special': {
+                escape: {attr:true},
                 outputText: "",
                 outputNodesNumber: 1,
                 attributes: {
@@ -68,78 +88,291 @@ Aria.classDefinition({
                 }
             },
 
-            // The following use cases just test the behavior of the escaping with the specific unsafe modifiers
-            // (default and empty), both with a default application and an explicit use of the escaping modifier
-            'default-modifier-default': {
-                outputText: "<div></div>"
-            },
-            'nothing-modifier-default-before': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'nothing-modifier-default-after': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'all-modifier-default-before': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'all-modifier-default-after': {
+            // ----------------------------------------------- modifier: default
+
+            'automatic-modifier_default': {
+                input: undefined,
+                modifiers: {
+                    'default': ["<div></div>"]
+                },
                 outputText: "<div></div>"
             },
 
-            'default-modifier-empty': {
+            'nothing-modifier_default-before': {
+                input: undefined,
+                escape: false,
+                modifiers: {
+                    'default': ["<div></div>"]
+                },
                 outputText: "<div></div>"
             },
-            'nothing-modifier-empty-before': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'nothing-modifier-empty-after': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'all-modifier-empty-before': {
-                outputText: "",
-                outputNodesNumber: 1
-            },
-            'all-modifier-empty-after': {
+            'all-modifier_default-before': {
+                input: undefined,
+                escape: true,
+                modifiers: {
+                    'default': ["<div></div>"]
+                },
                 outputText: "<div></div>"
+            },
+
+            'all-modifier_default-after': {
+                input: undefined,
+                escape: true,
+                modifiers: {
+                    'default': ["<div></div>"]
+                },
+                outputText: "<div></div>"
+            },
+
+
+            'nothing-modifier_default-after': {
+                input: undefined,
+                escape: false,
+                modifiers: {
+                    'default': ["<div></div>"]
+                },
+                outputText: "",
+                outputNodesNumber: 1
+            },
+
+            // ------------------------------------------------- modifier: empty
+
+            'automatic-modifier_empty': {
+                input: '',
+                modifiers: {
+                    empty: ['<div></div>']
+                },
+                outputText: "<div></div>"
+            },
+
+            'nothing-modifier_empty-before': {
+                input: '',
+                escape: false,
+                modifiers: {
+                    empty: ['<div></div>']
+                },
+                outputText: "<div></div>"
+            },
+            'all-modifier_empty-before': {
+                input: '',
+                escape: true,
+                modifiers: {
+                    empty: ['<div></div>']
+                },
+                outputText: "<div></div>"
+            },
+
+            'all-modifier_empty-after': {
+                input: '',
+                escape: true,
+                modifiers: {
+                    empty: ['<div></div>']
+                },
+                outputText: "<div></div>"
+            },
+
+            'nothing-modifier_empty-after': {
+                input: '',
+                escape: false,
+                modifiers: {
+                    empty: ['<div></div>']
+                },
+                outputNodesNumber: 1
+            },
+
+            // --------------------------------------------- modifier: highlight
+
+            'automatic-modifier_highlight': {
+                input: 'start-middle-end',
+                modifiers: {
+                    highlight: ['middle']
+                },
+                outputText: "start-<strong>middle</strong>-end"
+            },
+
+            'nothing-modifier_highlight-before': {
+                input: 'start-middle-end',
+                escape: false,
+                modifiers: {
+                    highlight: ['middle']
+                },
+                outputText: "start-<strong>middle</strong>-end"
+            },
+
+            'all-modifier_highlight-before': {
+                input: 'start-middle-end',
+                escape: true,
+                modifiers: {
+                    highlight: ['middle']
+                },
+                outputText: "start-<strong>middle</strong>-end"
+            },
+            'all-modifier_highlight-after': {
+                input: 'start-middle-end',
+                escape: true,
+                modifiers: {
+                    highlight: ['middle']
+                },
+                outputText: "start-<strong>middle</strong>-end"
+            },
+
+            'nothing-modifier_highlight-after': {
+                input: 'start-middle-end',
+                escape: false,
+                modifiers: {
+                    highlight: ['middle']
+                },
+                outputNodesNumber: 1
+            },
+
+            // -------------------------------------------- modifier: dateformat
+
+            'automatic-modifier_dateformat': {
+                input: this.date,
+                modifiers: {
+                    dateformat: [this.dateformat]
+                },
+                outputText: formattedDate
+            },
+            'nothing-modifier_dateformat-before': {
+                input: this.date,
+                escape: false,
+                modifiers: {
+                    dateformat: [this.dateformat]
+                },
+                outputText: formattedDate
+            },
+            'nothing-modifier_dateformat-after': {
+                input: this.date,
+                escape: false,
+                modifiers: {
+                    dateformat: [this.dateformat]
+                },
+                outputText: formattedDate
+            },
+            // This one should fail
+            // 'all-modifier_dateformat-before': {
+            //     input: this.date,
+            //     escape: true,
+            //     modifiers: {
+            //         dateformat: [this.dateformat]
+            //     },
+            //     outputText: formattedDate
+            // },
+            // ----
+            'all-modifier_dateformat-after': {
+                input: this.date,
+                escape: true,
+                modifiers: {
+                    dateformat: [this.dateformat]
+                },
+                outputText: formattedDate
             }
-        }
+        };
+
+
+
+        this.useCases = [];
+        this.useCasesMap = {};
+        this.inputsMap = {};
+
+        this.__forOwn(useCasesSpecs, function(id, spec) {
+            this.addUseCase(this.buildUseCase(id, spec));
+        });
+
+        this.setTestEnv({
+            data: {
+                useCases: this.useCasesMap,
+                inputs: this.inputsMap,
+                dateformat: this.dateformat,
+                date: this.date
+            }
+        });
     },
 
     $prototype: {
+        /***********************************************************************
+         * Use cases
+         **********************************************************************/
+
+        buildUseCase : function(id, spec) {
+            if (aria.utils.Type.isString(spec)) {
+                spec = {
+                    input: spec
+                };
+            }
+
+            spec.id = id;
+
+            return new this.UseCase(spec);
+        },
+
+        addUseCase : function(useCase) {
+            this.useCases.push(useCase);
+            this.useCasesMap[useCase.id] = useCase;
+            this.inputsMap[useCase.id] = useCase.input;
+        },
+
+        UseCase: function(spec) {
+            // -------------------------------------------------------------- id
+
+            this.id = spec.id;
+
+            // ----------------------------------------------------------- input
+
+            var input = spec.input;
+            this.input = input;
+
+            // ---------------------------------------------------------- escape
+
+            var escape = spec.escape;
+            this.escape = escape;
+
+            // ------------------------------------------------------- modifiers
+
+            var modifiers = spec.modifiers;
+            if (modifiers == null) {
+                modifiers = {};
+            }
+            this.modifiers = modifiers;
+
+            // ----------------------------------------------------- output text
+
+            var outputText = spec.outputText;
+            if (outputText == null) {
+                outputText = input;
+            }
+            outputText = "" + outputText;
+            this.outputText = outputText;
+
+            // ------------------------------------------------- number of nodes
+
+            var outputNodesNumber = spec.outputNodesNumber;
+            if (outputNodesNumber == null) {
+                outputNodesNumber = 0;
+            }
+            this.outputNodesNumber = outputNodesNumber;
+
+            // ------------------------------------------------------ attributes
+
+            var attributes = spec.attributes;
+            this.attributes = attributes;
+        },
+
         /***********************************************************************
          * Tests
          **********************************************************************/
 
         runTemplateTest: function() {
-            this.__forOwn(this.USE_CASES, this.__testUseCase);
+            this.__forEach(this.useCases, this.__testUseCase);
 
             this.end();
         },
 
-        __testUseCase: function(domId, useCase) {
-            // Expected results ------------------------------------------------
-
-            // ----------------------------------------------------- output text
-
+        __testUseCase: function(index, useCase) {
+            var domId = useCase.id;
             var expectedText = useCase.outputText;
-            if (expectedText == null) {
-                expectedText = "";
-            }
-
-            // ------------------------------------------------- number of nodes
-
             var expectedNumberOfNodes = useCase.outputNodesNumber;
-            if (expectedNumberOfNodes == null) {
-                expectedNumberOfNodes = 0;
-            }
-
-            // ------------------------------------------------------ attributes
-
             var attributes = useCase.attributes;
 
 

--- a/test/aria/templates/statements/ExpressionEscapeTestTpl.tpl
+++ b/test/aria/templates/statements/ExpressionEscapeTestTpl.tpl
@@ -19,72 +19,215 @@
 
 {macro main()}
 
-<div {id "default"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"}
-</div>
 
-<div {id "implicit"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHTML}
-</div>
 
-<div {id "all-boolean"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforHTML:true}
-</div>
-<div {id "all-object"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForhtml:{text: true, attr: true}}
-</div>
+/*******************************************************************************
+ * Automatic escaping
+ ******************************************************************************/
 
-<div {id "nothing-boolean"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeForHtml:false}
-</div>
-<div {id "nothing-object"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforHtml:{text: false, attr: false}}
-</div>
-
-<div {id "attr"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|escapeforhtml:{attr: true}}
-</div>
-<div {id "text"/}>
-    ${"<div class='output' style=\"color:blue\">&amp;</div>"|ESCAPEFORHTML:{text: true}}
+{var id = "automatic" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input}
 </div>
 
 
-<div {id "special-attr"/}>
-    <div data-quot="${'"quot"'|escapeForHTML:{attr:true}}" data-apos='${"'apos'"|escapeForHTML:{attr:true}}'></div>
+
+/*******************************************************************************
+ * Explicit final escaping
+ ******************************************************************************/
+
+// ------------------------------------------------------------------ Escape all
+
+{var id = "all-implicit" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML}
+</div>
+
+{var id = "all-boolean" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeforHTML:c.escape}
+</div>
+
+{var id = "all-object" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForhtml:c.escape}
+</div>
+
+// -------------------------------------------------------------- Escape nothing
+
+{var id = "nothing-boolean" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHtml:c.escape}
+</div>
+
+{var id = "nothing-object" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeforHtml:c.escape}
+</div>
+
+// ------------------------------------------------ Escape for specific contexts
+
+{var id = "attr" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeforhtml:c.escape}
+</div>
+
+{var id = "text" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|ESCAPEFORHTML:c.escape}
 </div>
 
 
-<div {id "default-modifier-default"/}>
-    ${undefined|default:'<div></div>'}
-</div>
-<div {id "nothing-modifier-default-before"/}>
-    ${undefined|escapeForHTML:false|default:'<div></div>'}
-</div>
-<div {id "nothing-modifier-default-after"/}>
-    ${undefined|default:'<div></div>'|escapeForHTML:false}
-</div>
-<div {id "all-modifier-default-before"/}>
-    ${undefined|escapeForHTML:true|default:'<div></div>'}
-</div>
-<div {id "all-modifier-default-after"/}>
-    ${undefined|default:'<div></div>'|escapeForHTML:true}
+{var id = "attr-special" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    <div data-quot="${'"quot"'|escapeForHTML:c.escape}" data-apos='${"'apos'"|escapeForHTML:c.escape}'></div>
 </div>
 
-<div {id "default-modifier-empty"/}>
-    ${''|empty:'<div></div>'}
+
+
+/*******************************************************************************
+ * Other modifiers behavior
+ ******************************************************************************/
+
+// --------------------------------------------------------------------- default
+
+{var id = "automatic-modifier_default" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|default:c.modifiers["default"][0]}
 </div>
-<div {id "nothing-modifier-empty-before"/}>
-    ${''|escapeForHTML:false|empty:'<div></div>'}
+
+{var id = "nothing-modifier_default-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|default:c.modifiers["default"][0]}
 </div>
-<div {id "nothing-modifier-empty-after"/}>
-    ${''|empty:'<div></div>'|escapeForHTML:false}
+
+{var id = "nothing-modifier_default-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|default:c.modifiers["default"][0]|escapeForHTML:c.escape}
 </div>
-<div {id "all-modifier-empty-before"/}>
-    ${''|escapeForHTML:true|empty:'<div></div>'}
+
+{var id = "all-modifier_default-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|default:c.modifiers["default"][0]}
 </div>
-<div {id "all-modifier-empty-after"/}>
-    ${''|empty:'<div></div>'|escapeForHTML:true}
+
+{var id = "all-modifier_default-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|default:c.modifiers["default"][0]|escapeForHTML:c.escape}
 </div>
+
+// ----------------------------------------------------------------------- empty
+
+{var id = "automatic-modifier_empty" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|empty:c.modifiers["empty"][0]}
+</div>
+
+{var id = "nothing-modifier_empty-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|empty:c.modifiers["empty"][0]}
+</div>
+
+{var id = "nothing-modifier_empty-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|empty:c.modifiers["empty"][0]|escapeForHTML:c.escape}
+</div>
+
+{var id = "all-modifier_empty-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|empty:c.modifiers["empty"][0]}
+</div>
+
+{var id = "all-modifier_empty-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|empty:c.modifiers["empty"][0]|escapeForHTML:c.escape}
+</div>
+
+// ------------------------------------------------------------------- highlight
+
+{var id = "automatic-modifier_highlight" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|highlight:c.modifiers["highlight"][0]}
+</div>
+
+{var id = "nothing-modifier_highlight-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|highlight:c.modifiers["highlight"][0]}
+</div>
+
+{var id = "nothing-modifier_highlight-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|highlight:c.modifiers["highlight"][0]|escapeForHTML:c.escape}
+</div>
+
+{var id = "all-modifier_highlight-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|highlight:c.modifiers["highlight"][0]}
+</div>
+
+{var id = "all-modifier_highlight-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|highlight:c.modifiers["highlight"][0]|escapeForHTML:c.escape}
+</div>
+
+// ------------------------------------------------------------------ dateformat
+
+{var id = "automatic-modifier_dateformat" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|dateformat:c.modifiers["dateformat"][0]}
+</div>
+
+{var id = "nothing-modifier_dateformat-before" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|escapeForHTML:c.escape|dateformat:c.modifiers["dateformat"][0]}
+</div>
+
+{var id = "nothing-modifier_dateformat-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|dateformat:c.modifiers["dateformat"][0]|escapeForHTML:c.escape}
+</div>
+
+// This one should fail
+// {var id = "all-modifier_dateformat-before" /}
+// <div {id id /}>
+//     {var c = data.useCases[id] /}
+//     ${c.input|escapeForHTML:c.escape|dateformat:c.modifiers["dateformat"][0]}
+// </div>
+// ----
+
+{var id = "all-modifier_dateformat-after" /}
+<div {id id /}>
+    {var c = data.useCases[id] /}
+    ${c.input|dateformat:c.modifiers["dateformat"][0]|escapeForHTML:c.escape}
+</div>
+
 
 {/macro}
 

--- a/test/aria/widgets/action/sortindicator/onclick/OnclickCallbackTpl.tpl
+++ b/test/aria/widgets/action/sortindicator/onclick/OnclickCallbackTpl.tpl
@@ -180,12 +180,12 @@
                 <td class="depTime">
                     {var datetoFormat = segment.departure.date /}
                     {var depDate = new Date(datetoFormat.year, datetoFormat.month, datetoFormat.date, datetoFormat.hours, datetoFormat.minutes, datetoFormat.seconds) /}
-                    ${depDate|dateformat:"hh:mm"|escapeForHTML}
+                    ${depDate|dateformat:"hh:mm"}
                 </td>
                 <td class="arrTime">
                     {var datetoFormat = segment.arrival.date /}
                     {var arrDate = new Date(datetoFormat.year, datetoFormat.month, datetoFormat.date, datetoFormat.hours, datetoFormat.minutes, datetoFormat.seconds) /}
-                    ${arrDate|dateformat:"hh:mm"|escapeForHTML}
+                    ${arrDate|dateformat:"hh:mm"}
                     {if !(aria.utils.Date.isSameDay(arrDate, depDate))}
                         ${getDayDelta(arrDate, depDate)}
                     {/if}

--- a/test/aria/widgets/form/datefield/checkDate/DateFieldTpl.tpl
+++ b/test/aria/widgets/form/datefield/checkDate/DateFieldTpl.tpl
@@ -27,7 +27,7 @@
             {var minDate = new Date(1980,0,1)/}
             {var maxDate = new Date(2025,11,25)/}
             {var shortFormat = aria.utils.environment.Date.getDateFormats().shortFormat/}
-            <p>Both dates should be between ${minDate|dateformat:shortFormat|escapeForHTML} and ${maxDate|dateformat:shortFormat|escapeForHTML}.</p>
+            <p>Both dates should be between ${minDate|dateformat:shortFormat} and ${maxDate|dateformat:shortFormat}.</p>
         </div>
         {if (data.displayField)}
         <p>


### PR DESCRIPTION
Now if the associated modifier is not present at the end, it is simply added behind the scenes (in a mode where it escapes for all contexts).

This is more consistent, logical, since the final output is ensured to be escaped This is the safest solution. It also greatly simplifies the code.

Tests have been refactored, and additional modifiers have been tested.
