### PR TITLE
fix scroll event issue

### DIFF
--- a/src/aria/utils/DomOverlay.js
+++ b/src/aria/utils/DomOverlay.js
@@ -73,13 +73,11 @@ Aria.classDefinition({
                 // fix 08364518 : if IE<9, the scroll event on an element does not bubble up and trigger the handler
                 // attached to the window
                 this._noBubbleEvent = (browser.isIE8 || browser.isIE7 || browser.isIE6);
-                if (!this._noBubbleEvent) {
-                    // Listen for scroll event to update the position of the overlay
-                    aria.utils.Event.addListener(Aria.$window, "scroll", {
-                        fn : this.__refresh,
-                        scope : this
-                    }, true);
-                }
+                // Listen for scroll event to update the position of the overlay
+                aria.utils.Event.addListener(Aria.$window, "scroll", {
+                    fn : this.__refresh,
+                    scope : this
+                }, true);
                 aria.templates.Layout.$on({
                     "viewportResized" : this.__refresh,
                     scope : this


### PR DESCRIPTION
for IE8, scroll event is not triggered on #document, but only on window (other browsers work differently)
http://www.quirksmode.org/dom/events/tests/scroll.html
