### PR TITLE
feat #1231 Selected option highlight in selectbox widget

### DIFF
--- a/src/aria/widgets/controllers/SelectBoxController.js
+++ b/src/aria/widgets/controllers/SelectBoxController.js
@@ -69,12 +69,24 @@ Aria.classDefinition({
             if (report.displayDropDown) {
                 dm.initialInput = displayValue;
                 var jsonUtils = aria.utils.Json;
-                jsonUtils.setValue(dm, 'selectedIdx', -1);
+                var selectedIndex = this._getSelectedIndex(dm.value);
+                jsonUtils.setValue(dm, 'selectedIdx', selectedIndex);
                 jsonUtils.setValue(dm, 'listContent', sgs);
             }
             return report;
         },
-
+        /**
+         * Returns the index of selected option
+         * @param {String} value selected option value
+         * @return {Integer}
+         */
+        _getSelectedIndex : function (value) {
+            for (var i = 0; i < this._options.length; i++) {
+                if (this._options[i].value === value) {
+                    return i;
+                }
+            }
+        },
         /**
          * Set the list widget.
          * @param {aria.widgets.form.list.List} listWidget

--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -105,15 +105,19 @@ Aria.classDefinition({
 
         /**
          * Return the item that should be preselected depending on the navigation event
+         * @param {Integer} selectedIdx selected option index
          * @protected
          * @return {Integer} Item position or null if nothing should be preselected
          */
-        _checkPreselect : function () {
+        _checkPreselect : function (selectedIdx) {
             if (!this._navigationEvent) { // will not override any selections using arrow keys or mouse over
                 if (this._data.preselect === "none") {
                     return null;
                 } else if (this._data.preselect === "always") {
-                    return 0;
+                    if (selectedIdx === -1 || selectedIdx === undefined) {
+                        selectedIdx = 0;
+                    }
+                    return selectedIdx;
                 }
             } else {
                 this._navigationEvent = false;
@@ -373,7 +377,7 @@ Aria.classDefinition({
          */
         _mergeItemsAndSelectionInfo : function (items, selectedValues, selectedIdx) {
             var arrayUtil = aria.utils.Array;
-            var preselect = this._checkPreselect();
+            var preselect = this._checkPreselect(selectedIdx);
             selectedIdx = (preselect === undefined) ? selectedIdx : preselect;
             var maxSelectedCount = this._getTrueMaxSelectedCount(items);
             var pbMaxSelected = false; // true if the number of selected values is greater than maxSelectedCount

--- a/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
@@ -22,5 +22,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.selectbox.checkValue.MainTemplateTestCase");
         this.addTests("test.aria.widgets.form.selectbox.checkTypeLetters.SelectBoxTypeAllLetters");
         this.addTests("test.aria.widgets.form.selectbox.preselect.PreselectTestCase");
+        this.addTests("test.aria.widgets.form.selectbox.optionhighlight.SelectboxOptionHighlightTestCase");
     }
 });

--- a/test/aria/widgets/form/selectbox/optionhighlight/SelectboxOptionHighlightTestCase.js
+++ b/test/aria/widgets/form/selectbox/optionhighlight/SelectboxOptionHighlightTestCase.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.selectbox.optionhighlight.SelectboxOptionHighlightTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.String"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.inputField = null;
+        this.expandButton = null;
+        this.dropdown = null;
+        this.options = null;
+        this.data = {
+            countries : [{
+                        value : "FR",
+                        label : "France"
+                    }, {
+                        value : "CH",
+                        label : "Switzerland"
+                    }, {
+                        value : "UK",
+                        label : "United Kingdom"
+                    }, {
+                        value : "US",
+                        label : "United States"
+                    }, {
+                        value : "ES",
+                        label : "Spain"
+                    }, {
+                        value : "PL",
+                        label : "Poland"
+                    }, {
+                        value : "SE",
+                        label : "Sweden"
+                    }, {
+                        value : "USA",
+                        label : "United States of America"
+                    }],
+            selection : "CH"
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.selectbox.optionhighlight.SelectboxOptionHighlightTpl",
+            data : this.data
+        });
+    },
+    $destructor : function () {
+        this.inputField = null;
+        this.expandButton = null;
+        this.dropdown = null;
+        this.options = null;
+        this.$TemplateTestCase.$destructor.call(this);
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.inputField = this.getInputField("myId");
+            this.expandButton = this.getExpandButton("myId");
+            aria.utils.SynEvents.click(this.expandButton, {
+                fn : this._afterClick,
+                scope : this
+            });
+        },
+        _afterClick : function () {
+            aria.core.Timer.addCallback({
+                fn : this._afterTimer,
+                scope : this,
+                delay : 500
+            });
+        },
+        _afterTimer : function () {
+            this.dropdown = this.getWidgetDropDownPopup("myId");
+            this.options = this.getElementsByClassName(this.dropdown, "xListSelectedItem_dropdown");
+            var selectedOption = aria.utils.String.trim(this.options[0].textContent || this.options[0].innerText);
+            this.assertEquals("Switzerland", selectedOption, "Expected %1, got %2");
+            this.inputField.value = "";
+            aria.utils.SynEvents.click(this.inputField, {
+                fn : this._typeOption,
+                scope : this
+            });
+        },
+        _typeOption : function () {
+            aria.utils.SynEvents.type(this.inputField, "pol[enter]", {
+                fn : this._clickDropdown,
+                scope : this
+            });
+
+        },
+        _clickDropdown : function () {
+            aria.utils.SynEvents.click(this.expandButton, {
+                fn : this._checkHighlight,
+                scope : this
+            });
+        },
+        _checkHighlight : function () {
+            this.dropdown = this.getWidgetDropDownPopup("myId");
+            this.options = this.getElementsByClassName(this.dropdown, "xListSelectedItem_dropdown");
+            var selectedOption = aria.utils.String.trim(this.options[0].textContent || this.options[0].innerText);
+            this.assertEquals("Poland", selectedOption, "Expected %1, got %2");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/selectbox/optionhighlight/SelectboxOptionHighlightTpl.tpl
+++ b/test/aria/widgets/form/selectbox/optionhighlight/SelectboxOptionHighlightTpl.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath : "test.aria.widgets.form.selectbox.optionhighlight.SelectboxOptionHighlightTpl"
+}}
+
+{macro main()}
+  {@aria:SelectBox {
+      id : "myId",
+      options : data.countries,
+      bind: {
+        value: {
+          inside: data,
+          to: 'selection'
+        }
+      },
+        helptext: 'HELPTEXT'
+  }/}
+{/macro}
+{/Template}


### PR DESCRIPTION
On click of selectbox widget, the selected option does not get highlighted in the dropdown. 
Example: http://instant.ariatemplates.com/anonymous/0dc229a5c8c664f9e3a3/f305c3
This commit makes the selected option highlighted in the dropdown.
