### PR TITLE
Fixing scroll bars related failing tests on Mac OS

### DIFF
--- a/src/aria/templates/Layout.js
+++ b/src/aria/templates/Layout.js
@@ -22,7 +22,6 @@ var ariaUtilsAriaWindow = require("../utils/AriaWindow");
 var ariaCoreTimer = require("../core/Timer");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
 
-
 (function () {
     var layout;
     var timer;
@@ -337,41 +336,51 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
             },
 
             /**
-             * Returns the width of scrollbars.
+             * Returns the width of scrollbars in pixels, as measured in the current browser.
              * @return {Number}
              */
-            getScrollbarsWidth : function () {
+            getScrollbarsMeasuredWidth : function () {
                 if (__scrollBarsWidth != null) {
                     return __scrollBarsWidth;
                 }
-                if (ariaCoreBrowser.isMac && ariaCoreBrowser.isWebkit) {
-                    return 17; // 17px is the size of scrollbar width on Safari and Chrome on Mac
-                } else {
-                    var document = Aria.$window.document;
-                    var o = document.createElement("div"); // outer div
-                    var i = document.createElement("div"); // inner div
-                    o.style.overflow = "";
-                    o.style.position = "absolute";
-                    o.style.left = "-10000px";
-                    o.style.top = "-10000px";
-                    o.style.width = "500px";
-                    o.style.height = "500px";
-                    // Old solution with width 100% seems to behave correctly
-                    // for all browsers except IE7. Some research gives that
-                    // just for IE7 this method does not work when setting width 100%,
-                    // but works correctly setting no width
-                    if (!ariaCoreBrowser.isIE7) {
-                        i.style.width = "100%";
-                    }
-                    i.style.height = "100%";
-                    document.body.appendChild(o);
-                    o.appendChild(i);
-                    __scrollBarsWidth = i.offsetWidth;
-                    o.style.overflow = "scroll";
-                    __scrollBarsWidth -= i.offsetWidth;
-                    document.body.removeChild(o);
-                    return __scrollBarsWidth;
+                var document = Aria.$window.document;
+                var o = document.createElement("div"); // outer div
+                var i = document.createElement("div"); // inner div
+                o.style.overflow = "";
+                o.style.position = "absolute";
+                o.style.left = "-10000px";
+                o.style.top = "-10000px";
+                o.style.width = "500px";
+                o.style.height = "500px";
+                // Old solution with width 100% seems to behave correctly
+                // for all browsers except IE7. Some research gives that
+                // just for IE7 this method does not work when setting width 100%,
+                // but works correctly setting no width
+                if (!ariaCoreBrowser.isIE7) {
+                    i.style.width = "100%";
                 }
+                i.style.height = "100%";
+                document.body.appendChild(o);
+                o.appendChild(i);
+                __scrollBarsWidth = i.offsetWidth;
+                o.style.overflow = "scroll";
+                __scrollBarsWidth -= i.offsetWidth;
+                document.body.removeChild(o);
+                return __scrollBarsWidth;
+            },
+
+            /**
+             * Returns the width of scrollbars in pixels. It uses the measured value returned by
+             * getScrollbarsMeasuredWidth if it is greater than zero, and a hard-coded value of 17px otherwise.<br>
+             * The need for a hard-coded value comes from Mac OS for which scrollbars cannot be measured with the
+             * getScrollbarsMeasuredWidth method, because they reserve no space. They are hidden by default, but they
+             * are displayed when scrolling, in which case they can hide some content, if they were not taken into
+             * account in the layout.
+             * @return {Number}
+             */
+            getScrollbarsWidth : function () {
+                var value = this.getScrollbarsMeasuredWidth();
+                return value > 0 ? value : 17;
             }
         }
     });

