### PR TITLE
Fix root map not taken into account for cssFolderPath

### DIFF
--- a/src/aria/templates/CSSTemplate.js
+++ b/src/aria/templates/CSSTemplate.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 var Aria = require("../Aria");
+var ariaCoreDownloadMgr = require("../core/DownloadMgr");
+
 /**
  * Even if not used in this class, the CSSMgr is needed in order to allow a CSSTemplate to be registered
  */
@@ -25,26 +27,27 @@ require("./CSSMgr");
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.templates.CSSTemplate",
-    $extends : (require("./BaseTemplate")),
+    $extends : require("./BaseTemplate"),
     $constructor : function () {
         this.$BaseTemplate.constructor.call(this);
+
+        var baseLogicalPath = this.$classpath.replace(/\./g, "/");
 
         /**
          * Path of the CSS Template. It corresponds to the classpath and starts with "/". Exposed to the {CSSTemplate}
          * @type String
          */
-        this.cssPath = "/" + this.$classpath.replace(/\./g, "/");
+        this.cssPath = "/" + baseLogicalPath;
 
-        var url = (require("../core/DownloadMgr")).resolveURL(this.cssPath, true);
+        // Even if we remove the whole file name afterwards, it is important to pass the extension to resolveURL:
+        var url = ariaCoreDownloadMgr.resolveURL(baseLogicalPath + ".tpl.css", true);
+
         /**
          * Path of the folder containing the CSS Template. It is relative to the Aria.rootFolderPath and takes into
          * account the Root Map (not the Url map). Exposed to the {CSSTemplate}
          * @type String
          */
         this.cssFolderPath = url.substring(0, url.lastIndexOf("/"));
-    },
-    $destructor : function () {
-        this.$BaseTemplate.$destructor.call(this);
     },
     $prototype : {
         /**

--- a/test/aria/templates/css/CSSTestSuite.js
+++ b/test/aria/templates/css/CSSTestSuite.js
@@ -26,6 +26,7 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.css.CSSCtxtTest");
         this.addTests("test.aria.templates.css.CSSMgrTest");
         this.addTests("test.aria.templates.css.CSSParserTest");
+        this.addTests("test.aria.templates.css.cssFolderPath.CSSFolderPathTestCase");
         this.addTests("test.aria.templates.css.cssMgr.CSSMgrTestCase");
         this.addTests("test.aria.templates.css.cssMgr.issue722.CSSMgrIssue722TestCase");
         this.addTests("test.aria.templates.css.ctxtMgr.CtxtMgrTestCase");

--- a/test/aria/templates/css/cssFolderPath/CSSFolderPathTestCase.js
+++ b/test/aria/templates/css/cssFolderPath/CSSFolderPathTestCase.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("ariatemplates/Aria");
+var ariaCoreDownloadMgr = require("ariatemplates/core/DownloadMgr");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.templates.css.cssFolderPath.CSSFolderPathTestCase",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        var xRoot = ariaCoreDownloadMgr.resolveURL(__filename, true).replace(/CSSFolderPathTestCase\.js$/, "")
+                + "root/";
+        ariaCoreDownloadMgr.updateRootMap({
+            "x" : {
+                "*" : xRoot
+            }
+        });
+        this.xRoot = xRoot;
+
+        this.setTestEnv({
+            template : "x.CSSFolderPathTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var info = Aria.$global.x.CSSFolderPathStyleScript.info;
+            this.assertEquals(info.calls, 1, "x.CSSFolderPathStyleScript.$constructor was not called.");
+            this.assertEquals(info.cssFolderPath, this.xRoot + "x", "Invalid cssFolderPath: " + info.cssFolderPath);
+            this.end();
+        }
+    }
+});

--- a/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathStyle.tpl.css
+++ b/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathStyle.tpl.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath: "x.CSSFolderPathStyle",
+    $hasScript: true
+}}
+
+    {macro main()}
+    {/macro}
+
+{/CSSTemplate}

--- a/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathStyleScript.js
+++ b/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathStyleScript.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var info = {
+    calls : 0
+};
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath : "x.CSSFolderPathStyleScript",
+    $constructor : function () {
+        info.cssFolderPath = this.cssFolderPath;
+        info.calls++;
+    }
+});
+module.exports.info = info;

--- a/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathTpl.tpl
+++ b/test/aria/templates/css/cssFolderPath/root/x/CSSFolderPathTpl.tpl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "x.CSSFolderPathTpl",
+    $css: ["x.CSSFolderPathStyle"]
+}}
+
+    {macro main()}
+        OK
+    {/macro}
+{/Template}


### PR DESCRIPTION
This pull request fixes a regression introduced by commit 96c3f0591012d316db5de8325225645449ee26a7:
the root map is not taken into account for the computation of the `cssFolderPath` property in CSS templates.
