### PR TITLE
Testing the packaged version instead of the unpackaged one

### DIFF
--- a/test/attester-packaged.yml
+++ b/test/attester-packaged.yml
@@ -10,6 +10,17 @@ tests:
     - /aria/css/atskin-<%= env.version %>.js
   classpaths:
    includes:
-    - test.aria.widgets.form.datepicker.pickdate.PickDate
-#Includes only a simple test in packaged mode, to check that the framework is correctly
-#loaded in packaged mode
+    - test.MainTestSuite
+   excludes:
+   #Excluded because PhantomJS does not support flash:
+    - test.aria.core.io.IOXDRTest
+   #Excluded because PhantomJS has random issues with history management:
+   # (to be investigated)
+    - test.aria.utils.History
+   #Excluded because PhantomJS has random issues with the viewport
+    - test.aria.widgets.container.dialog.scroll.OnScrollTestCase
+    - test.aria.widgets.container.dialog.resize.test3.DialogOnResizeTestCase
+    - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
+    - test.aria.widgets.container.dialog.indicators.DialogTestCase
+   #Excluded from this file but added in attester.yml (tests for the unpackaged version):
+    - test.aria.core.JsonValidatorTest

--- a/test/attester.yml
+++ b/test/attester.yml
@@ -10,15 +10,9 @@ tests:
     - /aria/css/atskin-<%= env.version %>.js
   classpaths:
    includes:
-    - test.MainTestSuite
-   excludes:
-   #Excluded because PhantomJS does not support flash:
-    - test.aria.core.io.IOXDRTest
-   #Excluded because PhantomJS has random issues with history management:
-   # (to be investigated)
-    - test.aria.utils.History
-   #Excluded because PhantomJS has random issues with the viewport
-    - test.aria.widgets.container.dialog.scroll.OnScrollTestCase
-    - test.aria.widgets.container.dialog.resize.test3.DialogOnResizeTestCase
-    - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
-    - test.aria.widgets.container.dialog.indicators.DialogTestCase
+#Includes only a simple template test in unpackaged mode, to check that the framework
+#can correctly load a template in unpackaged mode
+    - test.aria.widgets.form.datepicker.pickdate.PickDate
+#The following test does not work in packaged mode (because it tries to open a file from
+#the bootstrap, but it is packaged, and packaged files are not in the map)
+    - test.aria.core.JsonValidatorTest


### PR DESCRIPTION
This pull request moves all tests from `attester.yml` to `attester-packaged.yml` to run most of the tests in packaged mode and have a quicker result.
