### PR TITLE
fix Select widget with 'options' and 'value' binded.

### DIFF
--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -413,13 +413,7 @@ module.exports = Aria.classDefinition({
                         stopValueProp : true
                     });
                 } else {
-                    var selectField = this.getSelectField();
-                    for (var i = 0; i < selectField.options.length; i++) {
-                        if (selectField.options[i].value === newValue) {
-                            selectField.options[i].selected = true;
-                            break;
-                        }
-                    }
+                    this._selectValue(newValue);
                 }
             } else if (propertyName === 'mandatory') {
                 this._updateState();
@@ -434,8 +428,9 @@ module.exports = Aria.classDefinition({
                 this._updateState();
             } else if (propertyName === 'options') {
                 if (this.controller) {
+                    var selectValue = this.controller.getDataModel().value;
                     this.controller.setListOptions(newValue);
-                    var report = this.controller.checkValue(null);
+                    var report = this.controller.checkValue(selectValue);
                     this._reactToControllerReport(report, {
                         stopValueProp : true
                     });
@@ -450,6 +445,7 @@ module.exports = Aria.classDefinition({
                     }
 
                     var selectField = this.getSelectField();
+                    var currentValue = selectField.value;
                     // update the options list
                     var optionsListString = optionsMarkup.join('');
                     if (ariaCoreBrowser.isIE9 || ariaCoreBrowser.isIE8 || ariaCoreBrowser.isIE7) {
@@ -463,6 +459,7 @@ module.exports = Aria.classDefinition({
                     } else {
                         selectField.innerHTML = optionsListString;
                     }
+                    this._selectValue(currentValue);
                 }
 
             } else if (propertyName === 'formatError' || propertyName === 'formatErrorMessages'
@@ -471,6 +468,24 @@ module.exports = Aria.classDefinition({
                 this._updateState();
             } else {
                 this.$DropDownInput._onBoundPropertyChange.apply(this, arguments);
+            }
+        },
+
+
+        /**
+         * Set the 'selected' attribut on each options to true or false depending on the value
+         * @param {String} value The value to compare
+         * @private
+         */
+        _selectValue : function(value) {
+            var selectField = this.getSelectField();
+            var options = selectField.options;
+            for (var i = 0; i < options.length; i++) {
+                var option = options[i];
+                if (option.value === value) {
+                    option.selected = true;
+                    break;
+                }
             }
         },
 

--- a/test/aria/widgets/form/select/valueAndOptionsBinding/SelectTemplateTest.tpl
+++ b/test/aria/widgets/form/select/valueAndOptionsBinding/SelectTemplateTest.tpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath:"test.aria.widgets.form.select.valueAndOptionsBinding.SelectTemplateTest"
+}}
+    {macro main()}
+        {@aria:Select {
+            id: "simple_select",
+            label: "Select: ",
+            labelWidth:220,
+            sclass: 'simple',
+            bind: {
+                value: {
+                    to : "selectedValue1",
+                    inside : data
+                },
+                options: {
+                    to : "options",
+                    inside : data
+                }
+            }
+        }/}
+        <br />
+        {@aria:Select {
+            id: "select",
+            label: "Select: ",
+            labelWidth:220,
+             bind: {
+                value: {
+                    to : "selectedValue2",
+                    inside : data
+                },
+                options: {
+                    to : "options",
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+{/Template}

--- a/test/aria/widgets/form/select/valueAndOptionsBinding/SelectTemplateTestCase.js
+++ b/test/aria/widgets/form/select/valueAndOptionsBinding/SelectTemplateTestCase.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.select.valueAndOptionsBinding.SelectTemplateTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Dom", "aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            selectedValue1 : "two",
+            selectedValue2 : "two",
+            options : [{
+                value : "one",
+                label : "One"
+            }, {
+                value : "two",
+                label : "Two"
+            },{
+                value : "three",
+                label : "Three"
+            }]
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.select.valueAndOptionsBinding.SelectTemplateTest",
+            data : this.data
+
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+
+            // Change the options by binding:
+            aria.utils.Json.setValue(this.data, "options", [{
+                value : "zero",
+                label : "Zero"
+            },{
+                value : "four",
+                label : "Four"
+            }, {
+                value : "two",
+                label : "Two"
+            }]);
+
+            // Check that the selected is still "two" for a simple html widget
+            var select = this.getWidgetInstance("simple_select").getSelectField();
+            this.assertEquals(select.value, "two", "The value %2 should be selected instead of %1");
+
+            // Check that the selected is still "two" for a 'complex' select widget
+            var select = this.getWidgetInstance("select").getTextInputField();
+            var text = aria.utils.String.trim(select.textContent || select.innerText);
+            this.assertEquals(text, "Two", "The value %2 should be selected instead of %1");
+
+            this.end();
+        }
+    }
+});


### PR DESCRIPTION
If the options list changed, the value is no longer considered and
the first one is always selected
