### PR TITLE
fix #1222 improve SelectBox's wrong value error message & doc

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -814,7 +814,7 @@ Aria.beanDefinitions({
                 },
                 "options" : {
                     $type : "json:Array",
-                    $description : "List of the possible values that have to be proposed to the user",
+                    $description : "List of the possible values that have to be proposed to the user. Note that the value of SelectBox is validated against the options array when it's set, so before setting the `value` via `aria.utils.Json.setValue`, make sure the `options` array is up-to-date.",
                     $contentType : {
                         $type : "ListItemCfg"
                     },

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -22,6 +22,8 @@ Aria.classDefinition({
     $dependencies : ["aria.widgets.form.DropDownListTrait", "aria.widgets.controllers.SelectBoxController"],
     $css : ["aria.widgets.form.SelectBoxStyle", "aria.widgets.form.list.ListStyle", "aria.widgets.container.DivStyle"],
     $statics : {
+        /* overrides TextInput.WIDGET_VALUE_IS_WRONG_TYPE */
+        WIDGET_VALUE_IS_WRONG_TYPE : "%1Value '%2' is invalid. Note that SelectBox's value must be present in its options array. When changing both `value` and `options` via aria.utils.Json.setValue, change the options array first.",
         DUPLICATE_VALUE : "%1 - Duplicate values %2 found in options"
     },
     /**

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -153,7 +153,7 @@ Aria.classDefinition({
     },
     $statics : {
         // ERROR MESSAGE:
-        WIDGET_VALUE_IS_WRONG_TYPE : "%1Value %2 is of incorrect type."
+        WIDGET_VALUE_IS_WRONG_TYPE : "%1Value '%2' is of incorrect type."
     },
     $prototype : {
         /**


### PR DESCRIPTION
When the `options` array didn't contain the value the developer was trying to set
via `setValue`, the message in console was a bit cryptic. This commit adds
more explanations in the console error and cfgbeans.
