### PR TITLE
Correct interpretation of dates with localized months

### DIFF
--- a/src/aria/core/ResMgr.js
+++ b/src/aria/core/ResMgr.js
@@ -78,6 +78,9 @@ var resMgr = module.exports = Aria.classDefinition({
         this.loadedResources = null;
         this.resources = null;
     },
+    $events : {
+        "resourcesReloadComplete" : "Raised after resources are reloaded after a locale change"
+    },
     $statics : {
         DEPRECATED_METHOD : "%1 is deprecated.",
         BYPASSING_LOADER : "Unexpected call to Aria.resourcesDefinition for %1. The resource loader was not properly used.",
@@ -316,6 +319,7 @@ var resMgr = module.exports = Aria.classDefinition({
             }
             var self = this;
             Promise.all(tasks).thenSync(function () {
+                self.$raiseEvent("resourcesReloadComplete");
                 self.$callback(cb);
             });
         },

--- a/src/aria/resources/DateRes_et_EE.js
+++ b/src/aria/resources/DateRes_et_EE.js
@@ -32,7 +32,19 @@ Aria.resourcesDefinition({
         // a false value for the following items mean: use substring
         // to generate the short versions of days or months
         dayShort : false,
-        monthShort : false,
+        monthShort : [
+            "jaan",
+            "veebr",
+            "märts",
+            "apr",
+            "mai",
+            "juuni",
+            "juuli",
+            "aug",
+            "sept",
+            "okt",
+            "nov",
+            "dets"],
         month : [
             "jaanuar",
             "veebruar",

--- a/src/aria/resources/DateRes_fi_FI.js
+++ b/src/aria/resources/DateRes_fi_FI.js
@@ -32,7 +32,19 @@ Aria.resourcesDefinition({
         // a false value for the following items mean: use substring
         // to generate the short versions of days or months
         dayShort : false,
-        monthShort : false,
+        monthShort : [
+            "tammi",
+            "helmi",
+            "maalis",
+            "huhti",
+            "touko",
+            "kes\u00E4",
+            "hein\u00E4",
+            "elo",
+            "syys",
+            "loka",
+            "marras",
+            "joulu"],
         month : [
             "tammikuu",
             "helmikuu",

--- a/src/aria/resources/DateRes_fr_FR.js
+++ b/src/aria/resources/DateRes_fr_FR.js
@@ -32,7 +32,20 @@ Aria.resourcesDefinition({
         // a false value for the following items mean: use substring
         // to generate the short versions of days or months
         dayShort : false,
-        monthShort : false,
+        monthShort : [
+            "Janv.",
+            "F\u00E9vr.",
+            "Mars",
+            "Avr.",
+            "Mai",
+            "Juin",
+            "Juil.",
+            "Ao\u00FBt",
+            "Sept.",
+            "Oct.",
+            "Nov.",
+            "D\u00E9c."
+        ],
         month : [
             "Janvier",
             "F\u00E9vrier",

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -308,10 +308,10 @@ Aria.classDefinition({
             try {
 
                 var formattedValue = aria.utils.Date.format(new Date(2010, 3, 1, 0, 0, 0), "d MMM y");
-                this.assertTrue(formattedValue === "1 Avr 10", "Wrong output: " + formattedValue);
+                this.assertTrue(formattedValue === "1 Avr. 10", "Wrong output: " + formattedValue);
 
                 formattedValue = aria.utils.Date.format(new Date(2010, 3, 1, 0, 0, 0), "Ud MMM y");
-                this.assertTrue(formattedValue === "1 AVR 10", "Wrong output: " + formattedValue);
+                this.assertTrue(formattedValue === "1 AVR. 10", "Wrong output: " + formattedValue);
 
                 formattedValue = aria.utils.Date.format(new Date(2010, 3, 1, 0, 0, 0), "d I y");
                 this.assertTrue(formattedValue === "1 APR 10", "Wrong output: " + formattedValue);
@@ -323,7 +323,7 @@ Aria.classDefinition({
                 this.assertTrue(formattedValue === "01 APR 2010", "Wrong output: " + formattedValue);
 
                 formattedValue = aria.utils.Date.format(new Date(2010, 3, 1, 0, 0, 0), "Ud MMM y");
-                this.assertTrue(formattedValue === "1 AVR 10", "Wrong output: " + formattedValue);
+                this.assertTrue(formattedValue === "1 AVR. 10", "Wrong output: " + formattedValue);
 
                 this.notifyTestEnd("testAsyncDateFormatting");
 

--- a/test/aria/utils/DatePatternInterpret.js
+++ b/test/aria/utils/DatePatternInterpret.js
@@ -20,6 +20,10 @@ Aria.classDefinition({
     $classpath : "test.aria.utils.DatePatternInterpret",
     $extends : "aria.jsunit.TestCase",
     $dependencies : ["aria.utils.Date"],
+    $constructor : function () {
+        this.$TestCase.$constructor.call(this);
+        this.defaultTestTimeout = 60000;
+    },
     $prototype : {
         testInputPattern : function () {
             var today = new Date();
@@ -68,6 +72,94 @@ Aria.classDefinition({
             this.assertEquals(interpretedDate.getDate(), expectedDate.getDate());
             this.assertEquals(interpretedDate.getMonth(), expectedDate.getMonth());
             this.assertEquals(interpretedDate.getFullYear(), expectedDate.getFullYear());
+        },
+
+        testAsyncLocalizedInterpretation : function () {
+
+            this._toSkip = {
+                "ja_JP" : {
+                    "ddMMMyyyy" : [0, 1],
+                    "ddMMM" : [0, 1]
+                },
+                "ko_KR" : {
+                    "ddMMMyyyy" : [0, 1],
+                    "ddMMMMyyyy" : [0, 1],
+                    "ddMMM" : [0, 1],
+                    "ddMMMM" : [0, 1]
+                }
+            };
+            this._testLocale(0);
+        },
+
+        _testLocale : function (index) {
+            var languages = this.languages = [["ar", "SA"], ["da", "DK"], ["de", "DE"], ["en", "GB"], ["en", "US"],
+                    ["es", "ES"], ["et", "EE"], ["fi", "FI"], ["fr", "FR"], ["he", "IL"], ["is", "IS"], ["it", "IT"],
+                    ["ja", "JP"], ["kl", "GL"], ["ko", "KR"], ["nl", "NL"], ["no", "NO"], ["pl", "PL"], ["pt", "BR"],
+                    ["pt", "PT"], ["ru", "RU"], ["sv", "SE"], ["th", "TH"], ["tk", "TK"], ["tr", "TR"], ["zh", "CN"],
+                    ["is", "IS"], ["zh", "TW"]];
+            if (index < languages.length) {
+                aria.core.AppEnvironment.setEnvironment({
+                    language : {
+                        primaryLanguage : languages[index][0],
+                        region : languages[index][1]
+                    }
+                }, {
+                    fn : this._afterLocaleChange,
+                    scope : this,
+                    args : index
+                });
+            } else {
+                this.notifyTestEnd("testAsyncLocalizedInterpretation");
+            }
+        },
+
+        _afterLocaleChange : function (res, index) {
+            var language = this.languages[index].join("_");
+            var patterns = ["dd MMM yyyy", "dd MMMM yyyy", "ddMMMyyyy", "ddMMMMyyyy", "dd MMM", "dd MMMM", "ddMMM",
+                    "ddMMMM", "dd I yyyy", "ddIyyyy", "ddI", "dd-MMM-yyyy","dd/MMM*yyyy"];
+            var date, dateUtil = aria.utils.Date, formattedDate, interpreted, middleDate;
+            for (var k = 0; k < 12; k++) {
+                date = new Date(2015, k, 1);
+                middleDate = new Date(2015, k, 15);
+                for (var j = 0; j < patterns.length; j++) {
+                    var skip = this._toSkip[language] && this._toSkip[language][patterns[j]]
+                            && aria.utils.Array.contains(this._toSkip[language][patterns[j]], k);
+                    if (!skip) {
+                        formattedDate = dateUtil.format(date, patterns[j]);
+                        interpreted = dateUtil.interpret(formattedDate, {
+                            outputPattern : patterns[j]
+                        });
+
+                        this._assertDatesEquality(date, interpreted, formattedDate, language, patterns[j]);
+
+                        if (!/[\-\/]/.test(patterns[j])) {
+                            // check +5 pattern
+                            formattedDate = dateUtil.format(middleDate, patterns[j]);
+                            interpreted = dateUtil.interpret(formattedDate + "/+5");
+                            this._assertDatesEquality(middleDate, interpreted, formattedDate, language, patterns[j], "+5");
+
+                            // check -5 pattern
+                            interpreted = dateUtil.interpret(formattedDate + "/-5");
+                            this._assertDatesEquality(middleDate, interpreted, formattedDate, language, patterns[j], "-5");
+                        }
+                    }
+
+                }
+            }
+            this._testLocale(++index);
+        },
+
+        _assertDatesEquality : function (expected, got, formattedDate, language, pattern, shift) {
+            shift = shift || 0;
+            this.assertEquals(expected.getDate() + parseInt(shift, 10), got.getDate(), "Date " + formattedDate
+                    + (shift ? "/" + shift : "") + " was not correctly interpreted in language " + language);
+
+            this.assertEquals(expected.getMonth(), got.getMonth(), "Date " + formattedDate
+                    + " was not correctly interpreted in language " + language);
+            if (/y/.test(pattern)) {
+                this.assertEquals(expected.getFullYear(), got.getFullYear(), "Date " + formattedDate
+                        + " was not correctly interpreted in language " + language);
+            }
         }
     }
 });


### PR DESCRIPTION
Localized months were not recognized as valid inputs of the `aria.utils.Date.interpret` method.
This means that whenever the user selected a date in a DatePicker with output pattern containing "MMM" or "MMMM" (meaning with the localized short or full month), and then just changing, for example, the year, the entry could not be recognized.

This commit adds this feature. Also, the special case 04DEC/+13 now supports localized dates and the presence of spaces between day, month and year.
