### PR TITLE
fix #1193 async dependency load breaks sync method

### DIFF
--- a/src/aria/core/MultiLoader.js
+++ b/src/aria/core/MultiLoader.js
@@ -94,7 +94,7 @@ module.exports = Aria.classDefinition({
 
             if (promise) {
                 var self = this;
-                promise.then(function () {
+                promise.thenSync(function () {
                     self._execCallback(false);
                 }, function (error) {
                     if (!descriptor.onerror || !descriptor.onerror.override) {

--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -155,7 +155,8 @@ Aria.classDefinition({
         INVALID_BASEURL : "The base URL defined in the RequestMgr object is empty or invalid - please check: \nurl: %1",
         MISSING_SERVICESPEC : "Provided request object must contain an actionName or a serviceSpec element",
         CALLBACK_ERROR : "An error occured in the Request manager while processing the callback function.",
-        INVALID_URL : "Url for request is invalid: %1"
+        INVALID_URL : "Url for request is invalid: %1",
+        DEPENDENCIES_BROKE_SYNC : "Dependencies asynchronous load broke a synchronous request: all the dependencies have to be loaded before: %1"
     },
     $prototype : {
 
@@ -312,7 +313,8 @@ Aria.classDefinition({
                 id : id,
                 session : requestObject.session,
                 actionQueuing : requestObject.actionQueuing,
-                requestHandler : requestObject.requestHandler
+                requestHandler : requestObject.requestHandler,
+                syncFlag : false
             };
             Aria.load({
                 classes : dependencies,
@@ -322,6 +324,11 @@ Aria.classDefinition({
                     args : args
                 }
             });
+
+            // check if the request has been executed synchronously
+            if (!args.syncFlag && requestObject.async === false) {
+                this.$logError(this.DEPENDENCIES_BROKE_SYNC, [dependencies]);
+            }
 
             return id;
         },
@@ -333,6 +340,7 @@ Aria.classDefinition({
          */
         _onDependenciesReady : function (args) {
 
+            args.syncFlag = true;
             var req = args.req;
             // creates url for request
             var details = this.createRequestDetails(req.requestObject, args.session);

--- a/src/noder-modules/loader.js
+++ b/src/noder-modules/loader.js
@@ -103,7 +103,7 @@ LoaderProto.downloadModule = function (module) {
 // first entry point: if it is present, use the DownloadMgr to download files
 LoaderProto.loadUnpackaged = function (module) {
     if (this.isDownloadMgrUsable()) {
-        return this.downloadModule(module).then(bind1(this.parentLoader.preprocessUnpackaged, this.parentLoader, module));
+        return this.downloadModule(module).thenSync(bind1(this.parentLoader.preprocessUnpackaged, this.parentLoader, module));
     } else {
         return this.parentLoadUnpackaged(module);
     }

--- a/test/aria/modules/IoFilter.js
+++ b/test/aria/modules/IoFilter.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for the RequestMgr class
+ */
+Aria.classDefinition({
+    $classpath : 'test.aria.modules.IoFilter',
+    $extends : 'aria.core.IOFilter',
+    $constructor : function (translatePath, switchSyncAsync) {
+        this.$IOFilter.constructor.call(this);
+        this._switchSyncAsync = switchSyncAsync;
+        this._translatePath = translatePath;
+    },
+    $prototype : {
+        /**
+         * Method called before a request is sent to get a chance to change its arguments
+         * @param {aria.core.CfgBeans.IOAsyncRequestCfg} request
+         */
+        onRequest : function (request) {
+            if (request.url == this._translatePath) {
+                request.url = Aria.rootFolderPath + "test/aria/modules/test/SampleResponse.json";
+            } else if (request.async !== false && this._switchSyncAsync) {
+                // set all requests as sync
+                request.async = false;
+            }
+        }
+    }
+});

--- a/test/aria/modules/ModulesTestSuite.js
+++ b/test/aria/modules/ModulesTestSuite.js
@@ -26,7 +26,8 @@ Aria.classDefinition({
         this.addTests("test.aria.modules.RequestMgrI18nTest");
         this.addTests("test.aria.modules.RequestMgrJsonSerializerTest");
         this.addTests("test.aria.modules.RequestMgrTest");
-        this.addTests("test.aria.modules.RequestMgrSyncTest");
+        this.addTests("test.aria.modules.requestMgrSyncTest.SyncTest");
+        this.addTests("test.aria.modules.RequestMgrSyncErrorTest");
 
         this.addTests("test.aria.modules.queuing.SimpleSessionQueuingTest");
 

--- a/test/aria/modules/RequestMgrSyncErrorTest.js
+++ b/test/aria/modules/RequestMgrSyncErrorTest.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for the RequestMgr class
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.modules.RequestMgrSyncErrorTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.modules.RequestMgr", "test.aria.modules.IoFilter",
+            "aria.modules.requestHandler.environment.RequestHandler"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+        this.defaultTestTimeout = 5000;
+        this._flagOne = false;
+    },
+    $prototype : {
+
+        testAsyncError : function () {
+            this._oldRequestHandlerCfg = aria.modules.requestHandler.environment.RequestHandler.getRequestHandlerCfg();
+            aria.core.AppEnvironment.setEnvironment({
+                requestHandler : {
+                    implementation : "test.aria.modules.TestRequestHandler"
+                }
+            });
+            this._addFilter(false);
+            aria.modules.RequestMgr.submitJsonRequest({
+                moduleName : "xxx",
+                actionName : "yyy",
+                // set async flag
+                async : false
+            }, {
+                reqData : 123
+            }, {
+                fn : this._callback,
+                scope : this
+            });
+            this.assertErrorInLogs(aria.modules.RequestMgr.DEPENDENCIES_BROKE_SYNC);
+            this._flagOne = true;
+        },
+
+        _callback : function () {
+            this._removeFilter();
+            aria.core.AppEnvironment.setEnvironment({
+                requestHandler : this._oldRequestHandlerCfg
+            });
+            this.assertTrue(this._flagOne, "Request synchronously done: error expected");
+            this.notifyTestEnd("testAsyncError");
+        },
+
+        _addFilter : function (switchSyncAsync) {
+            this._filterInstance = new test.aria.modules.IoFilter("xxx/yyy", switchSyncAsync);
+            aria.core.IOFiltersMgr.addFilter(this._filterInstance);
+        },
+
+        _removeFilter : function () {
+            aria.core.IOFiltersMgr.removeFilter(this._filterInstance);
+        }
+
+    }
+});

--- a/test/aria/modules/TestRequestHandler.js
+++ b/test/aria/modules/TestRequestHandler.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2009-2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JSON handler, that handles JSON as well as a JavaScript object retrieved in responseJSON
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.modules.TestRequestHandler",
+    $extends : "aria.modules.requestHandler.JSONRequestHandler"
+});


### PR DESCRIPTION
all the dependencies have to be loaded before using the sync request, because otherwise the async Aria.load method would break the sync request behaviour.
An error message has been added and another strategy is used for the tests (filters instead of aria.core.IO.asyncRequest mockup).
