### PR TITLE
refactor cleanup dead code after #1057

### DIFF
--- a/src/aria/modules/RequestMgr.js
+++ b/src/aria/modules/RequestMgr.js
@@ -407,11 +407,6 @@ Aria.classDefinition({
                     }
                 }
             };
-            /* BACKWARD-COMPATIBILITY-BEGIN HEADERS */
-            if (req.postHeader) {
-                requestObject.postHeader = req.postHeader;
-            }
-            /* BACKWARD-COMPATIBILITY-END HEADERS */
             if (handler.expectedResponseType) {
                 requestObject.expectedResponseType = handler.expectedResponseType;
             }

--- a/test/aria/modules/requestHandler/RequestHandlerTest.js
+++ b/test/aria/modules/requestHandler/RequestHandlerTest.js
@@ -95,28 +95,6 @@ Aria.classDefinition({
             handler.$dispose();
         },
 
-        /* BACKWARD-COMPATIBILITY-BEGIN HEADERS */
-        /**
-         * Test to configure post data header.
-         */
-        testConfigurePostHeader : function () {
-            var handler = new aria.modules.requestHandler.RequestHandler();
-            var request = {
-                moduleName : "test",
-                actionName : "testConfigurePostHeader",
-                postHeader : "text/plain",
-                requestHandler : handler
-            };
-            var valid = aria.core.JsonValidator.normalize({
-                json : request,
-                beanName : "aria.modules.RequestBeans.RequestObject"
-            }, true);
-            this.assertTrue(valid);
-            this.assertTrue(request.postHeader === "text/plain");
-            handler.$dispose();
-        },
-        /* BACKWARD-COMPATIBILITY-END HEADERS */
-
         /**
          * Test to configure custom headers.
          */


### PR DESCRIPTION
Commit d46d7dd5a938591d6fd8b05622ec4b709e50f389 removed certain
functionalities regarding the usage of `postHeader` but some related
code was not removed properly.

This commit cleans this up by removing the framework code that was
effectively dead as of 1.6.1 (passing a param that was not taken into
account).

The removed test was passing because the cfgbean had `$restricted : false`
hence JSON validator was accepting even the keys removed from the cfgbean
in the earlier commit.

Close #1227.
