### PR TITLE
Removing the need for a build step after changing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 /src/aria/jsunit/robot-applet*
 
 /build/target/
+/src/aria/bootstrap.js
+/src/aria/bootstrap-node.js
+/src/aria/noderError/

--- a/build/grunt-config/config-atpackager-bootstrap-src.js
+++ b/build/grunt-config/config-atpackager-bootstrap-src.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aria Templates bootstrap build file for files generated in the source folder directly.
+ */
+module.exports = function (grunt) {
+    var packagingSettings = require('./config-packaging')(grunt);
+
+    var getNoderPackage = function (packageFile, mainFile, environment) {
+        return {
+            name : packageFile,
+            builder : {
+                type : 'NoderBootstrapPackage',
+                cfg : {
+                    header : packagingSettings.license,
+                    noderModules : ['src/noder-modules/*'],
+                    noderEnvironment : environment,
+                    noderConfigOptions : {
+                        main : mainFile,
+                        failFast : false,
+                        resolver : {
+                            "default" : {
+                                ariatemplates : "aria"
+                            }
+                        },
+                        packaging : {
+                            ariatemplates : true
+                        }
+                    }
+                }
+            },
+            files : [mainFile]
+        };
+    };
+
+    grunt.config.set('atpackager.bootstrapSrc', {
+        options : {
+            sourceDirectories : ['src'],
+            sourceFiles : [],
+            outputDirectory : 'src',
+            visitors : [{
+                        type : 'NoderPlugins',
+                        cfg : {
+                            targetBaseLogicalPath : "aria",
+                            targetFiles : "aria/noderError/**"
+                        }
+                    }, {
+                        type : 'NoderRequiresGenerator',
+                        cfg : {
+                            requireFunction : "syncRequire",
+                            wrapper : "<%= grunt.file.read('src/aria/bootstrap.tpl.js') %>",
+                            targetLogicalPath : 'aria/bootstrap.js',
+                            requires : packagingSettings.bootstrap.files
+                        }
+                    }, {
+                        type : 'NoderRequiresGenerator',
+                        cfg : {
+                            requireFunction : "syncRequire",
+                            wrapper : "<%= grunt.file.read('src/aria/bootstrap.tpl.js') %>",
+                            targetLogicalPath : 'aria/bootstrap-node.js',
+                            requires : packagingSettings.bootstrap.files
+                        }
+                    }],
+            packages : [getNoderPackage("aria/bootstrap.js", "aria/bootstrap.js", "browser"),
+                    getNoderPackage("aria/bootstrap-node.js", "aria/bootstrap-node.js", "node")]
+        }
+    });
+
+    grunt.config.set('removedirs.bootstrapSrc', {
+        folders : ['src/aria/noderError']
+    });
+
+    grunt.registerTask('src', ['removedirs:bootstrapSrc', 'atpackager:bootstrapSrc']);
+};

