### PR TITLE
fix #1021 getElementsByClassName discrepancy in Fx 3.6

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1305,6 +1305,7 @@ Aria.classDefinition({
             if (!domElement) {
                 return [];
             }
+            className = String(className); // Fx 3.6 compat
             if (domElement.getElementsByClassName) {
                 return domElement.getElementsByClassName(className);
             } else {


### PR DESCRIPTION
Modern browsers, and IE7+ coerce the class parameter to a string
automatically, it was not the case in Firefox 3.6.
