### PR TITLE
fix #08364518 loading indicator scroll issue in IE8-

### DIFF
--- a/src/aria/utils/Event.js
+++ b/src/aria/utils/Event.js
@@ -98,6 +98,52 @@
             },
 
             /**
+             * Appends an event handler to the given element and its ancestors
+             * @param {HTMLElement} element an element reference to assign the listener to.
+             * @param {String} event The type of event to append
+             * @param {aria.utils.Callback|Object} callback The method the event invokes, if callback is of type Object
+             * fn property is mandatory. <strong>Note that callback parameter cannot be a function - the form { fn :
+             * {Function}, scope: {Object}, args : {MultiTypes}} is preferred for this callback</strong>
+             * @param {Boolean} useCapture capture or bubble phase
+             * @param {Function} filterFunction function used to select HTML elements to append the listener to (it
+             * selects all the elements if the function is not provided)
+             * @return {Boolean} True if at least one listener was added, false otherwise.
+             */
+            addListenerRecursivelyUp : function (element, event, callback, useCapture, filterFunction) {
+                var added = false;
+                var parent = element.parentElement || element.parentNode; // Fx < 9 compat
+                while (parent != null) {
+                    if (!filterFunction || filterFunction(parent)) {
+                        added = this.addListener(parent, event, callback, useCapture) || added;
+                    }
+                    parent = parent.parentElement || parent.parentNode; // Fx < 9 compat
+                }
+                return added;
+            },
+
+            /**
+             * Removes an event handler to every ancestor of the given element
+             * @param {HTMLElement} element an element reference to remove the listener from.
+             * @param {String} event The type of event to remove
+             * @param {aria.utils.Callback|Object} callback The method the event invokes, if callback is undefined, then
+             * all event handlers for the type of event are removed.
+             * @param {Function} filterFunction function used to select HTML elements to remove the listener from (it
+             * selects all the elements if the function is not provided)
+             * @return {Boolean} True if at least one listener was removed, false otherwise.
+             */
+            removeListenerRecursivelyUp : function (element, event, callback, filterFunction) {
+                var removed = false;
+                var parent = element.parentElement || element.parentNode; // Fx < 9 compat
+                while (parent != null) {
+                    if (!filterFunction || filterFunction(parent)) {
+                        removed = this.removeListener(parent, event, callback) || removed;
+                    }
+                    parent = parent.parentElement || parent.parentNode; // Fx < 9 compat
+                }
+                return removed;
+            },
+
+            /**
              * Appends an event handler
              * @param {String|HTMLElement|Array} element An id, an element reference, or a collection of ids and/or
              * elements to assign the listener to.

--- a/test/aria/utils/overlay/OverlayTestSuite.js
+++ b/test/aria/utils/overlay/OverlayTestSuite.js
@@ -25,5 +25,6 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.overlay.loadingIndicator.zindex.IndexTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.refresh.RefreshTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest");
+        this.addTests("test.aria.utils.overlay.loadingIndicator.ieScrollIssue.IEScrollIssueTest");
     }
 });

--- a/test/aria/utils/overlay/loadingIndicator/ieScrollIssue/IEScrollIssueTest.js
+++ b/test/aria/utils/overlay/loadingIndicator/ieScrollIssue/IEScrollIssueTest.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.utils.overlay.loadingIndicator.ieScrollIssue.IEScrollIssueTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            template : "test.aria.utils.overlay.loadingIndicator.ieScrollIssue.TestTemplate",
+            iframe : true
+        });
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            this.scrollList = [80, 30, 130];
+            this.index = 0;
+            this.domElt = this.getElementById("mySpan");
+            this.domEltWrapper = this.templateCtxt.$getElementById("mySpan");
+            this.container = this.templateCtxt.$getElementById("container");
+
+            this.domEltWrapper.setProcessingIndicator(true, "*** Loading span content...");
+            this.overlay = this._getOverlay();
+            this.overlayElt = this.overlay.overlay;
+
+            this._checkSameGeometry();
+
+            this._scrollAndCheck();
+        },
+
+        _scrollAndCheck : function () {
+            if (this.index < this.scrollList.length) {
+                this.container.setScroll({
+                    scrollTop : this.scrollList[this.index]
+                });
+                this.index++;
+                this._checkAndCallback(this._scrollAndCheck);
+            } else {
+
+                this.domEltWrapper.setProcessingIndicator(false);
+
+                this.executed = false;
+
+                var that = this;
+                var refreshFn = this.overlay.refreshPosition;
+
+                this.testWindow.aria.utils.overlay.Overlay.prototype.refreshPosition = function () {
+                    that.executed = true;
+                    return refreshFn.apply(this, arguments);
+                };
+
+                this.domEltWrapper.setProcessingIndicator(true, "*** Loding span content...");
+
+                this.container.setScroll({
+                    scrollTop : 91
+                });
+
+                aria.core.Timer.addCallback({
+                    fn : this._checkCnt1,
+                    scope : this,
+                    delay : 100
+                });
+
+            }
+        },
+
+        _checkCnt1 : function () {
+            this.assertTrue(this.executed, "refresh callback not executed");
+            this.executed = false;
+            this.domEltWrapper.setProcessingIndicator(false);
+
+            this.container.setScroll({
+                scrollTop : 201
+            });
+
+            aria.core.Timer.addCallback({
+                fn : this._checkCnt2,
+                scope : this,
+                delay : 100
+            });
+        },
+
+        _checkCnt2 : function () {
+            this.assertFalse(this.executed, "refresh callback executed after overlay detach");
+            this.end();
+        },
+
+        _checkAndCallback : function (fn) {
+            // timeout is necessary because onscroll function execution is async
+            aria.core.Timer.addCallback({
+                fn : this._checkSameGeometry,
+                scope : this,
+                delay : 100,
+                args : {
+                    fn : fn
+                }
+            });
+        },
+
+        _checkSameGeometry : function (arg) {
+            var geoElt = this.testWindow.aria.utils.Dom.getGeometry(this.domElt);
+            var geoOvl = this.testWindow.aria.utils.Dom.getGeometry(this.overlayElt);
+            var json = aria.utils.Json;
+            this.assertJsonEquals(geoElt, geoOvl, "Overlay and element geometry are different: overlay=" + json.convertToJsonString(geoOvl) + ", element=" + json.convertToJsonString(geoElt));
+            if (arg) {
+                aria.core.Timer.addCallback({
+                    fn : arg.fn,
+                    scope : this
+                });
+            }
+        },
+
+        _getOverlay : function () {
+            var overlays = this.testWindow.aria.utils.DomOverlay.overlays;
+            var keys = aria.utils.Object.keys(overlays);
+            return overlays[keys[0]];
+        }
+
+    }
+});

--- a/test/aria/utils/overlay/loadingIndicator/ieScrollIssue/TestTemplate.tpl
+++ b/test/aria/utils/overlay/loadingIndicator/ieScrollIssue/TestTemplate.tpl
@@ -1,0 +1,15 @@
+{Template {
+    $classpath : "test.aria.utils.overlay.loadingIndicator.ieScrollIssue.TestTemplate"
+}}
+
+    {macro main()}
+    <div {id "container" /} style="height:350px; width:400px; background-color:green; overflow:scroll">
+        <div {id "mySpan" /} style="height: 200px; width: 200px; background-color: blue;" >to be updated</div>
+        <div id="testDiv1" style="height:500px; width:50px; background-color:red" >
+        </div>
+    </div>
+
+    {/macro}
+
+
+{/Template}


### PR DESCRIPTION
In IE8 and IE7 the scroll event does not bubble up, so the loading indicator refresh is not triggered when the user scrolls a view inside a container.
This fix registers listeners on the ancestors of the overlayed element (only for IE8 and below), and adds 2 new util methods in aria.utils.Event
