### PR TITLE
fix #1121 MAC with expand button: preselect property not working correctly

### DIFF
--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -168,7 +168,7 @@ Aria.classDefinition({
                 maxHeight : maxHeight,
                 minWidth : "minWidth" in options ? options.minWidth : defaultMinWidth,
                 width : this.__computeListWidth(cfg.popupWidth, defaultMinWidth),
-                preselect : cfg.preselect,
+                preselect : options.preselect || cfg.preselect,
                 bind : {
                     items : {
                         to : "listContent",

--- a/src/aria/widgets/form/MultiAutoComplete.js
+++ b/src/aria/widgets/form/MultiAutoComplete.js
@@ -131,6 +131,7 @@ Aria.classDefinition({
             };
 
             if (this.controller._isExpanded) {
+                options.preselect = "none";
                 options.defaultTemplate = this.controller.getExpandoTemplate();
                 options.maxOptions = (this.controller.maxOptions) ? this.__returnMaxCount() : null;
                 options.onchange = {

--- a/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -19,6 +19,7 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.widgets.form.multiautocomplete.preselectExpandButton.PreselectExpandButtonTestCase");
         this.addTests("test.aria.widgets.form.multiautocomplete.test1.MultiAutoAdd");
         this.addTests("test.aria.widgets.form.multiautocomplete.test2.MultiAutoRemove");
         this.addTests("test.aria.widgets.form.multiautocomplete.test3.MultiAutoDataCheck");

--- a/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTestCase.js
+++ b/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTestCase.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiautocomplete.preselectExpandButton.PreselectExpandButtonTestCase",
+    $extends : "test.aria.widgets.form.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+        this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
+
+        // setTestEnv has to be invoked before runTemplateTest fires
+        this.setTestEnv({
+            template : "test.aria.widgets.form.multiautocomplete.preselectExpandButton.PreselectExpandButtonTpl",
+            data : this.data
+        });
+
+    },
+    $prototype : {
+        /**
+         * This test is here to be sure that when preselect is 'always' and there is no value in the input field, then
+         * when expanded the first item is NOT selected.
+         */
+        runTemplateTest : function (id, continueWith) {
+            this.clickAndType(["[down]"], {
+                fn : this._afterType,
+                scope : this
+            });
+        },
+
+        _afterType : function (evt, args) {
+            this.waitFor({
+                condition : function () {
+                    return this.isMultiAutoCompleteOpen("MultiAutoId");
+                },
+                callback : this._checkValues
+            });
+        },
+
+        _checkValues : function (evt, args) {
+            this.assertFalse(this.getCheckBox('MultiAutoId', 0)._isChecked(), 'The first checkbox should not be checked.');
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTpl.tpl
+++ b/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTpl.tpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.form.multiautocomplete.preselectExpandButton.PreselectExpandButtonTpl",
+    $hasScript:true
+}}
+
+    {macro main()}
+
+         <h2>AutoComplete with Multi Options</h2>
+         <br />
+         {@aria:MultiAutoComplete {
+              id:"MultiAutoId",
+              resourcesHandler :getAirLinesHandler(),
+              freeText : true,
+              validationEvent : "onError",
+              autoFill: true,
+              autoselect: true,
+              preselect: 'always',
+              expandButton: true,
+              bind:{
+                "value" : {
+                    inside : data,
+                    to : 'ac_airline_values'
+                }
+              }
+         }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTplScript.js
+++ b/test/aria/widgets/form/multiautocomplete/preselectExpandButton/PreselectExpandButtonTplScript.js
@@ -1,0 +1,31 @@
+/**
+ * Script for the autocomplete sample
+ * @class samples.widgets.form.templates.AutoCompleteSampleScript
+ */
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.multiautocomplete.preselectExpandButton.PreselectExpandButtonTplScript',
+    $dependencies : ['aria.resources.handlers.LCRangeResourceHandler'],
+    $constructor : function () {
+
+        this._airLineHandler = new aria.resources.handlers.LCRangeResourceHandler();
+        this._airLineHandler.setSuggestions([{
+                    label : 'Air France',
+                    code : 'A1'
+                }, {
+                    label : 'Air France 2',
+                    code : 'A2'
+                }, {
+                    label : 'Finnair',
+                    code : 'XX'
+                }]);
+    },
+    $destructor : function () {
+        this._airLineHandler.$dispose();
+        this._airLineHandler = null;
+    },
+    $prototype : {
+        getAirLinesHandler : function () {
+            return this._airLineHandler;
+        }
+    }
+});


### PR DESCRIPTION
When using a MultiAutoComplete with expand button, it is now possible to use <code>preselect: 'always'</code> without the first element always being checked.
