### PR TITLE
Fixing random test failures with Slider and DoubleSlider

### DIFF
--- a/src/aria/touch/widgets/DoubleSlider.js
+++ b/src/aria/touch/widgets/DoubleSlider.js
@@ -23,7 +23,7 @@ var ariaWidgetLibsBaseWidget = require("../../widgetLibs/BaseWidget");
 var ariaUtilsJson = require("../../utils/Json");
 var ariaCoreBrowser = require("../../core/Browser");
 var ariaCoreJsonValidator = require("../../core/JsonValidator");
-
+var ariaUtilsDragdropDrag = require("../../utils/dragdrop/Drag");
 
 /**
  * Double Slider widget.<br/> This widget has two movable thumbs over a region defined by the width of the widget.<br/>
@@ -293,7 +293,7 @@ module.exports = Aria.classDefinition({
             if (ariaCoreBrowser.isOldIE) {
                 this.getDom().onselectstart = Aria.returnFalse;
             }
-            this._loadAndCreateDraggable();
+            this._createSliderDrag();
         },
 
         /**
@@ -359,35 +359,13 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Load the dependency for Drag before if not loaded yet.
-         * @protected
-         */
-        _loadAndCreateDraggable : function () {
-            if (aria.utils.dragdrop && aria.utils.dragdrop.Drag) {
-                this._createSliderDrag();
-            } else {
-                Aria.load({
-                    classes : ["aria.utils.dragdrop.Drag"],
-                    oncomplete : {
-                        fn : this._createSliderDrag,
-                        scope : this
-                    }
-                });
-            }
-        },
-
-        /**
          * Create the Draggable element.
          * @protected
          */
         _createSliderDrag : function () {
-            if (!this._cfg) {
-                // In case the widget gets disposed while loading the dependencies
-                return;
-            }
             var thumbs = [this._firstSlider, this._secondSlider];
             for (var i = 0, len = thumbs.length; i < len; i++) {
-                this._draggable[i] = new aria.utils.dragdrop.Drag(thumbs[i], {
+                this._draggable[i] = new ariaUtilsDragdropDrag(thumbs[i], {
                     handle : thumbs[i],
                     proxy : null,
                     axis : "x",

--- a/src/aria/touch/widgets/Slider.js
+++ b/src/aria/touch/widgets/Slider.js
@@ -21,7 +21,7 @@ var ariaUtilsHtml = require("../../utils/Html");
 var ariaWidgetLibsBaseWidget = require("../../widgetLibs/BaseWidget");
 var ariaUtilsJson = require("../../utils/Json");
 var ariaCoreJsonValidator = require("../../core/JsonValidator");
-
+var ariaUtilsDragdropDrag = require("../../utils/dragdrop/Drag");
 
 /**
  * Touch Slider Widget.
@@ -316,7 +316,7 @@ module.exports = Aria.classDefinition({
             }
             this._setLeftPosition();
             this._updateDisplay();
-            this._loadAndCreateDraggable();
+            this._createSliderDrag();
         },
 
         /**
@@ -352,33 +352,11 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Load the dependency for Drag before if not loaded yet.
-         * @protected
-         */
-        _loadAndCreateDraggable : function () {
-            if (aria.utils.dragdrop && aria.utils.dragdrop.Drag) {
-                this._createSliderDrag();
-            } else {
-                Aria.load({
-                    classes : ["aria.utils.dragdrop.Drag"],
-                    oncomplete : {
-                        fn : this._createSliderDrag,
-                        scope : this
-                    }
-                });
-            }
-        },
-
-        /**
          * Create the Draggable element.
          * @protected
          */
         _createSliderDrag : function () {
-            if (!this._cfg) {
-                // In case the widget gets disposed while loading the dependencies
-                return;
-            }
-            this._draggable = new aria.utils.dragdrop.Drag(this._slider, {
+            this._draggable = new ariaUtilsDragdropDrag(this._slider, {
                 handle : this._slider,
                 proxy : null,
                 axis : "x",


### PR DESCRIPTION
This PR makes `aria.utils.dragdrop.Drag` a static dependency of the Slider and DoubleSlider widgets. It does not make sense to have it as a dynamic dependency, as it is always needed, as soon as those
widgets are used. Moreover, using a dynamic dependency makes their test fail randomly, as the dependency may not have been completely loaded when the test starts, leading to errors.
