### PR TITLE
add getServices in PageEngine interface

### DIFF
--- a/src/aria/pageEngine/PageEngineInterface.js
+++ b/src/aria/pageEngine/PageEngineInterface.js
@@ -62,6 +62,14 @@ Aria.interfaceDefinition({
         },
 
         /**
+         * Exposed methods of module controllers as services
+         * @return {aria.pageEngine.CfgBeans:Module.services} Map containing exposed module controller methods
+         */
+        getServices : {
+            $type : "Function"
+        },
+
+        /**
          * Return instance of the pageProvider
          * @return {aria.pageEngine.CfgBeans:Start.pageProvider}
          */

--- a/test/aria/pageEngine/pageEngine/moduleControllerService/ModuleControllerServiceTest.js
+++ b/test/aria/pageEngine/pageEngine/moduleControllerService/ModuleControllerServiceTest.js
@@ -58,7 +58,7 @@ Aria.classDefinition({
             // tests property exposed directly as a service
             this.assertUndefined(services.SiteModuleServicesProperty);
             // tests property exposed through a method on ModuleServices1 (scope test)
-            this.assertTrue(services.SiteModuleServicesScope());
+            this.assertEquals(services.SiteModuleServicesScope(), "abcdef");
             // tests method exposed on ModuleServices1 (test.aria.pageEngine.pageEngine.site.modules.ModuleServices1)
             this.assertTrue(services.SiteModuleServicesMethod1() === "ModuleServices1");
             // tests method exposed on ModuleServices2 (test.aria.pageEngine.pageEngine.site.modules.ModuleServices2)
@@ -78,6 +78,9 @@ Aria.classDefinition({
             this.pageEngine._rootModule.unloadPageModules("ModuleServices1");
             // tests services are removed when a module gets unloaded
             this.assertUndefined(services.PageModuleServicesMethod1);
+            // test that getServices method is available also within modules
+            this.assertEquals(services.SiteModuleServicesMethod6(), "abcdef");
+
         },
 
         end : function () {

--- a/test/aria/pageEngine/pageEngine/site/PageProviderServices.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProviderServices.js
@@ -51,7 +51,8 @@ Aria.classDefinition({
                         services : {
                             "SiteModuleServicesMethod2" : "exposedMethod",
                             "SiteModuleServicesMethod3" : "exposedMethod",
-                            "SiteModuleServicesMethod4" : "exposedMethodDoesNotExist"
+                            "SiteModuleServicesMethod4" : "exposedMethodDoesNotExist",
+                            "SiteModuleServicesMethod6" : "methodToTestServicesAvailabilityInModules"
                         }
                     }
                 }

--- a/test/aria/pageEngine/pageEngine/site/modules/BaseModuleService.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/BaseModuleService.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
     $prototype : {
         $publicInterfaceName : "test.aria.pageEngine.pageEngine.site.modules.IModuleService",
         exposedMethod : function () {},
-        exposedPropertyThroughMethod : function () {}
+        exposedPropertyThroughMethod : function () {},
+        methodToTestServicesAvailabilityInModules : function () {}
     }
 });

--- a/test/aria/pageEngine/pageEngine/site/modules/IModuleService.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/IModuleService.js
@@ -28,6 +28,10 @@ Aria.interfaceDefinition({
         },
         exposedProperty : {
             $type : "Object"
+        },
+
+        methodToTestServicesAvailabilityInModules : {
+            $type : "Function"
         }
     }
 });

--- a/test/aria/pageEngine/pageEngine/site/modules/ModuleServices1.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/ModuleServices1.js
@@ -18,7 +18,7 @@ Aria.classDefinition({
     $extends : "test.aria.pageEngine.pageEngine.site.modules.BaseModuleService",
     $constructor : function () {
         this.$BaseModuleService.constructor.call(this);
-        this.publicProperty = true;
+        this.publicProperty = "abcdef";
     },
     $prototype : {
         exposedMethod : function () {

--- a/test/aria/pageEngine/pageEngine/site/modules/ModuleServices2.js
+++ b/test/aria/pageEngine/pageEngine/site/modules/ModuleServices2.js
@@ -17,8 +17,19 @@ Aria.classDefinition({
     $classpath : "test.aria.pageEngine.pageEngine.site.modules.ModuleServices2",
     $extends : "test.aria.pageEngine.pageEngine.site.modules.BaseModuleService",
     $prototype : {
+
+        init : function (args, cb) {
+            this._pageEngine = args.pageEngine;
+            this.$callback(cb);
+        },
+
         exposedMethod : function () {
             return "ModuleServices2";
+        },
+
+        methodToTestServicesAvailabilityInModules : function () {
+            var services = this._pageEngine.getServices();
+            return services.SiteModuleServicesScope();
         }
     }
 });


### PR DESCRIPTION
The `getServices` method is now available in the interface that is used to wrap the instance of page engine available in the initArgs of module controllers declared in the site configuration and in page definitions.
