### PR TITLE
Popup position with expanded list

### DIFF
--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -94,9 +94,18 @@ Aria.classDefinition({
             if (report && report.ok === false) {
                 report.errorValue = this.controller.selectedSuggestions;
             }
+            var repositionDropDown = false;
+            if (report && report.repositionDropDown) {
+                repositionDropDown = true;
+                report.repositionDropDown = false;
+            }
             this.$AutoComplete._reactToControllerReport.call(this, report, arg);
             if (report) {
                 this._updateMultiselectValues(report);
+            }
+            if (repositionDropDown && this._dropdownPopup) {
+                this._closeDropdown();
+                this._openDropdown();
             }
         },
 

--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -974,7 +974,9 @@ Aria.classDefinition({
          */
         deselectAll : function () {
             this.setSelectedValues([]);
-            this.json.setValue(this._data, "focusIndex", 0);
+            if (this._data) {
+                this.json.setValue(this._data, "focusIndex", 0);
+            }
         },
 
         /**
@@ -991,7 +993,9 @@ Aria.classDefinition({
                 }
             }
             this.setSelectedValues(selected);
-            this.json.setValue(this._data, "focusIndex", 0);
+            if (this._data) {
+                this.json.setValue(this._data, "focusIndex", 0);
+            }
         }
     }
 });

--- a/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -50,6 +50,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.multiautocomplete.enterAndTab.EnterAndTabTestCase");
         this.addTests("test.aria.widgets.form.multiautocomplete.popupGeometry.PopupWidthTest");
         this.addTests("test.aria.widgets.form.multiautocomplete.popupGeometry.PopupLeftPositionTest");
+        this.addTests("test.aria.widgets.form.multiautocomplete.popupGeometry.PopupTopPositionTest");
         this.addTests("test.aria.widgets.form.multiautocomplete.preselectAutofill.PreselectAutofillTestSuite");
     }
 });

--- a/test/aria/widgets/form/multiautocomplete/popupGeometry/PopupTopPositionTest.js
+++ b/test/aria/widgets/form/multiautocomplete/popupGeometry/PopupTopPositionTest.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiautocomplete.popupGeometry.PopupTopPositionTest",
+    $extends : "test.aria.widgets.form.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+        this.$BaseMultiAutoCompleteTestCase.$constructor.call(this);
+        this.data.expandButton = true;
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.clickonExpandoButton(this._afterExpandOpen);
+        },
+
+        _afterExpandOpen : function () {
+            this.getWidgetInstance("MultiAutoId").controller.getListWidget()._subTplCtxt.moduleCtrl.selectAll();
+            this._testDropdownPosition();
+            this.getWidgetInstance("MultiAutoId").controller.getListWidget()._subTplCtxt.moduleCtrl.deselectAll();
+            this._testDropdownPosition();
+            this.toggleOption("MultiAutoId", 0, "_afterFirstToggle");
+        },
+
+        _afterFirstToggle : function () {
+            this._testDropdownPosition();
+            this.toggleOption("MultiAutoId", 1, "_afterSecondToggle");
+        },
+
+        _afterSecondToggle : function () {
+            this._testDropdownPosition();
+            this.toggleOption("MultiAutoId", 2, "_afterThirdToggle");
+        },
+
+        _afterThirdToggle : function () {
+            this._testDropdownPosition();
+            this.toggleOption("MultiAutoId", 3, "_afterFouthToggle");
+        },
+
+        _afterFouthToggle : function () {
+            this._testDropdownPosition();
+            this.assertLogsEmpty();
+            this.end();
+        },
+
+        _testDropdownPosition : function () {
+            var dropdown = this.getWidgetDropDownPopup("MultiAutoId");
+            var dropdownGeometry = aria.utils.Dom.getGeometry(dropdown);
+            var macGeometry = aria.utils.Dom.getGeometry(this.getWidgetDomElement("MultiAutoId", "table"));
+
+            this.assertEqualsWithTolerance(dropdownGeometry.y, macGeometry.y + macGeometry.height, 5, "Wrong left position for the popup. Expected: %2. Got: %1");
+        }
+    }
+});


### PR DESCRIPTION
Suppose you have a `MultiAutoComplete` with an expand button.

When you add suggestions through the expanded list, its position is now correctly updated.

Also, when clicking on `Select all` or `Deselect all` an error was logged. This commit fixes this.
