### PR TITLE
Non-delegated events are now correctly raised on html widgets

### DIFF
--- a/src/aria/html/Select.js
+++ b/src/aria/html/Select.js
@@ -37,6 +37,11 @@ Aria.classDefinition({
             scope : this
         });
 
+        this._chainListener(cfg.on, 'blur', {
+            fn : this.__updateDataModel,
+            scope : this
+        });
+
         this.$Element.constructor.call(this, cfg, context, line);
     },
     $prototype : {

--- a/test/aria/html/select/onchange/DataModelOnChangeTestCase.js
+++ b/test/aria/html/select/onchange/DataModelOnChangeTestCase.js
@@ -15,13 +15,13 @@
 
 Aria.classDefinition({
     $classpath : "test.aria.html.select.onchange.DataModelOnChangeTestCase",
-    $extends : "aria.jsunit.TemplateTestCase",
-    $dependencies : ["aria.utils.Dom", "aria.html.Select", "aria.utils.SynEvents"],
+    $extends : "aria.jsunit.RobotTestCase",
     $constructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
+        this.$RobotTestCase.constructor.call(this);
 
         this.data = {
             selectedOption : "EURO",
+            onChangeCalls : 0,
             onChangeOption : ""
         };
         this.setTestEnv({
@@ -32,34 +32,18 @@ Aria.classDefinition({
     },
     $prototype : {
         runTemplateTest : function () {
+            var selectWidget = this.testDiv.getElementsByTagName("select")[0]; // we know there's only one
 
-            var document = Aria.$window.document;
-            var selectWidgets = this.testDiv.getElementsByTagName("select");
+            this.assertEquals(selectWidget.selectedIndex, 0, "The selected Index should be %2 but was %1");
 
-            // we know there's only one
-            var selectWidget = selectWidgets[0];
-            this.assertEquals(selectWidget.selectedIndex, 0, "The selected Index should be %2  but was %1 ");
-
-            // to be nullified in the callback of the click action
-            this.selectWidget = selectWidget;
-            this.selectWidget.focus();
-
-            this.synEvent.type(this.selectWidget, "[down][down][enter]", {
-                fn : function () {
-                    this.templateCtxt.$focus("justToFocusOut");
-                    this.waitFor({
-                        condition : function () {
-                            return this.data.onChangeOption !== "";
-                        },
-                        callback : this.afterChange
-                    });
-
-                },
+            this.synEvent.execute([["click", selectWidget], ["type", null, "[down][down][enter]\t"]], {
+                fn : this.afterChange,
                 scope : this
             });
         },
 
         afterChange : function () {
+            this.assertEquals(this.data.onChangeCalls, 1, "onchange should have been called exactly once");
             this.assertEquals(this.data.selectedOption, "POUND", "Selected Option should be %2  but was %1");
             this.assertEquals(this.data.onChangeOption, "POUND", "Changed Option should be %2  but was %1");
             this.end();

--- a/test/aria/html/select/onchange/DataModelOnChangeTpl.tpl
+++ b/test/aria/html/select/onchange/DataModelOnChangeTpl.tpl
@@ -23,20 +23,19 @@
 
 {macro main()}
 
- {var myStringOptions = ["EURO","FRANC SUISSE","POUND"]/}
-
-  {@html:Select{
-    options : myStringOptions,
-	bind : {
+	{@html:Select{
+		options : ["EURO","FRANC SUISSE","POUND"],
+		bind : {
 			value : {
-					inside : data,
-					to : "selectedOption"
-					}
-			},
-	on  :{
-		change:myFunc
+				inside : data,
+				to : "selectedOption"
+			}
+		},
+		on : {
+			change : onChange
 		}
 	}/}
-	<input {id "justToFocusOut"/}>
+	<input type="text">
 {/macro}
+
 {/Template}

--- a/test/aria/html/select/onchange/DataModelOnChangeTplScript.js
+++ b/test/aria/html/select/onchange/DataModelOnChangeTplScript.js
@@ -16,7 +16,8 @@
 Aria.tplScriptDefinition({
     $classpath : "test.aria.html.select.onchange.DataModelOnChangeTplScript",
     $prototype : {
-        myFunc : function () {
+        onChange : function () {
+            this.data.onChangeCalls++;
             this.data.onChangeOption = this.data.selectedOption;
         }
     }


### PR DESCRIPTION
This pull request fixes the following issue: non-delegated events were not raised on html widgets (the event mechanism implemented in `aria.html.Element` did no check whether events were delegated or not).

With this fix, if an event is not delegated, the fallback markup is added so that the handler is correctly called.

Especially, the `onchange` event on the html select widget is now correctly raised on IE 7-10, which fixes `test.aria.html.select.onchange.DataModelOnChangeTestCase`.
