### PR TITLE
New configuration for Icon Widget

### DIFF
--- a/src/aria/widgets/Icon.js
+++ b/src/aria/widgets/Icon.js
@@ -89,9 +89,13 @@ Aria.classDefinition({
                 delegationMarkup = delegateManager.getMarkup(this._delegateId) + " ";
             }
 
-            out.write(['<span id="', id, '" class="', this._getIconClasses(iconInfo), '" ', tooltip, delegationMarkup,
+            if (!iconInfo.spriteURL && cfg.icon) {
+                var classes = aria.widgets.AriaSkinInterface.getSkinObject("Icon", cfg.icon.split(":")[0], true).content[cfg.icon.split(":")[1]];
+                out.write(['<span id="', id, '" class="xWidget ', classes, '" ', '></span>'].join(''));
+            } else {
+                out.write(['<span id="', id, '" class="', this._getIconClasses(iconInfo), '" ', tooltip, delegationMarkup,
                     'style="', this._getIconStyle(iconInfo), '"></span>'].join(''));
-
+            }
         },
 
         /**

--- a/src/aria/widgets/IconStyle.tpl.css
+++ b/src/aria/widgets/IconStyle.tpl.css
@@ -24,30 +24,32 @@
         {var widgetSettings = aria.widgets.environment.WidgetSettings.getWidgetSettings() /}
 
         /* Icon class: ${info.skinClassName} */
-        .xICN${info.skinClassName} {
-            {if !widgetSettings.middleAlignment}vertical-align:top;{/if}
-            font-size:1px;
-            width:${info.skinClass.iconWidth}px;
-            height:${info.skinClass.iconHeight}px;
-            {call background(info.skinClass.backgroundColor,info.skinClass.spriteURL,"no-repeat top left") /}
-            {if info.skinClass.backgroundSize}
-                background-size:${info.skinClass.backgroundSize}%;
-            {/if}
-            border-top: ${info.skinClass.borderTop}px;
-            border-right: ${info.skinClass.borderRight}px;
-            border-bottom: ${info.skinClass.borderBottom}px;
-            border-left: ${info.skinClass.borderLeft}px;
-            border-top-right-radius: ${info.skinClass.borderTopRightRadius}px;
-            border-top-left-radius: ${info.skinClass.borderTopLeftRadius}px;
-            border-bottom-right-radius: ${info.skinClass.borderBottomRightRadius}px;
-            border-bottom-left-radius: ${info.skinClass.borderBottomLeftRadius}px;
-            {if info.skinClass.borderStyle}
-              border-style: ${info.skinClass.borderStyle};
-            {/if}
-            {if info.skinClass.borderColor}
-              border-color: ${info.skinClass.borderColor};
-            {/if}
-        }
+        {if info.skinClass.spriteURL}
+            .xICN${info.skinClassName} {
+                {if !widgetSettings.middleAlignment}vertical-align:top;{/if}
+                font-size:1px;
+                width:${info.skinClass.iconWidth}px;
+                height:${info.skinClass.iconHeight}px;
+                {call background(info.skinClass.backgroundColor,info.skinClass.spriteURL,"no-repeat top left") /}
+                {if info.skinClass.backgroundSize}
+                    background-size:${info.skinClass.backgroundSize}%;
+                {/if}
+                border-top: ${info.skinClass.borderTop}px;
+                border-right: ${info.skinClass.borderRight}px;
+                border-bottom: ${info.skinClass.borderBottom}px;
+                border-left: ${info.skinClass.borderLeft}px;
+                border-top-right-radius: ${info.skinClass.borderTopRightRadius}px;
+                border-top-left-radius: ${info.skinClass.borderTopLeftRadius}px;
+                border-bottom-right-radius: ${info.skinClass.borderBottomRightRadius}px;
+                border-bottom-left-radius: ${info.skinClass.borderBottomLeftRadius}px;
+                {if info.skinClass.borderStyle}
+                  border-style: ${info.skinClass.borderStyle};
+                {/if}
+                {if info.skinClass.borderColor}
+                  border-color: ${info.skinClass.borderColor};
+                {/if}
+            }
+        {/if}
 
         {if info.skinClassName == "checkBoxes" && !widgetSettings.middleAlignment}
             .xICN${info.skinClassName} {

--- a/test/aria/widgets/icon/fontIcon/FontIconTest.js
+++ b/test/aria/widgets/icon/fontIcon/FontIconTest.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case for test.aria.widgets.icon.fontIcon.FontIconTest
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.icon.fontIcon.FontIconTest",
+    $dependencies : ["aria.widgets.Icon"],
+    $extends : "aria.jsunit.WidgetTestCase",
+    $prototype : {
+        /**
+         * Helper to destroy an icon
+         * @param {Object} inst
+         */
+        _destroyIcon : function (inst) {
+            inst.$dispose();
+            this.outObj.clearAll();
+        },
+
+        /**
+         * Test base layout
+         */
+        testAsyncFontIconTest : function () {
+            var cfg = {
+                icon : "std:camera-retro"
+            };
+            var instance = new aria.widgets.Icon(cfg, this.outObj.tplCtxt);
+            instance.writeMarkup(this.outObj);
+            this.outObj.putInDOM();
+            // init widget
+            instance.initWidget();
+
+            var classList = instance.getDom().classList.toString();
+            this.assertTrue(classList.search('fa fa-camera-retro') !== -1, 'The css classes were not added to the icon');
+            this._destroyIcon(instance);
+            this.notifyTestEnd("testAsyncFontIconTest");
+        }
+    }
+});

--- a/test/attester-testskin.yml
+++ b/test/attester-testskin.yml
@@ -11,3 +11,4 @@ tests:
   classpaths:
    includes:
     - test.aria.widgets.skin.ExternalCSSTest
+    - test.aria.widgets.icon.fontIcon.FontIconTest


### PR DESCRIPTION
When there is not a sprite url defined, the icon widget configuration is composed by a list of css classes that will be added to the html element generated.
