### PR TITLE
fix #1113 widget verticalAlign is not applied to its label

### DIFF
--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -266,7 +266,7 @@ Aria.classDefinition({
 
             // PTR04951216 skinnable labels
             var cssClass = 'class="x' + this._skinnableClass + '_' + cfg.sclass + '_' + this._state + '_label"';
-            var IE7Align = aria.core.Browser.isIE7 ? "-25%" : "middle";
+            var IE7Align = aria.core.Browser.isIE7 ? "-25%" : (cfg.verticalAlign) ? cfg.verticalAlign : "middle";
             out.write('<label ' + cssClass + ' style="');
             if (!aria.widgets.environment.WidgetSettings.getWidgetSettings().middleAlignment) {
                 out.write('vertical-align:-1px;');

--- a/test/aria/widgets/verticalAlign/VerticalAlignTestCase.js
+++ b/test/aria/widgets/verticalAlign/VerticalAlignTestCase.js
@@ -41,7 +41,7 @@ Aria.classDefinition({
             this.compare();
         },
 
-        compare : function (expectedResult) {
+        compare : function () {
             var document = Aria.$window.document;
             // Select the divs to compare
             var found = document.getElementsByTagName("div");
@@ -54,30 +54,38 @@ Aria.classDefinition({
 
             for (var i = 0, ii = divs.length; i < ii; i++) {
                 var div = divs[i];
-                //var left = div.offsetLeft;
+                // var left = div.offsetLeft;
                 var top = div.offsetTop;
-                //var width = div.offsetWidth;
+                // var width = div.offsetWidth;
                 var height = div.offsetHeight;
                 var middlePosition = height / 2;
 
                 var widgets = this.getElementsByClassName(div, "xWidget");
 
                 // Check that every widget are centered
-                for(var j = 0, jj = widgets.length; j < jj; j++) {
+                for (var j = 0, jj = widgets.length; j < jj; j++) {
                     var widget = widgets[j];
                     // Check only the direct children of a line
                     if (widget.parentNode === div) {
                         if (widget.style.verticalAlign == "bottom") {
                             var offsetBottom = Math.abs(height - (widget.offsetTop + widget.offsetHeight));
-                            this.assertTrue(offsetBottom < 4, "Widget " + j + " in line " + i + " is not bottom aligned");
+                            this.assertTrue(offsetBottom < 4, "Widget " + j + " in line " + i
+                                    + " is not bottom aligned");
+                            var labelContent = widget.textContent || widget.innerText;
+                            if (labelContent === "email address") {
+                                var labelBottom = Math.abs(widget.offsetHeight
+                                        - (widget.firstChild.offsetTop + widget.firstChild.offsetHeight));
+                                this.assertTrue(labelBottom === 0, "Widget label " + j + " in line " + i
+                                        + " is not bottom aligned");
+                            }
                         } else {
                             var offsetMiddle = Math.abs(middlePosition - (widget.offsetTop + widget.offsetHeight / 2));
-                            this.assertTrue(offsetMiddle < 2, "Widget " + j + " in line " + i + " is not vertical aligned");
+                            this.assertTrue(offsetMiddle < 2, "Widget " + j + " in line " + i
+                                    + " is not vertical aligned");
                         }
                     }
                 }
-           }
-
+            }
             this.notifyTemplateTestEnd();
         }
     }

--- a/test/aria/widgets/verticalAlign/VerticalAlignTestCaseTpl.tpl
+++ b/test/aria/widgets/verticalAlign/VerticalAlignTestCaseTpl.tpl
@@ -38,7 +38,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:Select {
 				id: "mySelect1",
@@ -61,7 +62,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:MultiSelect {
 				activateSort: true,
@@ -82,7 +84,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:AutoComplete {
 				id: "acDest",
@@ -108,7 +111,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:Button {label:"Button"} /}
 		</div><br />
@@ -116,7 +120,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:Gauge {
 					minValue: -100,
@@ -129,7 +134,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:DateField {
 				label:"DateField: ",
@@ -142,7 +148,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:DatePicker {
 				label: "DatePicker: "
@@ -152,7 +159,8 @@
 			{@aria:TextField {
 				label:"email address",
 				labelAlign:"left",
-				helptext:"Textfield "
+				helptext:"Textfield ",
+				verticalAlign: "bottom"
 			}/}
 			{@aria:CheckBox {
 					label: "Checkbox 1 "


### PR DESCRIPTION
Fixes a bug for a widget label when using a <code>verticalAlign</code> property on a widget.