--- a/build/grunt-config/config-checkStyle.js
+++ b/build/grunt-config/config-checkStyle.js
@@ -27,6 +27,10 @@ module.exports = function (grunt) {
         source : {
             src : [
                     'src/aria/**/*.js',
+                    // Excludes generated files:
+                    '!src/aria/bootstrap.js',
+                    '!src/aria/bootstrap-node.js',
+                    '!src/aria/noderError/**',
                     // Using node.js globals
                     '!src/aria/node.js',
                     // Resource and skin definitions use the global Aria without require

--- a/build/grunt-config/config-packaging.js
+++ b/build/grunt-config/config-packaging.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
         bootstrap : {
             outputDirectory : getPath('../target/bootstrap'),
             files : require('../config/files-bootstrap.json'),
-            checkGlobalsFiles : ['**/*.js', '!aria/noderError/**'],
+            checkGlobalsFiles : ['**/*.js', '!aria/noderError/**', '!aria/bootstrap.js', '!aria/bootstrap-node.js'],
             bootstrapFileName : 'aria/' + pkg.name + '-' + pkg.version + '.js'
         },
         prod : {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -77,16 +77,14 @@ app.get("/playground/dev", function (req, res) {
         model : req.query.model
     });
 });
+// Rename bootstrap prefixing with ariatemplates- this fixes runIsolated in dev mode
 app.get("/aria-templates/dev/aria/ariatemplates-bootstrap.js", function (req, res) {
-    res.sendfile(path.normalize(__dirname + "/../build/target/bootstrap/aria/ariatemplates-" + pkg.version + ".js"));
-});
-app.get("/aria-templates/dev/aria/css/atskin.js", function (req, res) {
-    res.sendfile(path.normalize(__dirname + "/../build/target/bootstrap/aria/css/atskin-" + pkg.version + ".js"));
+    res.sendfile(path.normalize(__dirname + "/../src/aria/bootstrap.js"));
 });
 // Static CSS files for views and tools
 app.use("/css", express.static(__dirname + "/assets/css"));
-// Non minified version points to bootstrap folder
-app.use("/aria-templates/dev", express.static(__dirname + "/../build/target/bootstrap"));
+// Non minified version points to src folder
+app.use("/aria-templates/dev", express.static(__dirname + "/../src"));
 // Minified version points to standard build (npm install)
 app.use("/aria-templates", express.static(__dirname + "/../build/target/production"));
 // Test classpath redirects to test folder

--- a/src/aria/node.js
+++ b/src/aria/node.js
@@ -1,6 +1,6 @@
 /* global Aria:true, aria:true */
 var vm = require("vm"), fs = require("fs"), path = require("path");
-var ariaRootFolderPath = path.normalize(__dirname + "/../../build/target/bootstrap/");
+var ariaRootFolderPath = path.normalize(__dirname + "/../");
 
 /* aria and Aria are going to be global */
 aria = {};
@@ -19,7 +19,7 @@ global.load = function (filePath) {
 };
 
 try {
-    require(ariaRootFolderPath + "aria/node.js");
+    require(ariaRootFolderPath + "aria/bootstrap-node.js");
 
     // For all the other classes we use IO, define our node transport
     Aria.classDefinition({

--- a/test/test.htm
+++ b/test/test.htm
@@ -32,6 +32,8 @@
             isAmaBuild = !!(document.location.pathname.match(/\/aria\-templates(-\w+)?\/test\//));
             if (isAmaBuild) {
                 atversion = "1.1-SNAPSHOT";
+            } else if (devFiles) {
+                atversion = "bootstrap"; // atversion is not used in this case
             } else {
                 alert("Need an 'atversion=x.y.z' in the query string.");
             }
@@ -58,9 +60,9 @@
             }
         } else {
             if (devFiles) {
-                ariaRootPath = "../build/target/bootstrap/";
-                bootstrapFile = "aria/ariatemplates-" + atversion + ".js";
-                skinFile = "aria/css/" + skinName + "-" + atversion + ".js";
+                ariaRootPath = "../src/";
+                bootstrapFile = "aria/bootstrap.js";
+                skinFile = "aria/css/" + skinName + ".js";
             } else {
                 ariaRootPath = "../build/target/production/";
                 bootstrapFile = "aria/ariatemplates-" + atversion + ".js";


### PR DESCRIPTION
Before the migration to noder-js, it was possible to run Aria Templates directly from its src folder.

With the migration to noder-js, this was not possible any more for two reasons:

1) files in the src folder were using the old syntax (with `$dependencies`) and were converted at build time to the new syntax (with `require`)

-> now, starting with commit b0ae188305c0fa16fe7d458803580da551a1cb94, files in the repository are using the new syntax and it is no longer needed to convert them at build time.

2) the entry point file of Aria Templates needs to be generated (as it is built on top of noder-js, overriding one of its modules) and was generated in the build/target/bootstrap folder.

-> this pull request is changing the location where the entry point file is generated. It is now generated in the src foilder so that it is possible to fully execute Aria Templates directly from its src folder.

The generation of files in the src folder is now part of the full build and can also be run independently with: `grunt src`

The following files are generated in the src folder:
src/aria/bootstrap.js
src/aria/bootstrap-node.js
src/aria/noderError/*.js

After running "grunt src", it is possible to use the src folder directly to serve the Aria Templates files, and then changing most of the framework files can be done without requiring a build step. Running again `grunt src` is needed after changing noder-js itself or files in the src/noder-modules folder.
