### PR TITLE
Add jsdoc tags when needed

### DIFF
--- a/src/aria/core/ClassMgr.js
+++ b/src/aria/core/ClassMgr.js
@@ -21,6 +21,7 @@ var ariaCoreDownloadMgr = require("./DownloadMgr");
  * "TPL", "RES", "CSS", "TML" and "TXT"). Before loading a class, it is necessary to know its type (there is no naming
  * convention). This class uses the Cache object to store class definitions (through the DownloadMgr) and indicators
  * telling that a class is being downloaded.
+ * @dependencies ["aria.core.Cache", "aria.core.DownloadMgr"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.core.ClassMgr",

--- a/src/aria/core/DownloadMgr.js
+++ b/src/aria/core/DownloadMgr.js
@@ -19,6 +19,7 @@ var Aria = require("../Aria");
  * associated to the same physical URL, makes sure listeneres are associated to the same loader Manage logical path /
  * physical URL mapping (the same physical URL can be used for multiple logical paths in case of multipart (packaged)
  * files) thanks to the Url Map.
+ * @dependencies ["aria.core.Cache", "aria.utils.Json", "aria.utils.Type", "aria.core.FileLoader"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.core.DownloadMgr",

--- a/src/aria/core/FileLoader.js
+++ b/src/aria/core/FileLoader.js
@@ -15,6 +15,9 @@
 var Aria = require("../Aria");
 var ariaCoreCache = require("./Cache");
 
+/**
+ * @dependencies ["aria.core.Cache", "aria.core.IO", "aria.core.DownloadMgr"]
+ */
 module.exports = Aria.classDefinition({
     $classpath : "aria.core.FileLoader",
 

--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -20,6 +20,8 @@ var ariaUtilsJson = require("../utils/Json");
  * Connection manager class. Provides a way to make requests for different URI (file, XHR, XDR) and keeps a list of all
  * pending requests.
  * @singleton
+ * @dependencies ["aria.utils.Type", "aria.utils.Json", "aria.utils.json.JsonSerializer", "aria.core.Timer",
+ * "aria.utils.Array", "aria.utils.String"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.core.IO",

--- a/src/aria/core/Interfaces.js
+++ b/src/aria/core/Interfaces.js
@@ -214,6 +214,7 @@ var Aria = require("../Aria");
      * Singleton in charge of interface-related operations. It contains internal methods of the framework which should
      * not be called directly by the application developer.
      * @private
+     * @dependencies ["aria.utils.Type", "aria.core.JsonValidator"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.core.Interfaces",

--- a/src/aria/core/JsObject.js
+++ b/src/aria/core/JsObject.js
@@ -252,6 +252,7 @@ var Aria = require("../Aria");
 
     /**
      * Base class from which derive all JS classes defined through Aria.classDefinition()
+     * @dependencies ["aria.utils.String", "aria.core.Interfaces", "aria.utils.Type"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.core.JsObject",

--- a/src/aria/core/JsonValidator.js
+++ b/src/aria/core/JsonValidator.js
@@ -33,6 +33,7 @@ var Aria = require("../Aria");
      * Note: this class is tightly linked with JsonTypesCheck, to keep files with a reasonable size. Be carefull if
      * changing something: any protected method in this class (method whose name starts with one underscore) may be
      * called from JsonTypesCheck. Private methods (starting with two underscores) are not called from JsonTypesCheck.
+     * @dependencies ["aria.utils.Type", "aria.utils.Json", "aria.core.JsonTypesCheck"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.core.JsonValidator",
@@ -579,7 +580,8 @@ var Aria = require("../Aria");
 
             /**
              * Get a bean from its string reference.
-             * @param {String} strType The fully qualified bean name, ex: aria.widgets.calendar.CfgBeans.CalendarSettings
+             * @param {String} strType The fully qualified bean name, ex:
+             * aria.widgets.calendar.CfgBeans.CalendarSettings
              * @return {aria.core.BaseTypes:Bean} The bean definition if strType is valid, or null otherwise.
              */
             _getBean : function (strType) {

--- a/src/aria/core/ResMgr.js
+++ b/src/aria/core/ResMgr.js
@@ -50,6 +50,7 @@ var loadFile = function (logicalPath, args) {
 
 /**
  * Resources Manager. It keeps the list of loaded resources in order to reload them in case of locale change.
+ * @dependencies ["aria.core.environment.Environment", "aria.core.DownloadMgr"]
  */
 var resMgr = module.exports = Aria.classDefinition({
     $classpath : "aria.core.ResMgr",

--- a/src/aria/core/TplClassLoader.js
+++ b/src/aria/core/TplClassLoader.js
@@ -225,6 +225,8 @@ var ariaCoreJsonValidator = require("./JsonValidator");
 
     /**
      * ClassLoader for .tpl files.
+     * @extends aria.core.ClassLoader
+     * @dependencies ["aria.core.JsObject", "aria.core.Browser", "aria.core.JsonValidator"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.core.TplClassLoader",

--- a/src/aria/core/environment/Environment.js
+++ b/src/aria/core/environment/Environment.js
@@ -18,6 +18,8 @@ var ariaCoreAppEnvironment = require("../AppEnvironment");
 
 /**
  * Public API for retrieving, applying application variables.
+ * @extends aria.core.environment.EnvironmentBase
+ * @dependencies ["aria.core.environment.EnvironmentBaseCfgBeans", "aria.core.AppEnvironment"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.core.environment.Environment",

--- a/src/aria/ext/BundleAnalyzer.js
+++ b/src/aria/ext/BundleAnalyzer.js
@@ -33,6 +33,8 @@ var ariaCoreResMgr = require("../core/ResMgr");
  *     }
  * });
  * </pre>
+ *
+ * @dependencies ["aria.core.Cache", "aria.core.ResMgr"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.ext.BundleAnalyzer",

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -47,6 +47,9 @@ var ariaUtilsJson = require("../utils/Json");
 
     /**
      * Base class gathering all assertions used in Test case classes
+     * @extends aria.jsunit.Test
+     * @dependencies ["aria.core.Log", "aria.utils.Type", "aria.utils.String", "aria.utils.Json",
+     * "aria.core.log.SilentArrayAppender", "aria.core.log.DefaultAppender"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.jsunit.Assert",

--- a/src/aria/templates/CSSCtxtManager.js
+++ b/src/aria/templates/CSSCtxtManager.js
@@ -16,9 +16,7 @@ var Aria = require("../Aria");
 
 /**
  * List of active CSS templates loaded by Aria.loadTemplate
- * @class aria.templates.CSSCtxtManager
- * @extends aria.core.JsObject
- * @singleton
+ * @dependencies ["aria.templates.CSSCtxt"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.templates.CSSCtxtManager",

--- a/src/aria/templates/CSSTemplate.js
+++ b/src/aria/templates/CSSTemplate.js
@@ -20,8 +20,8 @@ require("./CSSMgr");
 
 /**
  * Base class from which all CSS templates inherit.
- * @class aria.templates.CSSTemplate
  * @extends aria.core.BaseTemplate
+ * @dependencies ["aria.templates.CSSMgr", "aria.core.DownloadMgr", "aria.templates.ICSS"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.templates.CSSTemplate",

--- a/src/aria/templates/Template.js
+++ b/src/aria/templates/Template.js
@@ -40,6 +40,9 @@ require("./$Template").load();
     /**
      * Base class from which all templates inherit. Some methods will be added to instances of this class, from the
      * TemplateCtxt class.
+     * @extends aria.templates.BaseTemplate
+     * @dependencies ["aria.utils.Array", "aria.tools.contextual.environment.ContextualMenu",
+     * "aria.core.AppEnvironment", "aria.templates.ITemplate", "aria.utils.environment.VisualFocus", "aria.utils.Json"]
      */
     module.exports = Aria.classDefinition({
         $classpath : "aria.templates.Template",

--- a/src/aria/utils/History.js
+++ b/src/aria/utils/History.js
@@ -70,6 +70,11 @@ var dynamicDependencies = require("./$History").getDependencies();
      */
     var hashManager = dynamicDependencies.hashManager;
 
+    /**
+     * Provides a cross-browser implementation of the history API. It uses native HTML5 History API when possible.
+     * @dependencies ["aria.utils.String", "aria.utils.Type", "aria.utils.Json", "aria.storage.LocalStorage",
+     * "aria.core.Browser", "aria.utils.Event"]
+     */
     module.exports = Aria.classDefinition({
         $classpath : "aria.utils.History",
         $singleton : true,

--- a/src/aria/utils/json/JsonSerializer.js
+++ b/src/aria/utils/json/JsonSerializer.js
@@ -16,6 +16,7 @@ var Aria = require("../../Aria");
 
 /**
  * Utility to convert data to a JSON string
+ * @dependencies ["aria.utils.Type", "aria.utils.Json"]
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.utils.json.JsonSerializer",


### PR DESCRIPTION
After the migration of the new syntax, some previously inferred documentation properties need to be explicitly declared.
The required declaration have been added to the classe that have already been migrated to the new syntax.
