### PR TITLE
fix #1148 disable npm spinner on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - npm install -g npm
   - npm --version
   - npm config set ca ""
+  - npm config set spin false
   - phantomjs --version
 script:
   - npm run ci


### PR DESCRIPTION
npm 1.4.11+ uses spinner (progress indicator) which messes with the output
of the test suite, making it less readable. There's no need for it during
Travis builds.

(you can see the output with spinner enabled e.g. [here](https://travis-ci.org/ariatemplates/ariatemplates/builds/26922151))
