### PR TITLE
Fixing path to the Java Robot applet

### DIFF
--- a/src/aria/jsunit/RobotJavaApplet.js
+++ b/src/aria/jsunit/RobotJavaApplet.js
@@ -232,7 +232,7 @@ Aria.classDefinition({
             VK_Y : 89,
             VK_Z : 90
         },
-        absoluteUrlRegExp : /^https?:\/\//
+        absoluteUrlRegExp : /^(https?:\/)?\//
     },
     $prototype : {
 


### PR DESCRIPTION
This pull request fixes the regular expression which was used to detect absolute URLs. URLs starting with a slash are now considered absolute, they are not relative to the <base> tag.

Because of this issue, the robot was not starting, when used with attester, in tests which use an iframe, such as `test.aria.widgets.container.tooltip.TooltipTestCase`.
