### PR TITLE
fix #1083 tooltip issue when there are quotes in the string

### DIFF
--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -20,7 +20,8 @@ Aria.classDefinition({
     $classpath : "aria.widgets.Widget",
     $extends : "aria.widgetLibs.BindableWidget",
     $dependencies : ["aria.widgets.CfgBeans", "aria.utils.Json", "aria.utils.Dom", "aria.DomEvent",
-            "aria.utils.Delegate", "aria.widgets.AriaSkinInterface", "aria.utils.Type", "aria.templates.RefreshManager"],
+            "aria.utils.Delegate", "aria.widgets.AriaSkinInterface", "aria.utils.Type",
+            "aria.templates.RefreshManager", "aria.utils.String"],
     $css : ["aria.widgets.GlobalStyle"],
     $onload : function () {
         // check for skin existency
@@ -372,7 +373,7 @@ Aria.classDefinition({
                 out.write('margin:' + this._defaultMargin + 'px;" ');
             }
             if (cfg.tooltip) {
-                out.write('title="' + cfg.tooltip + '" ');
+                out.write('title="' + aria.utils.String.escapeHTMLAttr(cfg.tooltip) + '" ');
             }
             if (cfg.tabIndex != null && !this._customTabIndexProvided && !cfg.disabled) {
                 var tabIndex = this._calculateTabIndex();

--- a/test/aria/widgets/action/link/LinkClick.js
+++ b/test/aria/widgets/action/link/LinkClick.js
@@ -50,6 +50,8 @@ Aria.classDefinition({
         _step2 : function () {
             this.assertTrue(this.env.data.linkClickCalled == 1);
             this.assertTrue(this.env.data.divClickCalled === 0);
+            var tooltipInQuotes = this._linkDomElt.parentNode.title;
+            this.assertEquals(tooltipInQuotes, '"Tooltip" in quotes', "Tooltip string is not properly escaped");
             this._linkDomElt = null;
             this.notifyTemplateTestEnd();
         }

--- a/test/aria/widgets/action/link/LinkClickTpl.tpl
+++ b/test/aria/widgets/action/link/LinkClickTpl.tpl
@@ -23,7 +23,8 @@
             {@aria:Link {
                 label: "Do not click here",
                 id: "link",
-                onclick: linkClick
+                onclick: linkClick,
+                tooltip:'"Tooltip" in quotes'
             }/}
         </div>
     {/macro}


### PR DESCRIPTION
This pull request fixes the issue with tooltip when there are quotes for the scenario as below
{@aria:Link {
                label: "Link",
                tooltip:'"Tooltip" in quotes'
 }/}
