### PR TITLE
Check widget template context still exists before using it

### DIFF
--- a/src/aria/widgetLibs/BindableWidget.js
+++ b/src/aria/widgetLibs/BindableWidget.js
@@ -168,8 +168,9 @@ Aria.classDefinition({
          * @param {Object} arg Any parameter which will be passed as first parameter to callback function.
          */
         evalCallback : function (callback, args) {
-            return this._context.evalCallback(callback, args);
+            if (this._context) {
+                return this._context.evalCallback(callback, args);
+            }
         }
-
     }
 });


### PR DESCRIPTION
Just check that the associated template context for a widget still exists
before trying to execute a given callback on it.

Fixes #1232
