### PR TITLE
Improving the precision of Drag utility and slider widgets

### DIFF
--- a/src/aria/touch/widgets/Slider.js
+++ b/src/aria/touch/widgets/Slider.js
@@ -407,6 +407,7 @@ module.exports = Aria.classDefinition({
          */
         _onDragStart : function (evt) {
             this._initialDrag = evt.src.posX;
+            this._initialSavedX = this._savedX;
         },
 
         /**
@@ -426,6 +427,7 @@ module.exports = Aria.classDefinition({
         _onDragEnd : function (evt) {
             this._move(evt.src);
             this._initialDrag = null;
+            this._initialSavedX = null;
             if (this._isSwitch) {
                 this._changeSwith();
             }
@@ -460,9 +462,7 @@ module.exports = Aria.classDefinition({
          * @param {Object} src Source of the drag gesture
          */
         _move : function (src) {
-            var diff = src.posX - this._initialDrag;
-            this._savedX += diff;
-            this._initialDrag = src.posX;
+            this._savedX = this._initialSavedX + src.posX - this._initialDrag;
             this._setValue();
             if (this._isSwitch) {
                 this._switchDisplay();

--- a/test/aria/touch/widgets/BaseRobotTest.js
+++ b/test/aria/touch/widgets/BaseRobotTest.js
@@ -53,16 +53,11 @@ Aria.classDefinition({
          * Get the coordinates of a position in the slider, useful as to in Robot.drag
          */
         toSlider : function (thumb, position) {
-            var geometry = this.widget._geometry;
-            var offset = 0;
-            if (thumb === "second") {
-                // We want the second thumb's left border to be on the target, since we are moving
-                // the thumb from the middle we need some offset
-                offset = 0.5 * this.widget._secondWidth;
-            }
+            var geometry = aria.utils.Dom.getClientGeometry(this.widget._domElt);
+            var offset = thumb === "second" ? this.widget._secondWidth / 2 : -this.widget._firstWidth / 2;
             return {
-                x : geometry.x + this.widget._cfg.width * position + offset,
-                y : geometry.y
+                x : geometry.x + this.widget._firstWidth + this.widget._railWidth * position + offset,
+                y : geometry.y + geometry.height / 2
             };
         },
 
@@ -98,8 +93,8 @@ Aria.classDefinition({
 
         expectAround : function (expected) {
             var widgetValue = this.widget.value;
-            this.assertEqualsWithTolerance(widgetValue[0], expected[0], 0.05, "Wrong first value in widget, %1 != %2");
-            this.assertEqualsWithTolerance(widgetValue[1], expected[1], 0.05, "Wrong second value in widget, %1 != %2");
+            this.assertEqualsWithTolerance(widgetValue[0], expected[0], 0.005, "Wrong first value in widget, %1 != %2");
+            this.assertEqualsWithTolerance(widgetValue[1], expected[1], 0.005, "Wrong second value in widget, %1 != %2");
 
             var modelValues = this.data.slider;
             this.assertEquals(widgetValue[0], modelValues[0], "Model differs from widget values, %1 != %2");
@@ -108,11 +103,11 @@ Aria.classDefinition({
             var positionFirst = parseInt(aria.utils.Dom.getStyle(this.widget._firstSlider, "left"), 10);
             var positionSecond = parseInt(aria.utils.Dom.getStyle(this.widget._secondSlider, "left"), 10);
 
-            // 15 is the size of the thumbs
-            var expectedFirst = (this.widget._cfg.width - 30) * expected[0];
-            var expectedSecond = (this.widget._cfg.width - 30) * expected[1] + 15;
-            this.assertEqualsWithTolerance(positionFirst, expectedFirst, 5, "Position of first is %1, expected %2");
-            this.assertEqualsWithTolerance(positionSecond, expectedSecond, 5, "Position of second is %1, expected %2");
+            var expectedFirst = this.widget._railWidth * expected[0];
+            var expectedSecond = this.widget._railWidth * expected[1] + this.widget._firstWidth;
+
+            this.assertEqualsWithTolerance(positionFirst, expectedFirst, 1, "Position of first is %1, expected %2");
+            this.assertEqualsWithTolerance(positionSecond, expectedSecond, 1, "Position of second is %1, expected %2");
         }
     }
 });

--- a/test/aria/touch/widgets/DoubleSliderSetValue.js
+++ b/test/aria/touch/widgets/DoubleSliderSetValue.js
@@ -67,11 +67,10 @@ Aria.classDefinition({
             var positionFirst = parseInt(aria.utils.Dom.getStyle(widget._firstSlider, "left"), 10);
             var positionSecond = parseInt(aria.utils.Dom.getStyle(widget._secondSlider, "left"), 10);
 
-            // 15 is the size of the thumbs
-            var expectedFirst = (widget._cfg.width - 30) * expected[0];
-            var expectedSecond = (widget._cfg.width - 30) * expected[1] + 15;
-            this.assertEqualsWithTolerance(positionFirst, expectedFirst, 5, "Position of first is %1, expected %2");
-            this.assertEqualsWithTolerance(positionSecond, expectedSecond, 5, "Position of second is %1, expected %2");
+            var expectedFirst = widget._railWidth * expected[0];
+            var expectedSecond = widget._railWidth * expected[1] + widget._firstWidth;
+            this.assertEqualsWithTolerance(positionFirst, expectedFirst, 1, "Position of first is %1, expected %2");
+            this.assertEqualsWithTolerance(positionSecond, expectedSecond, 1, "Position of second is %1, expected %2");
         },
 
         /**


### PR DESCRIPTION
This PR changes the strategy to compute the new position while dragging a DOM element with the drag utility.

Previously, the new position was computed by using the difference of coordinates between the previous mouse move event and the current mouse move event, thus accumulating rounding errors at each mouse move event. Because of this, the distance between the mouse and the dragged element could increase or decrease significantly while dragging the element.

With this PR, the new position is computed by using the difference of coordinates between the start of the drag (which is a fixed reference) and the current mouse move event, thus making sure the relative position between the mouse and the dragged element stays the same until the mouse is released.
