### PR TITLE
Possibility to customize the root module in a page engine-based application

### DIFF
--- a/src/aria/pageEngine/CfgBeans.js
+++ b/src/aria/pageEngine/CfgBeans.js
@@ -22,6 +22,7 @@ Aria.beanDefinitions({
     $namespaces : {
         "json" : "aria.core.JsonTypes",
         "core" : "aria.core.CfgBeans",
+        "template" : "aria.templates.CfgBeans",
         "animation" : "aria.utils.css.AnimationsBean"
     },
     $beans : {
@@ -55,6 +56,10 @@ Aria.beanDefinitions({
                 "oncomplete" : {
                     $type : "core:Callback",
                     $description : "Callback for the correct start of the Page Engine."
+                },
+                "rootModule" : {
+                    $type : "template:InitModuleCtrl",
+                    $description : "Custom root module controller for the application, it must extend aria.pageEngine.SiteRootModule"
                 }
             }
         },

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -33,5 +33,6 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.PageEngineTemplateDisposalTestWithAnimations");
         this.addTests("test.aria.pageEngine.pageEngine.issue626.PageReadyEventTest");
         this.addTests("test.aria.pageEngine.pageEngine.issue770.GetContentTest");
+        this.addTests("test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleTestSuite");
     }
 });

--- a/test/aria/pageEngine/pageEngine/PageEngineTestOne.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTestOne.js
@@ -33,7 +33,7 @@ Aria.classDefinition({
         },
 
         _onSiteConfigFailure : function (args) {
-            this.assertTrue(args == this.pageEngine.SITE_CONFIG_NOT_AVAILABLE);
+            this.assertTrue(args[0] == this.pageEngine.SITE_CONFIG_NOT_AVAILABLE);
             this.assertErrorInLogs(this.pageEngine.SITE_CONFIG_NOT_AVAILABLE);
             this._disposePageEngine();
 
@@ -45,7 +45,7 @@ Aria.classDefinition({
             });
         },
         _onInvalidSiteConfig : function (args) {
-            this.assertTrue(args == this.pageEngine.INVALID_SITE_CONFIGURATION);
+            this.assertTrue(args[0] == this.pageEngine.INVALID_SITE_CONFIGURATION);
             this.assertErrorInLogs(this.pageEngine.INVALID_SITE_CONFIGURATION + ":");
             this.assertErrorInLogs("1 - " + aria.core.JsonValidator.MISSING_MANDATORY);
 
@@ -58,7 +58,7 @@ Aria.classDefinition({
             });
         },
         _onMissingSiteDependencies : function (args) {
-            this.assertTrue(args == this.pageEngine.MISSING_DEPENDENCIES);
+            this.assertTrue(args[0] == this.pageEngine.MISSING_DEPENDENCIES);
             this.assertErrorInLogs(this.pageEngine.MISSING_DEPENDENCIES);
             this.assertErrorInLogs(aria.core.ClassLoader.CLASS_LOAD_FAILURE);
 
@@ -71,7 +71,7 @@ Aria.classDefinition({
             });
         },
         _onPageFailure : function (args) {
-            this.assertTrue(args == this.pageEngine.PAGE_NOT_AVAILABLE);
+            this.assertTrue(args[0] == this.pageEngine.PAGE_NOT_AVAILABLE);
             this.assertErrorInLogs(this.pageEngine.PAGE_NOT_AVAILABLE);
 
             this._disposePageEngine();
@@ -83,7 +83,7 @@ Aria.classDefinition({
             });
         },
         _onInvalidPage : function (args) {
-            this.assertTrue(args == this.pageEngine.INVALID_PAGE_DEFINITION);
+            this.assertTrue(args[0] == this.pageEngine.INVALID_PAGE_DEFINITION);
             this.assertErrorInLogs(this.pageEngine.INVALID_PAGE_DEFINITION + ":");
             this.assertErrorInLogs("1 - " + aria.core.JsonValidator.MISSING_MANDATORY);
 
@@ -96,7 +96,7 @@ Aria.classDefinition({
             });
         },
         _onMissingPageDependencies : function (args) {
-            this.assertTrue(args == this.pageEngine.MISSING_DEPENDENCIES);
+            this.assertTrue(args[0] == this.pageEngine.MISSING_DEPENDENCIES);
             this.assertErrorInLogs(this.pageEngine.MISSING_DEPENDENCIES);
             this.assertErrorInLogs(aria.core.ClassLoader.CLASS_LOAD_FAILURE);
 

--- a/test/aria/pageEngine/pageEngine/customRootModule/CustomRootModuleBaseTestCase.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/CustomRootModuleBaseTestCase.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleBaseTestCase",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.customRootModule.PageProvider");
+        this.rootModuleCfg = this.rootModuleCfg || null;
+    },
+    $prototype : {
+
+        runTestInIframe : function () {
+
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.customRootModule.PageProvider();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                rootModule : this.rootModuleCfg,
+                oncomplete : {
+                    fn : this._afterPageEngineStart,
+                    scope : this
+                },
+                onerror : {
+                    fn : this._afterPageEngineStart,
+                    scope : this
+                }
+            });
+
+        },
+
+        _afterPageEngineStart : function () {
+            this.end();
+        },
+
+        end : function () {
+            this._disposePageEngine();
+            this.$PageEngineBaseTestCase.end.call(this);
+        },
+
+        _disposePageEngine : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+
+        }
+
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/CustomRootModuleTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/CustomRootModuleTestSuite.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.pageEngine.pageEngine.customRootModule.NonExistentRootModuleClassTest");
+        this.addTests("test.aria.pageEngine.pageEngine.customRootModule.RootModuleWrongInheritanceTest");
+        this.addTests("test.aria.pageEngine.pageEngine.customRootModule.ValidCustomRootModuleTest");
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/NonExistentRootModuleClassTest.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/NonExistentRootModuleClassTest.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.NonExistentRootModuleClassTest",
+    $extends : "test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleBaseTestCase",
+    $constructor : function () {
+        this.rootModuleCfg = {
+            classpath : "a.class.that.does.not.Exist"
+        };
+        this.$CustomRootModuleBaseTestCase.constructor.call(this);
+    },
+    $prototype : {
+
+        _afterPageEngineStart : function () {
+            this.assertErrorInLogs(this._testWindow.aria.pageEngine.PageEngine.MISSING_DEPENDENCIES);
+            this.assertErrorInLogs(aria.core.ClassLoader.CLASS_LOAD_FAILURE);
+            this.end();
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/PageProvider.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/PageProvider.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Page provider
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.PageProvider",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $prototype : {
+
+        /**
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                appData : {
+                    message : "realAppData"
+                },
+                containerId : "at-main",
+                storage : {
+                    active : false
+                },
+                commonModules : {
+                    "m1" : {
+                        classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.TestModule",
+                        initArgs : {
+                            id : "m1"
+                        }
+                    }
+                }
+            };
+            this.$callback(callback.onsuccess, siteConfig);
+        },
+
+        /**
+         * @param {aria.pageEngine.CfgBeans:PageRequest} pageId Id of the page
+         * @param {aria.pageEngine.CfgBeans.ExtendedCallback} callback
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            this.$callback(callback.onsuccess, {
+                pageId : "aaa",
+                url : "/pageEngine/aaa",
+                title : "page_aaa",
+                pageComposition : {
+                    template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
+                    modules : {
+                        "m2" : {
+                            classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.TestModule",
+                            initArgs : {
+                                id : "m2"
+                            }
+                        }
+                    },
+                    placeholders : {
+                        "header" : {
+                            module : "common:m1",
+                            template : "test.aria.pageEngine.pageEngine.site.templates.Body"
+                        },
+                        "body" : {
+                            module : "m2",
+                            template : "test.aria.pageEngine.pageEngine.site.templates.Body"
+                        }
+                    }
+                }
+            });
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/RootModuleWrongInheritanceTest.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/RootModuleWrongInheritanceTest.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.RootModuleWrongInheritanceTest",
+    $extends : "test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleBaseTestCase",
+    $constructor : function () {
+        this.rootModuleCfg = {
+            classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.TestModule"
+        };
+        this.$CustomRootModuleBaseTestCase.constructor.call(this);
+    },
+    $prototype : {
+
+        _afterPageEngineStart : function () {
+            this.assertErrorInLogs(this._testWindow.aria.pageEngine.PageEngine.INVALID_ROOTMODULE_PARENT);
+            this.end();
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/ValidCustomRootModuleTest.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/ValidCustomRootModuleTest.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.ValidCustomRootModuleTest",
+    $extends : "test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleBaseTestCase",
+    $constructor : function () {
+        this._testData = {
+            eventLogs : [],
+            receivedInitArgs : {}
+        };
+        this.rootModuleCfg = {
+            classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.CustomRootModule",
+            constructorArgs : {
+                testData : this._testData
+            },
+            initArgs : {
+                further : "args",
+                appData : {
+                    message : "wrongAppData"
+                }
+            }
+        };
+        this.$CustomRootModuleBaseTestCase.constructor.call(this);
+    },
+    $prototype : {
+
+        _afterPageEngineStart : function () {
+            this.assertJsonEquals(this._testData.eventLogs, ["m1", "m2"], "Custom root module not able to listen to submodule's events.");
+            this.assertEquals(this._testData.receivedInitArgs.further, "args", "Extra initArgs not correctly passed to the custom root module.");
+            this.assertEquals(this._testData.receivedInitArgs.message, "realAppData", "appData in site configuration have been overridden by extra initArgs parameters.");
+            this.end();
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/modules/CustomRootModule.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/modules/CustomRootModule.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.CustomRootModule",
+    $extends : "aria.pageEngine.SiteRootModule",
+    $constructor : function (args) {
+        this._testData = args.testData;
+        this.$SiteRootModule.$constructor.call(this);
+    },
+    $prototype : {
+
+        init : function (initArgs, cb) {
+            this._testData.receivedInitArgs.message = initArgs.appData.message;
+            this._testData.receivedInitArgs.further = initArgs.further;
+            this.$SiteRootModule.init.apply(this, arguments);
+        },
+
+        onSubModuleEvent : function (evt) {
+            if (evt.name == "modulePageReady") {
+                this._testData.eventLogs.push(evt.id);
+            }
+            this.$SiteRootModule.onSubModuleEvent.apply(this, arguments);
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/modules/ITestModule.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/modules/ITestModule.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.interfaceDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.ITestModule",
+    $extends : "aria.templates.IModuleCtrl",
+    $events : {
+        "modulePageReady" : "Event raised when a pageReady event is raised from the pageEngine"
+    }
+});

--- a/test/aria/pageEngine/pageEngine/customRootModule/modules/TestModule.js
+++ b/test/aria/pageEngine/pageEngine/customRootModule/modules/TestModule.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.customRootModule.modules.TestModule",
+    $extends : "aria.templates.ModuleCtrl",
+    $implements : ["test.aria.pageEngine.pageEngine.customRootModule.modules.ITestModule"],
+    $destructor : function () {
+        this.pageEngine.$unregisterListeners(this);
+        this.pageEngine = null;
+        this.$ModuleCtrl.$destructor.call(this);
+    },
+    $prototype : {
+
+        $publicInterfaceName : "test.aria.pageEngine.pageEngine.customRootModule.modules.ITestModule",
+
+        init : function (initArgs, cb) {
+            this.pageEngine = initArgs.pageEngine;
+            this.pageEngine.$addListeners({
+                "pageReady" : this._raisePageEvent,
+                scope : this
+            });
+
+            this.id = initArgs.id;
+            this.$callback(cb);
+        },
+
+        _raisePageEvent : function () {
+            this.$raiseEvent({
+                name : "modulePageReady",
+                id : this.id
+            });
+        }
+    }
+});


### PR DESCRIPTION
This commit introduces the possibility to customize the site root module in a page engine-based application.
The configuration of the module has to be given as an argument of the start method of the page engine class. It has to extend `aria.pageEngine.SiteRootModule` controller.
