### PR TITLE
Fixing popup position of MAC

### DIFF
--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -72,13 +72,23 @@ Aria.classDefinition({
                             popup : "bottom left"
                         }],
                 offset : {
-                    top : this._skinObj.offsetTop
+                    top : this._skinObj.offsetTop,
+                    left : this._getPopupLeftOffset()
                 },
                 closeOnMouseClick : true,
                 closeOnMouseScroll : true,
                 ignoreClicksOn : this._getPopupIgnoreClicksOnDomElts(),
                 preferredWidth : this._getPopupWidth()
             });
+        },
+
+        /**
+         * Internal method to handle the left offset of the popup
+         * @protected
+         * @return {Integer} Left offset
+         */
+        _getPopupLeftOffset : function () {
+            return 0;
         },
 
         /**

--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -183,6 +183,20 @@ Aria.classDefinition({
         },
 
         /**
+         * Internal method to handle the left offset that the popup should have when there are items inside the text field
+         * @protected
+         * @return {Integer} Left offset
+         */
+        _getPopupLeftOffset : function () {
+            if (!this.controller._isExpanded) {
+                var inputElements = aria.utils.Dom.getDomElementsChildByTagName(this.$Input._getInputMarkupDomElt.call(this), "input");
+                return (inputElements.length > 0) ? inputElements[0].offsetLeft : 0;
+            } else {
+                return 0;
+            }
+        },
+
+        /**
          * Internal method to handle the click event to remove suggestion. This event is used to set focus on input
          * field
          * @param {aria.DomEvent} event Event object


### PR DESCRIPTION
This commit fixes the popup position of the MultiAutoComplete widget that should be positioned after the items already inserted inside the text field.
