### PR TITLE
Exposing module services in a Page Engine based application

### DIFF
--- a/src/aria/pageEngine/CfgBeans.js
+++ b/src/aria/pageEngine/CfgBeans.js
@@ -375,7 +375,6 @@ Aria.beanDefinitions({
                         $description : "List of pieces of contents to be displayed."
                     }]
         },
-
         "Module" : {
             $type : "json:Object",
             $description : "Description of the module that is created at page level.",
@@ -392,6 +391,19 @@ Aria.beanDefinitions({
                 "bind" : {
                     $type : "json:ObjectRef",
                     $description : "List of data bindings. The key is a location in the module's data model, the value is inside the site module controller and has the form 'location:path' like 'appData:search.from'"
+                },
+                "services" : {
+                    $type : "json:Map",
+                    $keyType : {
+                        $type : "json:String",
+                        $description : "Public name of the service."
+                    },
+                    $contentType : {
+                        $type : "json:String",
+                        $description : "Name of the method as declared inside the module controller."
+                    },
+                    $description : "Map containing the module controller methods to expose.",
+                    $default : {}
                 }
             }
         },

--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -759,7 +759,9 @@ Aria.classDefinition({
          */
         _getPlaceholderContents : function (pageConfig, contentId) {
             var outputContent = [];
-            var content = pageConfig.contents.placeholderContents ? pageConfig.contents.placeholderContents[contentId] : null;
+            var content = pageConfig.contents.placeholderContents
+                    ? pageConfig.contents.placeholderContents[contentId]
+                    : null;
             if (!content) {
                 return outputContent;
             }
@@ -836,6 +838,14 @@ Aria.classDefinition({
          */
         getPageProvider : function () {
             return this._pageProvider;
+        },
+
+        /**
+         * Exposed methods of module controllers as services
+         * @return {aria.pageEngine.CfgBeans:Module.services} Map containing exposed module controller methods
+         */
+        getServices : function () {
+            return this._rootModule.services;
         },
 
         /**

--- a/test/aria/pageEngine/PageEngineTestSuite.js
+++ b/test/aria/pageEngine/PageEngineTestSuite.js
@@ -21,6 +21,7 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TestSuite",
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.pageEngine.pageEngine.moduleControllerService.ModuleControllerServiceTest");
         this.addTests("test.aria.pageEngine.contentProcessors.MarkdownProcessorTest");
         this.addTests("test.aria.pageEngine.siteRootModule.SiteRootModuleTestSuite");
         this.addTests("test.aria.pageEngine.utils.UtilsTestSuite");

--- a/test/aria/pageEngine/pageEngine/moduleControllerService/ModuleControllerServiceTest.js
+++ b/test/aria/pageEngine/pageEngine/moduleControllerService/ModuleControllerServiceTest.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.moduleControllerService.ModuleControllerServiceTest",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $dependencies : ["aria.pageEngine.pageProviders.BasePageProvider",
+            "aria.pageEngine.pageProviders.BasePageProviderBeans"],
+    $constructor : function () {
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.site.PageProviderServices");
+        this._cssBasePath = "test/aria/pageEngine/pageEngine/site/css/";
+
+    },
+    $prototype : {
+
+        runTestInIframe : function () {
+            this._createPageEngine({
+                oncomplete : "_onPageEngineStarted"
+            });
+        },
+
+        _createPageEngine : function (args) {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.site.PageProviderServices();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this[args.oncomplete],
+                    scope : this
+                }
+            });
+
+        },
+
+        _onPageEngineStarted : function () {
+            this._testGetServices();
+            this.end();
+        },
+
+        /**
+         * Test the exposure of the module controller methods
+         */
+        _testGetServices : function () {
+            var services = this.pageEngine.getServices();
+            // tests property exposed directly as a service
+            this.assertUndefined(services.SiteModuleServicesProperty);
+            // tests property exposed through a method on ModuleServices1 (scope test)
+            this.assertTrue(services.SiteModuleServicesScope());
+            // tests method exposed on ModuleServices1 (test.aria.pageEngine.pageEngine.site.modules.ModuleServices1)
+            this.assertTrue(services.SiteModuleServicesMethod1() === "ModuleServices1");
+            // tests method exposed on ModuleServices2 (test.aria.pageEngine.pageEngine.site.modules.ModuleServices2)
+            this.assertTrue(services.SiteModuleServicesMethod2() === "ModuleServices2");
+            // tests error logging, when there is an existing service
+            this.assertErrorInLogs(this.pageEngine._rootModule.SERVICE_ALREADY_DEFINED);
+            // tests when there is an existing service, the last exposed method wins
+            this.assertTrue(services.SiteModuleServicesMethod3() === "ModuleServices2");
+            // tests that no service is available when a module method that does not exist was exposed as a service
+            this.assertUndefined(services.SiteModuleServicesMethod4);
+            // tests error logging, when a module method that does not exist is being exposed as a service
+            this.assertErrorInLogs(this.pageEngine._rootModule.SERVICE_METHOD_NOT_FOUND);
+            // tests method exposed as a service but not on the public interface
+            this.assertUndefined(services.SiteModuleServicesMethod5);
+            // tests method exposed through services defined in the page definition
+            this.assertTrue(services.PageModuleServicesMethod1() === "ModuleServices1");
+            this.pageEngine._rootModule.unloadPageModules("ModuleServices1");
+            // tests services are removed when a module gets unloaded
+            this.assertUndefined(services.PageModuleServicesMethod1);
+        },
+
+        end : function () {
+            this._disposePageEngine();
+            this.$PageEngineBaseTestCase.end.call(this);
+        },
+
+        _disposePageEngine : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+        }
+    }
+
+});

--- a/test/aria/pageEngine/pageEngine/site/PageProviderServices.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderServices.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Page provider
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.PageProviderServices",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $constructor : function (navigation) {
+
+        this._navigation = navigation;
+
+    },
+    $prototype : {
+
+        /**
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                containerId : "at-main",
+                storage : {
+                    active : false
+                },
+                commonModules : {
+                    "module1" : {
+                        classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices1",
+                        services : {
+                            "SiteModuleServicesProperty" : "exposedProperty",
+                            "SiteModuleServicesScope" : "exposedPropertyThroughMethod",
+                            "SiteModuleServicesMethod1" : "exposedMethod",
+                            "SiteModuleServicesMethod3" : "exposedMethod",
+                            "SiteModuleServicesMethod5" : "exposedMethodNotOnInterface"
+                        }
+                    },
+                    "module2" : {
+                        classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices2",
+                        services : {
+                            "SiteModuleServicesMethod2" : "exposedMethod",
+                            "SiteModuleServicesMethod3" : "exposedMethod",
+                            "SiteModuleServicesMethod4" : "exposedMethodDoesNotExist"
+                        }
+                    }
+                }
+            };
+            if (this._navigation) {
+                siteConfig.navigation = this._navigation;
+            }
+            this.$callback(callback.onsuccess, siteConfig);
+        },
+
+        /**
+         * @param {String} pageId Id of the page
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            var pageId = pageRequest.pageId;
+            if ((!pageId)) {
+                this.$callback(callback.onsuccess, {
+                    pageId : "ModuleServices1",
+                    contents : {},
+                    pageComposition : {
+                        template : "test.aria.pageEngine.pageEngine.site.templates.ModuleServicesTemplate",
+                        modules : {
+                            "module1" : {
+                                classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices1",
+                                services : {
+                                    "PageModuleServicesMethod1" : "exposedMethod"
+                                }
+                            }
+                        },
+                        placeholders : {
+                            "myPlaceholder" : {
+                                template : "test.aria.pageEngine.pageEngine.site.templates.ModuleServicesTemplate",
+                                module : "module1"
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/modules/BaseModuleService.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/BaseModuleService.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.modules.BaseModuleService",
+    $extends : "aria.templates.ModuleCtrl",
+    $implements : ["test.aria.pageEngine.pageEngine.site.modules.IModuleService"],
+    $prototype : {
+        $publicInterfaceName : "test.aria.pageEngine.pageEngine.site.modules.IModuleService",
+        exposedMethod : function () {},
+        exposedPropertyThroughMethod : function () {}
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/modules/IModuleService.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/IModuleService.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test Module Service Interface
+ */
+Aria.interfaceDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.modules.IModuleService",
+    $extends : "aria.templates.IModuleCtrl",
+    $interface : {
+        exposedMethod : {
+            $type : "Function"
+        },
+        exposedPropertyThroughMethod : {
+            $type : "Function"
+        },
+        exposedProperty : {
+            $type : "Object"
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/modules/ModuleServices1.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/ModuleServices1.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices1",
+    $extends : "test.aria.pageEngine.pageEngine.site.modules.BaseModuleService",
+    $constructor : function () {
+        this.$BaseModuleService.constructor.call(this);
+        this.publicProperty = true;
+    },
+    $prototype : {
+        exposedMethod : function () {
+            return "ModuleServices1";
+        },
+
+        exposedPropertyThroughMethod : function () {
+            return this.publicProperty;
+        },
+
+        exposedMethodNotOnInterface : function () {
+            return false;
+        },
+
+        exposedProperty : {}
+
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/modules/ModuleServices2.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/ModuleServices2.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices2",
+    $extends : "test.aria.pageEngine.pageEngine.site.modules.BaseModuleService",
+    $prototype : {
+        exposedMethod : function () {
+            return "ModuleServices2";
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/templates/ModuleServicesTemplate.tpl
+++ b/test/aria/pageEngine/pageEngine/site/templates/ModuleServicesTemplate.tpl
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+{Template {
+  $classpath : "test.aria.pageEngine.pageEngine.site.templates.ModuleServicesTemplate",
+  $wlibs: {
+     "embed": "aria.embed.EmbedLib"
+  }
+}}
+
+{macro main ()}
+
+     Module Services Template
+
+{/macro}
+
+
+{/Template}


### PR DESCRIPTION
Using the following API for both site and page definitions, it is now possible to expose a module controllers methods as services which you can then have access to by using the new <code>getServices()</code> method from the <code>aria.pageEngine.PageEngine</code> class:

```
         module1 : {
             ...
             services : {                
                 'MyServiceMethod1' : 'exposedMethod1',
                 'MyServiceMethod2' : 'exposedMethod2'
             }
         },
         module2 : {
             ...
             services : {
                 'MyServiceMethod3' : 'exposedMethod3',
                 'MyServiceMethod4' : 'exposedMethod4'                 
             }
         }

```
