### PR TITLE
Test launcher fixes and improvements

### DIFF
--- a/test/test.htm
+++ b/test/test.htm
@@ -10,8 +10,7 @@
         if (document.location.protocol == "file:") {
             alert("file:// protocol is not supported, please run this URL through HTTP server")
         }
-        var isAmaBuild = !!(document.location.pathname.match(/\/aria\-templates(-dave|-dev)?\/test\//));
-        var url = document.location.href;
+        var url = document.location.search;
 
         // Aria Templates framework parameters
         var Aria = {
@@ -24,12 +23,15 @@
         var devFiles = (url.indexOf("dev=false") == -1);
 
         var atversion;
-        if (isAmaBuild) {
-            atversion = "1.1-SNAPSHOT";
-        } else { // if opensource build then version must be placed in the URL
-            var versionMatch = url.match(/atversion\=(\d+\.\d+\.\d+)/);
-            if (versionMatch) {
-                atversion = versionMatch[1];
+        var versionMatch = url.match(/atversion\=(\d+\.\d+(\.|-)[0-9A-Z]+)/);
+        var isAmaBuild;
+        if (versionMatch) {
+            atversion = versionMatch[1];
+            isAmaBuild = (versionMatch[2] == "-");
+        } else {
+            isAmaBuild = !!(document.location.pathname.match(/\/aria\-templates(-\w+)?\/test\//));
+            if (isAmaBuild) {
+                atversion = "1.1-SNAPSHOT";
             } else {
                 alert("Need an 'atversion=x.y.z' in the query string.");
             }
@@ -125,6 +127,7 @@
         var info = "skin " + skinName + " / ";
         info += (devFiles ? "dev" : "built") + " files / ";
         info += (isAmaBuild ? "ama" : "opensource") + " / ";
+        info += "atversion: " + atversion + " / ";
         info += (Aria.verbose ? "verbose" : "nonverbose") + " console";
         document.getElementById("_TestInfoOutput_").innerHTML = info;
     </script>

--- a/test/testLauncher.js
+++ b/test/testLauncher.js
@@ -76,10 +76,10 @@ Aria.load({
             html += '<form action="test.htm" style="text-align:center; font-family:Arial;">';
             if (qs.getKeyValue('dev') == "false") {
                 html += '<input type="hidden" name="dev" value="false">';
-                var atversion = qs.getKeyValue('atversion');
-                if (atversion) {
-                    html += '<input type="hidden" name="atversion" value="' + atversion + '">';
-                }
+            }
+            var atversion = qs.getKeyValue('atversion');
+            if (atversion) {
+                html += '<input type="hidden" name="atversion" value="' + atversion + '">';
             }
             if (qs.getKeyValue('verbose') == "false") {
                 html += '<input type="hidden" name="verbose" value="false">';


### PR DESCRIPTION
This PR includes the following changes:
- it fixes an issue with the form used by the launcher to request the
  test classpath (the URL did not include the version number parameter
  when using dev files).
- it adds the ability to change the `isAmaBuild` flag from the URL
  (by using `-` or `.` in the second part of the version number).
- it extends the pattern of `isAmaBuild` URLs to include any path which
  follows the `/aria-templates-something` pattern (instead of only
  `/aria-templates-dave` and `/aria-templates-dev`).
- it adds the Aria Templates version number on the test page
