### PR TITLE
Support for external hash change in page engine

### DIFF
--- a/src/aria/pageEngine/utils/HashManager.js
+++ b/src/aria/pageEngine/utils/HashManager.js
@@ -31,22 +31,27 @@ Aria.classDefinition({
         /**
          * Shortcut to the hash manager
          * @type aria.utils.HashManager
-         * @private
+         * @protected
          */
         this._hashManager = aria.utils.HashManager;
 
         /**
          * Listener of the hashchange
          * @type aria.core.CfgBeans:Callback
-         * @private
+         * @protected
          */
         this._onHashChangeCallback = {
             fn : this._onHashChange,
             scope : this
         };
 
-        this._hashManager.addCallback(this._onHashChangeCallback);
+        /**
+         * @type String
+         * @protected
+         */
+        this._lastPageId = null;
 
+        this._hashManager.addCallback(this._onHashChangeCallback);
     },
     $destructor : function () {
         this._hashManager.removeCallback(this._onHashChangeCallback);
@@ -58,16 +63,20 @@ Aria.classDefinition({
 
         /**
          * Retrieves the pageId from the cache and navigates to it
-         * @private
+         * @protected
          */
         _onHashChange : function () {
             var url = this.getUrl();
             var pageId = this._cache[url] ? this._cache[url].id : null;
-            if (pageId && this._navigate) {
-                this.$callback(this._navigate, {
-                    pageId : pageId,
-                    url : url
-                });
+            if (pageId) {
+                if (this._navigate) {
+                    this.$callback(this._navigate, {
+                        pageId : pageId,
+                        url : url
+                    });
+                }
+            } else {
+                this._addInCache(url, this._lastPageId);
             }
         },
 
@@ -76,9 +85,10 @@ Aria.classDefinition({
          * @param {aria.pageEngine.CfgBeans:PageRequest} pageRequest
          */
         update : function (pageRequest) {
-            var url = pageRequest.url, title = pageRequest.title, typeUtil = aria.utils.Type;
+            var url = pageRequest.url, title = pageRequest.title, pageId = pageRequest.pageId, typeUtil = aria.utils.Type;
+            this._lastPageId = pageId;
             if (typeUtil.isString(url)) {
-                this._addInCache(url, pageRequest.pageId);
+                this._addInCache(url, pageId);
                 if (this.getUrl() != url) {
                     this._hashManager.setHash(url);
                 }

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -34,5 +34,6 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.issue626.PageReadyEventTest");
         this.addTests("test.aria.pageEngine.pageEngine.issue770.GetContentTest");
         this.addTests("test.aria.pageEngine.pageEngine.customRootModule.CustomRootModuleTestSuite");
+        this.addTests("test.aria.pageEngine.pageEngine.externalHashNavigation.ExternalHashNavigationTest");
     }
 });

--- a/test/aria/pageEngine/pageEngine/externalHashNavigation/ExternalHashNavigationTest.js
+++ b/test/aria/pageEngine/pageEngine/externalHashNavigation/ExternalHashNavigationTest.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.externalHashNavigation.ExternalHashNavigationTest",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineTestFive",
+    $prototype : {
+        _onPageEngineStarted : function (args) {
+            this._hashManager = this._testWindow.aria.utils.HashManager;
+
+            this._checkPageAAA();
+            this._checkUrl(/\/pageEngine\/aaa/);
+            this._checkTitle("page_aaa");
+
+            this._hashManager.setHash("anotherOne");
+            this.waitUntilUrl(/#anotherOne$/, this._afterHashChangeOne);
+        },
+
+        _afterHashChangeOne : function () {
+            this._checkUrl(/anotherOne/);
+            this._checkPageAAA();
+            this._checkTitle("page_aaa");
+            this._hashManager.setHash("anotherTwo");
+            this.waitUntilUrl(/#anotherTwo$/, this._afterHashChangeTwo);
+        },
+
+        _afterHashChangeTwo : function () {
+            this._checkUrl(/anotherTwo/);
+            this._checkPageAAA();
+            this._checkTitle("page_aaa");
+
+            this.pageEngine.navigate({
+                pageId : "bbb"
+            }, {
+                fn : this._afterSecondPageReady,
+                scope : this
+            });
+        },
+
+        _afterSecondPageReady : function () {
+            this._checkPageBBB();
+            this._checkTitle("page_bbb");
+
+            this._hashManager.setHash("anotherThree");
+            this.waitUntilUrl(/#anotherThree$/, this._afterHashChangeThree);
+        },
+
+        _afterHashChangeThree : function () {
+            this._checkUrl(/anotherThree/);
+            this._checkPageBBB();
+            this._checkTitle("page_bbb");
+
+            if (aria.core.Browser.isOldIE) {
+                this.end();
+            } else {
+                this._testWindow.history.back();
+                this.waitUntilUrl(/#$/, this._afterFirstBack);
+            }
+        },
+
+        _afterFirstBack : function () {
+            this._checkPageBBB();
+            this._checkTitle("page_bbb");
+
+            this._testWindow.history.back();
+            this.waitUntilUrl(/#anotherTwo$/, this._afterSecondBack);
+        },
+
+        _afterSecondBack : function () {
+            this._checkUrl(/anotherTwo/);
+            this._checkPageAAA();
+            this._checkTitle("page_aaa");
+
+            this._testWindow.history.back();
+            this.waitUntilUrl(/#anotherOne$/, this._afterThirdBack);
+        },
+
+        _afterThirdBack : function () {
+            this._checkUrl(/anotherOne/);
+            this._checkPageAAA();
+            this._checkTitle("page_aaa");
+            this.end();
+        },
+
+        waitUntilUrl : function (url, cb) {
+            this.waitFor({
+                condition : function () {
+                    return this._testWindow.location.href.match(url);
+                },
+                callback : cb
+            });
+        }
+
+    }
+});

--- a/test/aria/pageEngine/pageEngine/site/PageProvider.js
+++ b/test/aria/pageEngine/pageEngine/site/PageProvider.js
@@ -67,10 +67,11 @@ Aria.classDefinition({
         loadPageDefinition : function (pageRequest, callback) {
             var cssBasePath = "test/aria/pageEngine/pageEngine/site/css/";
             var pageId = pageRequest.pageId;
+            var url = pageRequest.url;
             if ((!pageId) || (pageId == "aaa")) {
                 this.$callback(callback.onsuccess, {
                     pageId : "aaa",
-                    url : "/pageEngine/aaa",
+                    url : url || "/pageEngine/aaa",
                     title : "page_aaa",
                     contents : {
                         menus : {
@@ -137,7 +138,7 @@ Aria.classDefinition({
             if (pageId == "bbb") {
                 this.$callback(callback.onsuccess, {
                     pageId : "bbb",
-                    url : "",
+                    url : url || "",
                     title : "page_bbb",
                     contents : {
                         menus : {
@@ -198,7 +199,7 @@ Aria.classDefinition({
             if (pageId == "ccc") {
                 this.$callback(callback.onsuccess, {
                     pageId : "ccc",
-                    url : "/pageEngine/ccc",
+                    url : url || "/pageEngine/ccc",
                     title : "page_ccc",
                     contents : {
                         menus : {

--- a/test/aria/pageEngine/utils/BaseNavigationManagerTest.js
+++ b/test/aria/pageEngine/utils/BaseNavigationManagerTest.js
@@ -271,6 +271,11 @@ Aria.classDefinition({
             this._navManager.$dispose();
 
             this._clearLocalStorage();
+
+            this._furtherTests();
+        },
+
+        _furtherTests : function () {
             this.end();
 
         },

--- a/test/aria/pageEngine/utils/HashManagerTest.js
+++ b/test/aria/pageEngine/utils/HashManagerTest.js
@@ -24,7 +24,84 @@ Aria.classDefinition({
 
         _getNavManagerInstance : function (cb, options) {
             return new this._testWindow.aria.pageEngine.utils.HashManager(cb, options);
-        }
+        },
 
+        _furtherTests : function () {
+            this._initTestVariables();
+            this._testWindow.aria.utils.HashManager.setHash("");
+
+            this._navManager = this._getNavManagerInstance({
+                fn : this._fakeNavigate,
+                scope : this
+            }, {
+                active : false
+            });
+            this._testCacheLength(0);
+
+            this._update({
+                pageId : "aaa",
+                title : "aaa_title",
+                url : "aaa_url_new"
+            });
+            this._testCacheLength(1);
+            this._testTitle("aaa_title");
+            this._testCacheEntry("aaa_url_new", "aaa");
+
+            this._testWindow.aria.utils.HashManager.setHash("external");
+
+            aria.core.Timer.addCallback({
+                fn : this._afterExternalHashSetting,
+                scope : this
+            });
+        },
+        _afterExternalHashSetting : function () {
+            this._testCacheLength(2);
+            this._testTitle("aaa_title");
+            this._testCacheEntry("external", "aaa");
+
+            this._update({
+                pageId : "bbb",
+                title : "bbb_title",
+                url : "bbb_url"
+            });
+            this._testCacheLength(3);
+            this._testTitle("bbb_title");
+            this._testCacheEntry("bbb_url", "bbb");
+
+            this._testWindow.history.back();
+            if (aria.core.Browser.isOldIE) {
+                this._endFurtherTest();
+            } else {
+                aria.core.Timer.addCallback({
+                    fn : this._afterFurtherBack,
+                    scope : this,
+                    delay : 100
+                });
+            }
+        },
+
+        _afterFurtherBack : function () {
+            this._testCacheLength(3);
+            this._testNavigationLog(0, "aaa");
+
+            this._testWindow.history.forward();
+
+            aria.core.Timer.addCallback({
+                fn : this._afterFurtherForward,
+                scope : this,
+                delay : 100
+            });
+        },
+
+        _afterFurtherForward : function () {
+            this._testCacheLength(3);
+            this._testNavigationLog(1, "bbb");
+            this._endFurtherTest();
+        },
+
+        _endFurtherTest : function () {
+            this._navManager.$dispose();
+            this.end();
+        }
     }
 });


### PR DESCRIPTION
When navigation is set to `hash` in the site configuration, it is now possible to change the hash manually without compromising the back/forward navigation.
Before this commit, after manually changing the hash and then navigating away to another page, it was impossible to correctly go back because the manually added hash was not correctly mapped to a page.
