### PR TITLE
fix incomplete fast normalization in case of recursive bean definitions

### DIFF
--- a/src/aria/core/JsonTypesCheck.js
+++ b/src/aria/core/JsonTypesCheck.js
@@ -413,10 +413,18 @@
                             continue;
                         }
                         var property = properties[propertyName];
+                        var strDefault = null;
                         if ("$strDefault" in property) {
+                            strDefault = property.$strDefault;
+                        } else if (("$default" in property) && property.$getDefault) {
+                            // $strDefault may not be already defined at the time makeFastNorm is called,
+                            // even if a default value does exist. In that case, let's generate a call to $getDefault.
+                            strDefault = "beanProperties['" + propertyName + "'].$getDefault()";
+                        }
+                        if (strDefault) {
                             hasProperties = true;
-                            strBuffer.push("if (obj['" + propertyName + "'] == null) { obj['" + propertyName + "']  = "
-                                    + property.$strDefault + "}");
+                            strBuffer.push("if (obj['" + propertyName + "'] == null) { obj['" + propertyName + "'] = "
+                                    + strDefault + "; }");
                             if (property.$fastNorm) {
                                 strBuffer.push("else { beanProperties['" + propertyName + "'].$fastNorm(obj['"
                                         + propertyName + "']); }");

--- a/src/aria/core/JsonValidator.js
+++ b/src/aria/core/JsonValidator.js
@@ -413,6 +413,15 @@ var Aria = require("../Aria");
                     // beanDef.$strDefault = typeRef.$strDefault;
                 }
 
+                var tempFastNorm = baseType && baseType.makeFastNorm && !beanDef.$fastNorm;
+                if (tempFastNorm) {
+                    // Prepare with empty $fastNorm and $getDefault functions because the existence of those functions
+                    // can be checked during the call to baseType.preprocess.
+                    // This happens especially in case the bean structure is recursive.
+                    beanDef.$fastNorm = Aria.returnNull;
+                    beanDef.$getDefault = Aria.returnNull;
+                }
+
                 // apply baseType preprocessing if any
                 if (baseType && baseType.preprocess) {
                     baseType.preprocess(beanDef, beanName, packageDef);
@@ -423,12 +432,8 @@ var Aria = require("../Aria");
                     return this._typeError;
                 }
 
-                if (baseType && baseType.makeFastNorm && !beanDef.$fastNorm) {
-
-                    // prepare with empty getDefault function
-                    beanDef.$getDefault = Aria.returnNull;
-
-                    // generate fast normalizer, if not provided
+                if (tempFastNorm) {
+                    // generate fast normalizer
                     baseType.makeFastNorm(beanDef);
                 }
 

--- a/test/aria/core/CoreTestSuite.js
+++ b/test/aria/core/CoreTestSuite.js
@@ -37,6 +37,7 @@ Aria.classDefinition({
         this.addTests("test.aria.core.InterfacesTest");
         this.addTests("test.aria.core.JsObjectTest");
         this.addTests("test.aria.core.JsonValidatorTest");
+        this.addTests("test.aria.core.jsonValidator.RecursiveBeansTest");
         this.addTests("test.aria.core.LogTest");
         this.addTests("test.aria.core.ObservableTest");
         this.addTests("test.aria.core.prototypefn.PrototypeFnTestCase");

--- a/test/aria/core/jsonValidator/RecursiveBeans.js
+++ b/test/aria/core/jsonValidator/RecursiveBeans.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.beanDefinitions({
+    $package : "test.aria.core.jsonValidator.RecursiveBeans",
+    $namespaces : {
+        "json" : "aria.core.JsonTypes"
+    },
+    $beans : {
+        "Tree" : {
+            $type : "json:Object",
+            $properties : {
+                "subTrees" : {
+                    $type : "json:Array",
+                    $default : [],
+                    $contentType : {
+                        $type : "Tree"
+                    }
+                },
+                "value1" : {
+                    $type : "json:Integer",
+                    $default : 3
+                },
+                "value2" : {
+                    $type : "json:Integer",
+                    $default : 7
+                }
+            }
+        }
+    }
+});

--- a/test/aria/core/jsonValidator/RecursiveBeansTest.js
+++ b/test/aria/core/jsonValidator/RecursiveBeansTest.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.core.jsonValidator.RecursiveBeansTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.core.JsonValidator", "test.aria.core.jsonValidator.RecursiveBeans"],
+    $prototype : {
+
+        _initialData : function () {
+            return {
+                value1 : 1,
+                subTrees : [{
+                            value2 : 0
+                        }, {
+                            value1 : 4,
+                            subTrees : [{
+                                        subTrees : [{
+                                                    subTrees : []
+                                                }, {
+                                                    value1 : 2
+                                                }]
+                                    }]
+                        }]
+            };
+        },
+
+        _normalizedData : function () {
+            return {
+                value1 : 1,
+                value2 : 7,
+                subTrees : [{
+                            value1 : 3,
+                            value2 : 0,
+                            subTrees : []
+                        }, {
+                            value1 : 4,
+                            value2 : 7,
+                            subTrees : [{
+                                        value1 : 3,
+                                        value2 : 7,
+                                        subTrees : [{
+                                                    value1 : 3,
+                                                    value2 : 7,
+                                                    subTrees : []
+                                                }, {
+                                                    value1 : 2,
+                                                    value2 : 7,
+                                                    subTrees : []
+                                                }]
+                                    }]
+                        }]
+            };
+        },
+
+        _checkNormalization : function () {
+            var param = {
+                json : this._initialData(),
+                beanName : "test.aria.core.jsonValidator.RecursiveBeans.Tree"
+            };
+            var res = aria.core.JsonValidator.normalize(param);
+            this.assertJsonEquals(param.json, this._normalizedData());
+        },
+
+        testExecuteNormalize : function () {
+            // test in slow mode:
+            this.assertTrue(aria.core.JsonValidator._options.checkEnabled, "This test is expected to be run with aria.core.JsonValidator._options.checkEnabled = true");
+            this._checkNormalization();
+
+            // test in fast mode:
+            aria.core.JsonValidator._options.checkEnabled = false;
+            this._checkNormalization();
+
+            // reset initial mode:
+            aria.core.JsonValidator._options.checkEnabled = true;
+        }
+    }
+});


### PR DESCRIPTION
This PR fixes the following issue: fast normalization was incomplete when a bean definition references itself in one of its sub-properties (see the test added in this PR).
Note that this issue only happened with fast normalization (i.e. when `aria.core.JsonValidator._options.checkEnabled = false`, which is the case automatically when `Aria.debug = false`)
