### PR TITLE
feat #1132 Add env. parameter for escapeforhtml

### DIFF
--- a/src/aria/core/environment/Environment.js
+++ b/src/aria/core/environment/Environment.js
@@ -179,6 +179,35 @@ Aria.classDefinition({
                 return true;
             }
             return false;
+        },
+
+        /**
+         * Turn on or off auto-escaping of HTML in statements
+         * @public
+         * @param {Boolean} escape
+         */
+        setEscapeHtmlByDefault : function (escape) {
+            var currentValue = this.hasEscapeHtmlByDefault();
+            if (currentValue !== escape && (escape === true || escape === false)) {
+                aria.core.AppEnvironment.setEnvironment({
+                    "templateSettings" : {
+                        "escapeHtmlByDefault" : escape
+                    }
+                }, null, true);
+            }
+        },
+
+        /**
+         * Return true if auto-escaping of HTML is enabled.
+         * @public
+         * @return {Boolean}
+         */
+        hasEscapeHtmlByDefault : function () {
+            var settings = this.checkApplicationSettings("templateSettings");
+            if (settings && settings.escapeHtmlByDefault) {
+                return true;
+            }
+            return false;
         }
     }
 });

--- a/src/aria/core/environment/EnvironmentBaseCfgBeans.js
+++ b/src/aria/core/environment/EnvironmentBaseCfgBeans.js
@@ -42,6 +42,12 @@ Aria.beanDefinitions({
                         "primaryLanguage" : "en",
                         "region" : "US"
                     }
+                },
+
+                "templateSettings" : {
+                    $type : "TemplateSettingsCfg",
+                    $description : "Default templating engine settings",
+                    $default : {}
                 }
             }
         },
@@ -82,6 +88,18 @@ Aria.beanDefinitions({
                 }
             }
 
+        },
+
+        "TemplateSettingsCfg" : {
+            $type : "json:Object",
+            $description : "",
+            $properties : {
+                "escapeHtmlByDefault" : {
+                    $type : "json:Boolean",
+                    $description : "Indicates if markup should be automatically escaped in ${} statements",
+                    $default : true
+                }
+            }
         },
 
         "FormatTypes" : {

--- a/src/aria/templates/Statements.js
+++ b/src/aria/templates/Statements.js
@@ -106,7 +106,8 @@ Aria.classDefinition({
 
                     var escapeModifierName = classGenerator.escapeModifier; // Gets the actual name of the modifier in this context
 
-                    if (escapeModifierName != null) {
+                    var escapeHtmlByDefault = aria.core.environment.Environment.hasEscapeHtmlByDefault();
+                    if (escapeHtmlByDefault && escapeModifierName != null) {
                         escapeModifierName = escapeModifierName.toLowerCase();
 
                         if (parts[parts.length - 1].toLowerCase().indexOf(escapeModifierName) < 0) {

--- a/test/aria/core/environment/Environment.js
+++ b/test/aria/core/environment/Environment.js
@@ -136,6 +136,23 @@ Aria.classDefinition({
             this.assertFalse(dev);
         },
 
+        testHasEscapeHtmlByDefault : function () {
+            aria.core.AppEnvironment.setEnvironment({
+                "templateSettings" : {
+                    "hasEscapeHtml" : true
+                }
+            }, null, true);
+            var escape = aria.core.environment.Environment.hasEscapeHtmlByDefault();
+            this.assertTrue(escape);
+        },
+
+        testSetEscapeHtmlByDefault : function () {
+            aria.core.environment.Environment.setEscapeHtmlByDefault(false);
+            var escape = aria.core.environment.Environment.hasEscapeHtmlByDefault();
+            this.assertFalse(escape);
+        },
+
+
         testAsyncSettingsPreservedAfterCustomizationEnabled : function () {
             // make sure the class is not loaded - clue of this test
             if (aria.core.environment.Customizations) {


### PR DESCRIPTION
- added templateSettings in EnvironmentSettings
- added hasEscapeHtmlByDefault and setEscapeHtmlByDefault to Environment
- modified Statements.js to check this parameter
- added tests

! I still need to update ExpressionEscapeTest , but if someone can have a look and let me know if you're fine with the gist of the change that'd be great.
