### PR TITLE
fix splitter borderWidth skin property

### DIFF
--- a/src/aria/widgets/container/Splitter.js
+++ b/src/aria/widgets/container/Splitter.js
@@ -209,7 +209,7 @@ Aria.classDefinition({
             var size = this._calculateSize(cfg);
             this.setProperty("size1", size.size1);
             this.setProperty("size2", size.size2);
-            var borderClass = "", splitterBarSize = orientation ? cfg.width : cfg.height;
+            var borderClass = "";
             var height = this._height + this._skinObj.separatorHeight, width = this._width
                     + this._skinObj.separatorWidth;
             var bordersWidth = 0;
@@ -237,11 +237,11 @@ Aria.classDefinition({
             out.endSection();
             out.write('</span> ');
 
-            var sDimension, sPosition, sEndPosition;
+            var sDimension, sPosition, sEndPosition, splitterBarSize;
             if (orientation) {
-                cfgHclass = size.size2, cfgWclass = cfg.width - bordersWidth, sDimension = "width", sPosition = "top", sEndPosition = "bottom";
+                cfgHclass = size.size2, cfgWclass = cfg.width - bordersWidth, sDimension = "width", splitterBarSize = cfgWclass, sPosition = "top", sEndPosition = "bottom";
             } else {
-                cfgHclass = cfg.height - bordersWidth, cfgWclass = size.size2, sDimension = "height", sPosition = "left", sEndPosition = "right";
+                cfgHclass = cfg.height - bordersWidth, cfgWclass = size.size2, sDimension = "height", splitterBarSize = cfgHclass, sPosition = "left", sEndPosition = "right";
             }
 
             out.write(['<span class="', this._handleBarClass, '" style="' + sDimension + ':', splitterBarSize,

--- a/test/aria/widgets/container/ContainerTestSuite.js
+++ b/test/aria/widgets/container/ContainerTestSuite.js
@@ -24,6 +24,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.splitter.SplitterTest");
         this.addTests("test.aria.widgets.container.splitter.move.SplitterTestMoveUpDown");
         this.addTests("test.aria.widgets.container.splitter.move.SplitterTestMoveLeftRight");
+        this.addTests("test.aria.widgets.container.splitter.skin.SplitterBorderWidthTest");
         this.addTests("test.aria.widgets.container.tooltip.TooltipTestCase");
         this.addTests("test.aria.widgets.container.dialog.DialogTestSuite");
         this.addTests("test.aria.widgets.container.bindableSize.BindableSizeTestSuite");

--- a/test/aria/widgets/container/splitter/skin/SplitterBorderWidthTest.js
+++ b/test/aria/widgets/container/splitter/skin/SplitterBorderWidthTest.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.splitter.skin.SplitterBorderWidthTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype : {
+        borderWidth : 20,
+
+        setUp : function () {
+            var splitterSkin = aria.widgets.AriaSkin.skinObject.Splitter.std;
+            splitterSkin.borderWidth = this.borderWidth;
+            splitterSkin.borderColor = "blue";
+        },
+
+        runTemplateTest : function () {
+            this.checkSplitter("H", "width", "x");
+            this.checkSplitter("V", "height", "y");
+            this.end();
+        },
+
+        checkSplitter : function (orientation, commonDimension, commonPosition) {
+            var domUtils = aria.utils.Dom;
+            var instance = this.getWidgetInstance("splitter" + orientation);
+            var fullSplitter = instance._domElt;
+            var splitBar = instance._splitBar;
+            var splitBarProxy = instance._splitBarProxy;
+            var panel1 = instance._splitPanel1;
+            var panel2 = instance._splitPanel2;
+            var geomFullSplitter = domUtils.getGeometry(fullSplitter);
+            var geomSplitBar = domUtils.getGeometry(splitBar);
+            var geomSplitBarProxy = domUtils.getGeometry(splitBarProxy);
+            var geomPanel1 = domUtils.getGeometry(panel1);
+            var geomPanel2 = domUtils.getGeometry(panel2);
+            this.assertEquals(geomFullSplitter[commonDimension], 300);
+            var sizeCommon = 300 - 2 * this.borderWidth;
+            var posCommon = geomFullSplitter[commonPosition] + this.borderWidth;
+            this.assertEquals(geomSplitBarProxy[commonDimension], sizeCommon);
+            this.assertEquals(geomSplitBarProxy[commonPosition], posCommon);
+            this.assertEquals(geomSplitBar[commonDimension], sizeCommon);
+            this.assertEquals(geomSplitBar[commonPosition], posCommon);
+            this.assertEquals(geomPanel1[commonDimension], sizeCommon);
+            this.assertEquals(geomPanel1[commonPosition], posCommon);
+            this.assertEquals(geomPanel2[commonDimension], sizeCommon);
+            this.assertEquals(geomPanel2[commonPosition], posCommon);
+        }
+    }
+});

--- a/test/aria/widgets/container/splitter/skin/SplitterBorderWidthTestTpl.tpl
+++ b/test/aria/widgets/container/splitter/skin/SplitterBorderWidthTestTpl.tpl
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath:"test.aria.widgets.container.splitter.skin.SplitterBorderWidthTestTpl"
+}}
+
+   {macro main()}
+      {@aria:Splitter {
+         id: "splitterH",
+         orientation: "horizontal",
+         macro1: "panel1",
+         macro2: "panel2",
+         width: 300,
+         height: 600
+      }}
+      {/@aria:Splitter}
+      {@aria:Splitter {
+         id: "splitterV",
+         orientation: "vertical",
+         macro1: "panel1",
+         macro2: "panel2",
+         width: 600,
+         height: 300
+      }}
+      {/@aria:Splitter}
+   {/macro}
+
+   {macro panel1()}
+      Panel 1
+   {/macro}
+
+   {macro panel2()}
+      Panel 2
+   {/macro}
+
+{/Template}


### PR DESCRIPTION
The `borderWidth` skin property of the splitter was not correctly taken into account for the size of the split bar (which was larger than the dimension of both panels and was hiding the border on the right or on the bottom).
This pull request fixes this issue.
