### PR TITLE
fix for test.aria.widgets.form.autocomplete.samevalue.AutoComplete

### DIFF
--- a/src/aria/jsunit/RobotJavaApplet.js
+++ b/src/aria/jsunit/RobotJavaApplet.js
@@ -67,6 +67,7 @@ Aria.classDefinition({
             VK_BACK_QUOTE : 192,
             VK_BACK_SLASH : 92,
             VK_BACK_SPACE : 8,
+            VK_BACKSPACE : 8,
             VK_BEGIN : 65368,
             VK_BRACELEFT : 161,
             VK_BRACERIGHT : 162,

--- a/test/aria/widgets/form/autocomplete/samevalue/AutoComplete.js
+++ b/test/aria/widgets/form/autocomplete/samevalue/AutoComplete.js
@@ -15,7 +15,7 @@
 
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.autocomplete.samevalue.AutoComplete",
-    $extends : "aria.jsunit.TemplateTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
     $prototype : {
         runTemplateTest : function () {
             this.clickAndType('acDest1', 'lon', {


### PR DESCRIPTION
Note that `test.aria.widgets.form.autocomplete.samevalue.AutoComplete` started failing with commit 1d02f12b58f5d4f84773f2d3605fa544eb096e93.
However, doing the test scenario manually or with the robot does not raise any error.
As a consequence, this pull request changes the test to use the robot instead of Syn.
(Syn puts the cursor at a wrong position when simulating a click on the field).
