### PR TITLE
fix #1147 set lower timeout for test cases

### DIFF
--- a/src/aria/jsunit/TestCase.js
+++ b/src/aria/jsunit/TestCase.js
@@ -27,10 +27,9 @@ Aria.classDefinition({
     $classpath : "aria.jsunit.TestCase",
     $extends : "aria.jsunit.Assert",
     $dependencies : ["aria.core.Sequencer", "aria.utils.Json", "aria.utils.Type", "aria.utils.Object",
-            "aria.utils.Array"],
+            "aria.utils.Array", "aria.core.Browser"],
     $statics : {
-        // some tests run slower on IE when they are in a suite
-        "defaultTestTimeout" : 60000,
+        "defaultTestTimeout" : aria.core.Browser.isIE7 ? 30000 : 20000,
 
         IFRAME_BASE_CSS_TEXT : "position:fixed;top:20px;left:20px;z-index:10000;width:1000px;height:700px;border:1px solid blue;background:aliceblue;opacity:0.8;-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';filter: alpha(opacity=80);",
 

--- a/test/aria/widgets/container/splitter/move/SplitterTestMoveLeftRight.js
+++ b/test/aria/widgets/container/splitter/move/SplitterTestMoveLeftRight.js
@@ -19,9 +19,14 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.container.splitter.move.SplitterTestMoveLeftRight",
     $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.core.Browser"],
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
-        this.defaultTestTimeout = aria.core.Browser.isSafari ? 150000 : 40000;
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isPhantomJS || aria.core.Browser.isSafari) {
+            this.defaultTestTimeout = 40000;
+        } else if (aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 30000;
+        }
     },
     $prototype : {
         // TODO change all those delays into waitFor({condition, callback})
@@ -92,7 +97,7 @@ Aria.classDefinition({
                 y : geometry.y + 100
             };
             var options = {
-                duration : 2500,
+                duration : 1000,
                 to : {
                     x : from.x + (args.destPosX),
                     y : from.y

--- a/test/aria/widgets/container/splitter/move/SplitterTestMoveUpDown.js
+++ b/test/aria/widgets/container/splitter/move/SplitterTestMoveUpDown.js
@@ -19,6 +19,15 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.container.splitter.move.SplitterTestMoveUpDown",
     $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.core.Browser"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isPhantomJS || aria.core.Browser.isSafari) {
+            this.defaultTestTimeout = 40000;
+        } else if (aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 30000;
+        }
+    },
     $prototype : {
         runTemplateTest : function () {
             aria.core.Timer.addCallback({
@@ -87,7 +96,7 @@ Aria.classDefinition({
                 y : geometry.y
             };
             var options = {
-                duration : 2500,
+                duration : 1000,
                 to : {
                     x : from.x,
                     y : from.y + (args.destPosY)

--- a/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
@@ -46,9 +46,12 @@ Aria.classDefinition({
     $classpath : "test.aria.widgets.form.autocomplete.preselectAutofill.PreselectAutofillBaseTest",
     $extends : "aria.jsunit.RobotTestCase",
     $dependencies : ["aria.popups.PopupManager", "aria.resources.handlers.LCResourcesHandler", "aria.utils.Array",
-            "aria.utils.Type"],
+            "aria.utils.Type", "aria.core.Browser"],
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
+        if (aria.core.Browser.isPhantomJS || aria.core.Browser.isIE7) {
+            this.defaultTestTimeout = 40000;
+        }
         this.resourcesHandler = this.resourcesHandler || new aria.resources.handlers.LCResourcesHandler();
         this.resourcesHandler.setSuggestions([{
                     label : "P2. TESTER B",

--- a/test/aria/widgets/form/autocomplete/typefast/AutoSelectTestCase.js
+++ b/test/aria/widgets/form/autocomplete/typefast/AutoSelectTestCase.js
@@ -26,8 +26,6 @@ Aria.classDefinition({
                 valueNoFill : ""
             }
         });
-
-        // this.defaultTestTimeout = 60000;
     },
     $prototype : {
         runTemplateTest : function () {

--- a/test/aria/widgets/form/datepicker/errorstate/DatePicker.js
+++ b/test/aria/widgets/form/datepicker/errorstate/DatePicker.js
@@ -16,8 +16,16 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.datepicker.errorstate.DatePicker",
     $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.core.Browser"],
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
+        // TODO this test is ridiculously long, split it
+        this.defaultTestTimeout = 40000;
+        if (aria.core.Browser.isIE7) {
+            this.defaultTestTimeout = 50000;
+        } else if (aria.core.Browser.isPhantomJS) {
+            this.defaultTestTimeout = 60000;
+        }
         this.setTestEnv({
             template : "test.aria.widgets.form.datepicker.errorstate.DatePickerTpl"
         });

--- a/test/aria/widgets/form/multiautocomplete/popupGeometry/PopupTopPositionTest.js
+++ b/test/aria/widgets/form/multiautocomplete/popupGeometry/PopupTopPositionTest.js
@@ -16,8 +16,12 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.multiautocomplete.popupGeometry.PopupTopPositionTest",
     $extends : "test.aria.widgets.form.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $dependencies : ["aria.core.Browser"],
     $constructor : function () {
         this.$BaseMultiAutoCompleteTestCase.$constructor.call(this);
+        if (aria.core.Browser.isIE7) {
+            this.defaultTestTimeout = 30000;
+        }
         this.data.expandButton = true;
     },
     $prototype : {

--- a/test/aria/widgets/form/multiautocomplete/test11/MultiAutoInvalidDataModel.js
+++ b/test/aria/widgets/form/multiautocomplete/test11/MultiAutoInvalidDataModel.js
@@ -16,9 +16,12 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.multiautocomplete.test11.MultiAutoInvalidDataModel",
     $extends : "test.aria.widgets.form.multiautocomplete.BaseMultiAutoCompleteTestCase",
+    $dependencies : ["aria.core.Browser"],
     $constructor : function () {
         this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
-
+        if (aria.core.Browser.isPhantomJS) {
+            this.defaultTestTimeout = 40000;
+        }
         this.data.freeText = false;
     },
     $prototype : {


### PR DESCRIPTION
TODO
- [x] check if timeouts are good enough for IE8

This commit changes default test timeout from 60s to 20s (30s on IE7) to give faster feedback to the developer.

Majority of our tests can run <10s, only a few tests require explicitly setting higher timeouts for some browsers (most notably IE7 and PhantomJS).

The rationale for the change is the long waiting time for results during release testing, since lots of tests, when run via attester, time out only after 60s, and the browser is idle for that time.
