### PR TITLE
atskin issue with MultiSelect in normalErrorFocused state.

### DIFF
--- a/src/aria/css/atskin.js
+++ b/src/aria/css/atskin.js
@@ -114,7 +114,7 @@ Aria.classDefinition({
                         normalErrorFocused : {
                             sprIdx : 4,
                             icons : {
-                                dropdown : "dropdown::multiselect_error"
+                                dropdown : "dropdown:multiselect_error"
                             }
                         },
                         mandatory : {


### PR DESCRIPTION
This PR fixes an issue for the MultiSelect in the `atskin` skin.
When the MultiSelect is in the error state, if it is focused, the following JavaScript error is thrown:
error in aria.widgets.frames.FrameWithIcons, method: _computeIconSize: ICON_NOT_FOUND

The issue comes from an extra colon in the name of the icon.
