### PR TITLE
Fixing keystrokes-related failing tests on Mac OS

### DIFF
--- a/test/aria/widgets/form/autocomplete/caret/CaretTestCase.js
+++ b/test/aria/widgets/form/autocomplete/caret/CaretTestCase.js
@@ -21,8 +21,10 @@ Aria.classDefinition({
     },
     $prototype : {
         runTemplateTest : function () {
+            var isMac = aria.core.Browser.isMac;
+            var home = isMac ? "[<META>][left][>META<]" : "[home]";
             var input = this.getInputField("ac");
-            this.synEvent.execute([["click", input], ["type", input, "[home][right][<shift>][right][right][>shift<]"],
+            this.synEvent.execute([["click", input], ["type", input, home + "[right][<shift>][right][right][>shift<]"],
                     ["pause", 1000], ["type", input, "a"], ["pause", 500], ["type", input, "p"], ["pause", 500]], {
                 fn : this.onType,
                 scope : this

--- a/test/aria/widgets/form/textarea/maxlength/MaxLengthTestCase.js
+++ b/test/aria/widgets/form/textarea/maxlength/MaxLengthTestCase.js
@@ -23,6 +23,8 @@ Aria.classDefinition({
     },
     $prototype : {
         runTemplateTest : function () {
+            var isMac = aria.core.Browser.isMac;
+            this.ctrlKey = isMac ? "META" : "CTRL";
 
             var textareas = Aria.$window.document.getElementsByTagName("textarea");
             this.textarea = textareas[0];
@@ -49,7 +51,7 @@ Aria.classDefinition({
             this.synEvent.click(this.textareaForCopy, {
                 fn : function () {
                     aria.utils.Caret.setPosition(this.textareaForCopy, 0, 3);
-                    this.synEvent.type(this.textareaForCopy, "[<CTRL>]c[>CTRL<]", {
+                    this.synEvent.type(this.textareaForCopy, "[<" + this.ctrlKey + ">]c[>" + this.ctrlKey + "<]", {
                         fn : this.paste,
                         scope : this
                     });
@@ -62,7 +64,7 @@ Aria.classDefinition({
             this.synEvent.click(this.textarea, {
                 fn : function () {
                     aria.utils.Caret.setPosition(this.textarea, 0, 2);
-                    this.synEvent.type(this.textarea, "[<CTRL>]v[>CTRL<]", {
+                    this.synEvent.type(this.textarea, "[<" + this.ctrlKey + ">]v[>" + this.ctrlKey + "<]", {
                         fn : function () {
                             /*
                             this.waitFor({


### PR DESCRIPTION
This PR fixes 2 failing tests on Mac OS, due to different keystrokes on this operating system.
