### PR TITLE
Updating type check for Array

### DIFF
--- a/src/aria/core/JsonTypesCheck.js
+++ b/src/aria/core/JsonTypesCheck.js
@@ -452,7 +452,7 @@
                 preprocess : __checkContentType,
                 process : function (args) {
                     var v = args.value;
-                    if (typeof(v) != 'object' || v == null || v.constructor != Array) {
+                    if (!typeUtils.isArray(v)) {
                         return __badTypeError(this, args);
                     }
                     var ct = args.beanDef.$contentType;


### PR DESCRIPTION
The check for array was not working properly, this commit change the condition in order to use the aria.utils.Type.isArray method instead.
