### PR TITLE
History `onpopstate` event has been renamed to `popstate`

### DIFF
--- a/src/aria/utils/History.js
+++ b/src/aria/utils/History.js
@@ -170,12 +170,13 @@
             this._dispose();
         },
         $events : {
-            "onpopstate" : {
+            "popstate" : {
                 description : "Notify window when a state is popped and raise this event",
                 properties : {
                     state : "The state that has been popped."
                 }
-            }
+            },
+            "onpopstate" : "Alias to the standard html5 `popstate` event"
         },
         $prototype : {
 
@@ -480,6 +481,10 @@
                 }
                 this.$raiseEvent({
                     name : "onpopstate",
+                    state : state
+                });
+                this.$raiseEvent({
+                    name : "popstate",
                     state : state
                 });
             },

--- a/test/aria/utils/History.js
+++ b/test/aria/utils/History.js
@@ -102,7 +102,7 @@
             startTest : function () {
                 this._history = this._newWindow.aria.utils.History;
                 this._history.$on({
-                    "onpopstate" : this._onpopstateCB
+                    "popstate" : this._onpopstateCB
                 });
                 this._checkState(null);// 2
                 this._checkTitle("HistoryTest");// 4


### PR DESCRIPTION
This change has been done to be more compliant with the standard HTML5 spec.
Both events are still present, and both of them are fired when needed.
Tests have been updated to only use the more standard one.
