### PR TITLE
[on hold] fix #1090 - allowing individual year change

### DIFF
--- a/src/aria/jsunit/RobotJavaApplet.js
+++ b/src/aria/jsunit/RobotJavaApplet.js
@@ -67,6 +67,7 @@ Aria.classDefinition({
             VK_BACK_QUOTE : 192,
             VK_BACK_SLASH : 92,
             VK_BACK_SPACE : 8,
+            VK_BACKSPACE : 8,
             VK_BEGIN : 65368,
             VK_BRACELEFT : 161,
             VK_BRACERIGHT : 162,

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -521,6 +521,10 @@ Aria.beanDefinitions({
                     $type : "json:Date",
                     $description : "Reference date from which value can be calculated."
                 },
+                "allowChangeYear" : {
+                    $type : "json:Boolean",
+                    $description : "Specifies whether user should be allowed to change individually the year in a fullFormat/longFormat date pattern."
+                },
                 "bind" : {
                     $type : "TextInputCfg.bind",
                     $properties : {

--- a/src/aria/widgets/form/DateField.js
+++ b/src/aria/widgets/form/DateField.js
@@ -39,6 +39,9 @@ Aria.classDefinition({
         if (cfg.referenceDate) {
             controller.setReferenceDate(new Date(cfg.referenceDate));
         }
+        if (cfg.allowChangeYear) {
+            controller.setAllowChangeYear(cfg.allowChangeYear);
+        }
     },
     $prototype : {
 

--- a/test/aria/widgets/form/datefield/changeYear/IssueTest.js
+++ b/test/aria/widgets/form/datefield/changeYear/IssueTest.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.datefield.changeYear.IssueTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            date : null
+        };
+        this.setTestEnv({
+            data : this.data
+        });
+        this.day = "10";
+        this.month = "11";
+        this.tests = [{
+                    // set year = 1980 (should ignore final spaces)
+                    text : "[backspace][backspace][backspace][backspace]1980[space][space][space]",
+                    year : 1980
+                }, {
+                    // set year = 1950: not valid
+                    text : "[backspace][backspace]50"
+                }, {
+                    // delete year: not valid
+                    text : "[backspace][backspace][backspace][backspace]"
+                }, {
+                    // set year = 2017: back to valid state
+                    text : "2017",
+                    year : 2017
+                }, {
+                    // put invalid chars: not valid
+                    text : "[backspace]uy"
+                }, {
+                    // set year = 1980
+                    text : "[backspace][backspace][backspace][backspace][backspace]1980[space][space][space]",
+                    year : 1980
+                }];
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.testCount = 0;
+            this.df = this.getInputField("df1");
+            this.extInput = this.getElementById("justToFocusOut");
+            this.focusField(this.insertFirstValue);
+        },
+
+        insertFirstValue : function () {
+            this.synEvent.type(this.df, this.day + this.month + "2014", {
+                fn : this.blurField(this.execTest),
+                scope : this
+            });
+        },
+
+        execTest : function () {
+            if (this.testCount < this.tests.length) {
+                this.focusField(this.typeYear);
+            } else {
+                this.notifyTemplateTestEnd();
+            }
+        },
+
+        typeYear : function () {
+            this.synEvent.type(this.df, "[end]" + this.tests[this.testCount].text, {
+                fn : this.blurField(this.onChangeYear),
+                scope : this
+            });
+        },
+
+        onChangeYear : function () {
+            this.checkDate(this.tests[this.testCount].year);
+            this.testCount++;
+            this.execTest();
+        },
+
+        blurField : function (fn) {
+            return function () {
+                this.synEvent.click(this.extInput, {
+                    fn : fn,
+                    scope : this
+                });
+            };
+        },
+
+        focusField : function (fn) {
+            this.synEvent.click(this.df, {
+                fn : fn,
+                scope : this
+            });
+        },
+
+        checkDate : function (year) {
+            if (year) {
+                var d = new Date(year, this.month - 1, this.day);
+                this.assertEquals(this.data.date.getTime(), d.getTime(), "Data set is " + this.data.date
+                        + " while it should be " + d);
+            } else {
+                this.assertUndefined(this.data.date, "Data should be undefined. Instead it is %1");
+            }
+        }
+
+    }
+});

--- a/test/aria/widgets/form/datefield/changeYear/IssueTestTpl.tpl
+++ b/test/aria/widgets/form/datefield/changeYear/IssueTestTpl.tpl
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+{Template {
+    $classpath:"test.aria.widgets.form.datefield.changeYear.IssueTestTpl",
+    $dependencies:["aria.utils.environment.Date"]
+}}
+
+    {macro main()}
+
+    <fieldset  class="fieldsetDemo">
+        <legend>Please enter date here</legend>
+        <div class="panel dates">
+            {var minDate = new Date(1980,0,1)/}
+            {var maxDate = new Date(2025,11,25)/}
+            {var shortFormat = aria.utils.environment.Date.getDateFormats().shortFormat/}
+            <p>Dates should be between ${minDate|dateformat:shortFormat} and ${maxDate|dateformat:shortFormat}.</p>
+        </div>
+        <p>
+            {@aria:DateField {
+                label:"Datefield 1",
+                labelPos:"left",
+                id: "df1",
+                labelAlign:"right",
+                helptext:"Enter date 1",
+                width:250,
+                block:true,
+                minValue: minDate,
+                maxValue: maxDate,
+                allowChangeYear: true,
+                pattern : aria.utils.environment.Date.getDateFormats().fullFormat,
+                bind:{
+                    "value":{
+                        inside: data,
+                        to: 'date'
+                    }
+                }
+            }/}
+        </p>
+
+        <input {id "justToFocusOut"/}>
+
+        </fieldset>
+
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
User is allowed to change individually the year when using fullFormat or longFormat.
eg. 
"Friday 11 November 2011" in DateField can be changed in "Friday 11 November 2012" without rewriting the full date.
