### PR TITLE
feat #1261 Classic Test Runner branding

### DIFF
--- a/src/aria/tester/runner/view/main/MainCSS.tpl.css
+++ b/src/aria/tester/runner/view/main/MainCSS.tpl.css
@@ -42,8 +42,15 @@
         height : 100px;
     }
 
+    .nameHeader {
+        float:left;
+        position:relative;
+        height: 50px;
+        font: italic bold 28px/50px 'Times New Roman';
+        color: rgb(0, 60, 136)
+    }
+
     .monitor {
-        margin-top:50px;
         position:relative;
         float:left;
         z-index:10000;

--- a/src/aria/tester/runner/view/normal/Normal.tpl
+++ b/src/aria/tester/runner/view/normal/Normal.tpl
@@ -37,6 +37,9 @@
             defaultTemplate:"aria.tester.runner.view.nav.Nav"
         } /}
         </div>
+        <div class="nameHeader" style="width: ${$hdim(180)}px;">
+            Classic Test Runner
+        </div>
         <div class="monitor" style="
             height : ${$vdim(282)}px;
             width : ${$hdim(180)}px;


### PR DESCRIPTION
Related to attester/attester#66

I coined the term "Classic Test Runner" to differentiate it from Attester to have less confusion (because people keep talking "Attester" about both of them).

This PR just adds a banner with that name so that it's obvious (I hope) this is independent entity from Attester.

![ctr](https://cloud.githubusercontent.com/assets/1437027/3983966/0dce2dd2-2884-11e4-88e6-71aabed9107f.png)

Should someone have better name or better CSS, scream :)
