### PR TITLE
fix #1139 DomTestCase fail in Firefox

### DIFF
--- a/test/aria/dom/basic/DomTestCase.js
+++ b/test/aria/dom/basic/DomTestCase.js
@@ -25,7 +25,8 @@ Aria.classDefinition({
         this.$TemplateTestCase.constructor.call(this);
 
         this.setTestEnv({
-            template : "test.aria.dom.basic.BigPage"
+            template : "test.aria.dom.basic.BigPage",
+            css : "font-family:Tahoma,Verdana,sans-serif"
         });
     },
     $prototype : {
@@ -74,7 +75,7 @@ Aria.classDefinition({
             var viewport = aria.utils.Dom._getViewportSize();
 
             // Should be bigger equal to the viewport
-            this.assertTrue(size.width === viewport.width, "Page width should be viewport width.");
+            this.assertEquals(size.width, viewport.width, "Page width should be viewport width.");
             // This assertion cannot be proved, the tester adds something in the page that makes it long
             // this.assertTrue(size.height === viewport.height);
 
@@ -97,8 +98,8 @@ Aria.classDefinition({
 
             this.assertTrue(geo.x < 30, "d1: Expected x < 30, got " + geo.x);
             this.assertTrue(geo.y < 30, "d1: Expected y < 30, got " + geo.y);
-            this.assertTrue(geo.width === 100, "d1: Expected width equal to 100, got " + geo.width);
-            this.assertTrue(geo.height === 100, "d1: Expected height equal to 100, got " + geo.height);
+            this.assertEquals(geo.width, 100, "d1: Expected width equal to 100, got " + geo.width);
+            this.assertEquals(geo.height, 100, "d1: Expected height equal to 100, got " + geo.height);
 
             // Geometry of the second div
             div = this.getElementById("d2");
@@ -106,8 +107,8 @@ Aria.classDefinition({
 
             this.assertTrue(geo.x < 30, "d2: Expected x < 30, got " + geo.x);
             this.assertTrue(geo.y >= 100, "d2: Expected y >= 100, got " + geo.y);
-            this.assertTrue(geo.width === 100, "d2: Expected width equal to 100, got " + geo.width);
-            this.assertTrue(geo.height === 100, "d2: Expected height equal to 100, got " + geo.height);
+            this.assertEquals(geo.width, 100, "d2: Expected width equal to 100, got " + geo.width);
+            this.assertEquals(geo.height, 100, "d2: Expected height equal to 100, got " + geo.height);
 
             // Geometry of the span
             span = this.getElementById("s1");
@@ -119,15 +120,11 @@ Aria.classDefinition({
 
             // On mac, webkit scrollbars are not visualized without scrolling
             if (aria.core.Browser.isMac && aria.core.Browser.isWebkit) {
-                this.assertTrue(geo.width == 100, "s1: Expected width == 100, got "
-                    + geo.width);
-                this.assertTrue(geo.height == 100, "s1: Expected height == 100, got "
-                    + geo.height);
+                this.assertEquals(geo.width, 100, "s1: Expected width == 100, got %1");
+                this.assertEquals(geo.height, 100, "s1: Expected height == 100, got %1");
             } else {
-                this.assertTrue(geo.width == (100 - scrollbarsWidth), "s1: Expected width == 100 - scollbarsWidth, got "
-                    + geo.width);
-                this.assertTrue(geo.height == (100 - scrollbarsWidth), "s1: Expected height == 100 - scollbarsWidth, got "
-                    + geo.height);
+                this.assertEquals(geo.width, (100 - scrollbarsWidth), "s1: Expected width == %2, got %1");
+                this.assertEquals(geo.height, (100 - scrollbarsWidth), "s1: Expected height == %2, got %1");
             }
 
             // End of test


### PR DESCRIPTION
There's a 0.5px (in this particular scenario) discrepancy in calculations in
Dom.getGeometry method which stems from a quirk in some browsers for
inline containers, for certain font face (Arial, Times New Roman) with
line-height:normal which is a CSS default.

For inline container, it's top position with respect to the parent depends
on the line-height value. For line-height normal, for most of the fonts,
that distance is zero. However for some fonts in some browsers (Firefox,
Chrome abover certain threshold) the computer value of line-height makes
this top position being > 0 and some computations fail later due to that.

This commit just changes the default font for the test. The test started
failing in 1.5.3 after change of the skin from atdefskin to atskin which
removed setting of a default font.

Proper workaround for the issue would require substantial changes to
Dom.getGeometry().

See https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
