### PR TITLE
fix npm test run twice raised errors

### DIFF
--- a/build/grunt-config/config-checkStyle.js
+++ b/build/grunt-config/config-checkStyle.js
@@ -56,7 +56,8 @@ module.exports = function (grunt) {
                         // Syntax errors, used for testing
                         '!test/aria/templates/test/error/*.js',
                         // Syntax errors, used for testing
-                        '!test/aria/templates/reloadResources/ExternalResourceErr.js']
+                        '!test/aria/templates/reloadResources/ExternalResourceErr.js',
+                        '!test/nodeTestResources/testProject/target/**/*']
             },
             options : {
                 "unused" : false,


### PR DESCRIPTION
It was due to jslint validation for \test\nodeTestResources\testProject\target.
This folder has been excluded.
