### PR TITLE
fix #1126 MultiAutoComplete: Datamodel issue when entering rangevalues twice

### DIFF
--- a/src/aria/widgets/controllers/MultiAutoCompleteController.js
+++ b/src/aria/widgets/controllers/MultiAutoCompleteController.js
@@ -101,11 +101,7 @@
                     if (this.freeText) {
                         report.ok = true;
                         var valueToAdd;
-                        if (dataModel.text == trimText) {
-                            valueToAdd = dataModel.value;
-                        } else {
-                            valueToAdd = trimText;
-                        }
+                        valueToAdd = dataModel.value || trimText;
                         dataModel.value = null;
                         dataModel.text = '';
                         report.text = "";
@@ -351,7 +347,7 @@
                         }
                         jsonUtils.setValue(dataModel, 'multipleSelect', true);
                         jsonUtils.setValue(dataModel, 'selectedValues', selectedValues);
-                        dataModel.value = selectedValues;
+                        dataModel.value = selectedValues.length > 0 ? selectedValues : null;
                     } else if (allSuggestions) {
                         var selectedValues = [];
                         for (var i = 0; i < dataModel.listContent.length; i++) {

--- a/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/multiautocomplete/MultiAutoCompleteTestSuite.js
@@ -53,5 +53,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.multiautocomplete.popupGeometry.PopupLeftPositionTest");
         this.addTests("test.aria.widgets.form.multiautocomplete.popupGeometry.PopupTopPositionTest");
         this.addTests("test.aria.widgets.form.multiautocomplete.preselectAutofill.PreselectAutofillTestSuite");
+        this.addTests("test.aria.widgets.form.multiautocomplete.testDMOnFreetext.MultiAutoDataModelTest");
     }
 });

--- a/test/aria/widgets/form/multiautocomplete/testDMOnFreetext/MultiAutoDataModelTest.js
+++ b/test/aria/widgets/form/multiautocomplete/testDMOnFreetext/MultiAutoDataModelTest.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiautocomplete.testDMOnFreetext.MultiAutoDataModelTest",
+    $extends : "test.aria.widgets.form.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $constructor : function () {
+
+        this.data = {
+            ac_airline_values : ["India", "Singapore"],
+            freeText : true
+        };
+        this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
+
+    },
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            // initial test for all the suggestions added
+            this.checkSelectedItems(2);
+            this.clickAndType(["p1-3", "[enter]"], {
+                fn : this._afterFirstEnter,
+                scope : this
+            }, 800);
+        },
+        _afterFirstEnter : function () {
+            this.checkSelectedItems(5, ["India", "Singapore", "P1.some", "P2.kon", "P3.red"]);
+            this.checkDataModel(5, ["India", "Singapore", {
+                        label : 'P1.some',
+                        code : 'P1'
+                    }, {
+                        label : 'P2.kon',
+                        code : 'P2'
+                    }, {
+                        label : 'P3.red',
+                        code : 'P3'
+                    }]);
+
+            this.clickAndType(["p1-3", "[enter]"], {
+                fn : this._afterSecondEnter,
+                scope : this
+            }, 800);
+        },
+        _afterSecondEnter : function () {
+            this.checkSelectedItems(6, ["India", "Singapore", "P1.some", "P2.kon", "P3.red", "p1-3"]);
+            this.checkDataModel(6, ["India", "Singapore", {
+                        label : 'P1.some',
+                        code : 'P1'
+                    }, {
+                        label : 'P2.kon',
+                        code : 'P2'
+                    }, {
+                        label : 'P3.red',
+                        code : 'P3'
+                    }, "p1-3"]);
+            this.end();
+        }
+    }
+});


### PR DESCRIPTION
This pull request fixes the datamodel issue for MAC widget when freeText is true and entering rangevalues twice.
