### PR TITLE
Enforce Tooltip dimensions configuration

### DIFF
--- a/src/aria/widgets/container/Tooltip.js
+++ b/src/aria/widgets/container/Tooltip.js
@@ -35,7 +35,7 @@
     Aria.classDefinition({
         $classpath : 'aria.widgets.container.Tooltip',
         $extends : 'aria.widgets.container.Container',
-        $dependencies : ['aria.widgets.container.Div', 'aria.popups.Popup'],
+        $dependencies : ['aria.widgets.container.Div', 'aria.popups.Popup', 'aria.utils.Math', 'aria.utils.Dom'],
         $onload : function (classRef) {
             timer = aria.core.Timer;
         },
@@ -45,6 +45,7 @@
         },
         $constructor : function (cfg, ctxt) {
             this.$Container.constructor.apply(this, arguments);
+            this._directInit = false;
             this._associatedWidget = null;
             this._showTimeout = null;
             this._popup = null; // will contain the popup object when displayed
@@ -69,11 +70,16 @@
              */
             _writerCallback : function (out) {
                 var cfg = this._cfg;
+                var viewport = aria.utils.Dom._getViewportSize();
                 // We can lose the reference to this div, as it will be destroyed by the section
                 var div = new aria.widgets.container.Div({
                     sclass : cfg.sclass,
                     width : cfg.width,
                     height : cfg.height,
+                    minWidth : cfg.minWidth,
+                    minHeight : cfg.minHeight,
+                    maxWidth : aria.utils.Math.min(cfg.maxWidth, viewport.width),
+                    maxHeight : aria.utils.Math.min(cfg.maxHeight, viewport.height),
                     printOptions : cfg.printOptions,
                     cssClass : this._context.getCSSClassNames(true)
                 }, this._context, this._lineNumber);

--- a/test/aria/widgets/container/tooltip/InnerTemplate.tpl
+++ b/test/aria/widgets/container/tooltip/InnerTemplate.tpl
@@ -39,7 +39,9 @@
         {@aria:Tooltip {
             id : "myTestingTooltip",
             macro : "tooltipContent",
-            showDelay : 12
+            showDelay : 12,
+            minWidth : 80,
+            maxWidth : 100
         }/}
 
         {@aria:Tooltip {

--- a/test/aria/widgets/container/tooltip/TooltipTestCase.js
+++ b/test/aria/widgets/container/tooltip/TooltipTestCase.js
@@ -71,9 +71,12 @@ Aria.classDefinition({
             var tooltipContent = DomUtil.getElementById("testMe");
             var contentGeometry = DomUtil.getGeometry(tooltipContent);
             var anchorGeometry = DomUtil.getGeometry(tooltipAnchor);
+            var tooltipContainerWidth = DomUtil.getGeometry(tooltipContent.parentNode).width;
 
             var distance = Math.abs(contentGeometry.y - anchorGeometry.y);
             this.assertTrue(distance < 60, "Tooltip is too far from the anchor");
+            this.assertTrue(tooltipContainerWidth >= 80, "Tooltip width is " + tooltipContainerWidth + " while minWidth was set to 80");
+            this.assertTrue(tooltipContainerWidth <= 100, "Tooltip width is " + tooltipContainerWidth + " while maxWidth was set to 100");
 
             this.end();
         }


### PR DESCRIPTION
Dimension configurations (min/maxWidth, min/maxHeight) for the Tooltip widget were ignored and generated exceptions.  This PR fixes that.