--- a/test/aria/dom/getGeometry/PartiallyOverflowingFromParentTest.js
+++ b/test/aria/dom/getGeometry/PartiallyOverflowingFromParentTest.js
@@ -21,7 +21,7 @@
 Aria.classDefinition({
     $classpath : 'test.aria.dom.getGeometry.PartiallyOverflowingFromParentTest',
     $extends : 'aria.jsunit.TestCase',
-    $dependencies : ['aria.utils.Dom'],
+    $dependencies : ['aria.utils.Dom', 'aria.templates.Layout'],
     $constructor : function () {
         this.$TestCase.constructor.call(this);
         this.testarea = Aria.$window.document.getElementById("TESTAREA");
@@ -193,7 +193,7 @@ Aria.classDefinition({
             // SSSSSOOSSSSSSS
             // _____OO_______
 
-            // using range to not care much about exact height of the scrollbar which may vary across the browsers
+            var scrollbarWidth = aria.templates.Layout.getScrollbarsMeasuredWidth();
             this._testChildGeometryHeight({
                 parent : {
                     height : 333,
@@ -203,7 +203,7 @@ Aria.classDefinition({
                     height : 500
                 },
                 expectChildGeo : true,
-                expectedChildGeoHeightRange : [313, 332]
+                expectedChildGeoHeight : 333 - scrollbarWidth
             });
         },
 
@@ -239,10 +239,6 @@ Aria.classDefinition({
 
             if (opt.expectedChildGeoHeight) {
                 this.assertEquals(geo.height, opt.expectedChildGeoHeight, "Child's getGeometry().height should have been %2, got %1");
-            }
-            if (opt.expectedChildGeoHeightRange) {
-                var range = opt.expectedChildGeoHeightRange;
-                this.assertTrue(range[0] < geo.height && geo.height < range[1]);
             }
         }
     }

--- a/test/aria/utils/Dom.js
+++ b/test/aria/utils/Dom.js
@@ -20,7 +20,7 @@ Aria.classDefinition({
     $classpath : "test.aria.utils.Dom",
     $extends : "aria.jsunit.TestCase",
     $dependencies : ["aria.utils.Dom", "aria.utils.Type", "aria.utils.DomBeans", "aria.popups.Beans",
-            "aria.utils.Math", "aria.core.JsonValidator"],
+            "aria.utils.Math", "aria.core.JsonValidator", "aria.templates.Layout"],
     $constructor : function () {
         /**
          * Dom elements created, to delete them if there was any issue in the test
@@ -239,6 +239,7 @@ Aria.classDefinition({
          * Test the scroll Into View method
          */
         test_scrollIntoView : function () {
+            var scrollbarsWidth = aria.templates.Layout.getScrollbarsMeasuredWidth();
             Aria.$window.scroll(0, 0);
             var document = Aria.$window.document;
             var test = document.createElement("div");
@@ -280,23 +281,25 @@ Aria.classDefinition({
             // measuring pos is more reliable
             var position = aria.utils.Dom.calculatePosition(target);
 
-            this.assertTrue(position.top <= 405 && position.top >= 401, "Did not scroll vertically properly to object");
-            this.assertTrue(position.left <= 304 && position.left >= 300, "Did not scroll vertically properly to object");
+            this.assertEqualsWithTolerance(position.top, 150 + 10 + 20 + 10 + 300 + 10 - scrollbarsWidth - 60 - 2 * 10, 2, "Did not scroll vertically properly to object (position.top is %1, expecting %2)");
+            this.assertEqualsWithTolerance(position.left, 50 + 10 + 20 + 10 + 300 + 10 - scrollbarsWidth - 60 - 2 * 10, 2, "Did not scroll vertically properly to object (position.left is %1, expecting %2)");
 
             target = document.getElementById("block_66");
 
             aria.utils.Dom.scrollIntoView(target, true);
 
-            var position = aria.utils.Dom.calculatePosition(target);
-            this.assertTrue(position.top < 182 && position.top > 178, "Did not scroll vertically properly to object");
-            this.assertTrue(position.left < 82 && position.left > 78, "Did not scroll vertically properly to object");
+            position = aria.utils.Dom.calculatePosition(target);
+            this.assertEqualsWithTolerance(position.top, 150 + 10 + 20, 2, "Did not scroll vertically properly to object (position.top is %1, expecting %2)");
+            this.assertEqualsWithTolerance(position.left, 50 + 10 + 20, 2, "Did not scroll vertically properly to object (position.left is %1, expecting %2)");
 
             target = document.getElementById("block_77");
-
             // this should not change scrolls as target is already visible
             aria.utils.Dom.scrollIntoView(target);
-            this.assertTrue(position.top < 182 && position.top > 178, "Did not scroll vertically properly to object");
-            this.assertTrue(position.left < 82 && position.left > 78, "Did not scroll vertically properly to object");
+
+            target = document.getElementById("block_66");
+            position = aria.utils.Dom.calculatePosition(target);
+            this.assertEqualsWithTolerance(position.top, 150 + 10 + 20, 2, "Did not scroll vertically properly to object (position.top is %1, expecting %2)");
+            this.assertEqualsWithTolerance(position.left, 50 + 10 + 20, 2, "Did not scroll vertically properly to object (position.left is %1, expecting %2)");
 
             // test body scrolling
             test.innerHTML = "<div id='block_block' style='display:inline-block;height:60px;width:60px;margin:10px;border:solid 10px #A39770;background:#A32500;'></div>";


### PR DESCRIPTION
This commit fixes 2 failing tests on Mac OS. On this operating system, scroll bars do not take any space (they are hidden most of the time, and even when they are displayed, they are displayed on top of the content without changing the layout).
