### PR TITLE
fix null bound value in @aria:CheckBox triggers an exception

### DIFF
--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -116,12 +116,12 @@ Aria.classDefinition({
 
                 out.write(['<input style="display:inline-block"', cfg.disabled ? ' disabled' : '',
                         this._isChecked() ? ' checked' : '', ' type="', cfg._inputType, '"', name, ' value="',
-                        cfg.value.toString(), '" ' + tabIndex + '/>'].join(''));
+                        cfg.value, '" ' + tabIndex + '/>'].join(''));
             } else {
                 this._icon.writeMarkup(out);
                 out.write(['<input', Aria.testMode ? ' id="' + this._domId + '_input"' : '', ' style="display:none"',
                         cfg.disabled ? ' disabled' : '', this._isChecked() ? ' checked' : '', ' type="',
-                        cfg._inputType, '"', name, ' value="', cfg.value.toString(), '"/>'].join(''));
+                        cfg._inputType, '"', name, ' value="', cfg.value, '"/>'].join(''));
             }
         },
 

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -22,6 +22,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.datefield.DateFieldTestSuite");
         this.addTests("test.aria.widgets.form.CheckBoxTest");
         this.addTests("test.aria.widgets.form.checkbox.SetDisabledTest");
+        this.addTests("test.aria.widgets.form.checkbox.nullBoundValue.CheckBoxNullBoundValueTest");
         this.addTests("test.aria.widgets.form.GaugeTest");
         this.addTests("test.aria.widgets.form.InputTest");
         this.addTests("test.aria.widgets.form.InputValidationHandlerTest");

--- a/test/aria/widgets/form/checkbox/nullBoundValue/CheckBoxNullBoundValueTest.js
+++ b/test/aria/widgets/form/checkbox/nullBoundValue/CheckBoxNullBoundValueTest.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.checkbox.nullBoundValue.CheckBoxNullBoundValueTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $prototype : {
+        runTemplateTest : function () {
+            var widgetInstance = this.getWidgetInstance("checkbox");
+            this.assertEquals(widgetInstance._cfg.bind.value.inside.value, null, "Initial value is not null!");
+            var domElt = widgetInstance.getDom();
+            this.assertNotEquals(domElt, null, "getDom() returns null");
+            this.synEvent.click(domElt, {
+                scope : this,
+                fn : this.afterClick
+            });
+        },
+        afterClick : function () {
+            var widgetInstance = this.getWidgetInstance("checkbox");
+            this.assertEquals(widgetInstance._cfg.bind.value.inside.value, true, "Clicking on the checkbox did not set the value to true!");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/checkbox/nullBoundValue/CheckBoxNullBoundValueTestTpl.tpl
+++ b/test/aria/widgets/form/checkbox/nullBoundValue/CheckBoxNullBoundValueTestTpl.tpl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "test.aria.widgets.form.checkbox.nullBoundValue.CheckBoxNullBoundValueTestTpl"
+}}
+{macro main()}
+    {var d = {value:null}/}
+    {@aria:CheckBox {
+        id : "checkbox",
+        label : "This is a checkbox",
+        bind : {
+            value : {
+                inside : d,
+                to : "value"
+            }
+        }
+    }/}
+{/macro}
+{/Template}


### PR DESCRIPTION
This issue fixes an exception happening when displaying a checkbox bound to a null value in the data model.
