### PR TITLE
fix #1287  navigation keymap inconsistency

### DIFF
--- a/src/aria/templates/NavigationManager.js
+++ b/src/aria/templates/NavigationManager.js
@@ -17,7 +17,6 @@ var ariaUtilsType = require("../utils/Type");
 require("./CfgBeans");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
 
-
 /**
  * Handle keyboard navigation and shortcut for a given section.
  * @class aria.templates.NavigationManager
@@ -69,7 +68,7 @@ module.exports = Aria.classDefinition({
             };
             if (ariaCoreJsonValidator.normalize(normalizeCfg)) {
                 configuration = normalizeCfg.json;
-                this.globalKeyMap.push(configuration);
+                this.globalKeyMap.unshift(configuration);
             } else {
                 this.$logError(this.INVALID_GLOBAL_KEYMAP_CFG);
             }
@@ -94,8 +93,9 @@ module.exports = Aria.classDefinition({
         removeGlobalKeyMap : function (configuration) {
             for (var index = 0, l = this.globalKeyMap.length, mapConfig; index < l; index++) {
                 mapConfig = this.globalKeyMap[index];
-                if (mapConfig.key == configuration.key && (!!configuration.alt == !!mapConfig.alt)
-                        && (!!configuration.shift == !!mapConfig.shift) && (!!configuration.ctrl == !!mapConfig.ctrl)) {
+                if (mapConfig.key == configuration.key && (!!configuration.modal == !!mapConfig.modal)
+                        && (!!configuration.alt == !!mapConfig.alt) && (!!configuration.shift == !!mapConfig.shift)
+                        && (!!configuration.ctrl == !!mapConfig.ctrl)) {
                     this.globalKeyMap.splice(index, 1);
                     return true;
                 }

--- a/test/aria/templates/keyboardNavigation/DialogNavTestCase.js
+++ b/test/aria/templates/keyboardNavigation/DialogNavTestCase.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test keymap navigation (the specific case of ESCAPE handled by a user defined callback and a Dialog)
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.templates.keyboardNavigation.DialogNavTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            escapeEvts : 0
+        };
+
+        this.setTestEnv({
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this._typeEsc({
+                fn : this._openDialog,
+                scope : this
+            });
+        },
+
+        _openDialog : function () {
+            // key shortcut callback should have been called once (dialog is not visible)
+            this.assertEquals(this.data.escapeEvts, 1, "key shortcut callback has been called %1 times while it should be called once.");
+            aria.utils.Json.setValue(this.data, "dialogOpen", true);
+            this._typeEsc({
+                fn : this._retryEscape,
+                scope : this
+            });
+        },
+
+        _retryEscape : function () {
+            // key shortcut callback should have been called once (dialog has been shown and escape keypress hid it: no
+            // callback is triggered)
+            this.assertEquals(this.data.escapeEvts, 1, "key shortcut callback has been called %1 times while it should be called once.");
+            this._typeEsc({
+                fn : this._end,
+                scope : this
+            });
+        },
+
+        _end : function () {
+            // key shortcut callback should have been called for the second time (the escape keypress has been handled
+            // by the callback)
+            this.assertEquals(this.data.escapeEvts, 2, "key shortcut callback has been called %1 times while it should be called twice.");
+            this.notifyTemplateTestEnd();
+        },
+
+        _typeEsc : function (callback) {
+            this.synEvent.type(this.getElementById("toBeFocused"), "[escape]", callback);
+        }
+    }
+});

--- a/test/aria/templates/keyboardNavigation/DialogNavTestCaseTpl.tpl
+++ b/test/aria/templates/keyboardNavigation/DialogNavTestCaseTpl.tpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.templates.keyboardNavigation.DialogNavTestCaseTpl",
+    $hasScript : true,
+}}
+
+    {macro main()}
+        <p> <a {id "toBeFocused"/} href = "javascript:void(0);" {on click { fn : clickHandler }/} > Click here </a> to open the dialog </p>
+        {@aria:Dialog {
+            id : "myDialog",
+            title : "Dialog Sample",
+            icon : "std:info",
+            width : 400,
+            maxHeight : 500,
+            modal : true,
+            visible : false,
+            macro : "myContent",
+            bind : {
+                "visible" : {
+                    inside : data,
+                    to : 'dialogOpen'
+                }
+            }
+        }/}
+    {/macro}
+
+    {macro myContent()}
+        <p>Test dialog </p>
+    {/macro}
+
+{/Template}

--- a/test/aria/templates/keyboardNavigation/DialogNavTestCaseTplScript.js
+++ b/test/aria/templates/keyboardNavigation/DialogNavTestCaseTplScript.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.templates.keyboardNavigation.DialogNavTestCaseTplScript",
+    $constructor : function () {
+        aria.templates.NavigationManager.addGlobalKeyMap({
+            key : "ESCAPE",
+            callback : {
+                fn : function () {
+                    this.data.escapeEvts++;
+                },
+                scope : this
+            }
+        });
+    },
+    $destructor : function () {
+        aria.templates.NavigationManager.removeGlobalKeyMap({
+            key : "ESCAPE"
+        });
+    },
+    $prototype : {
+        clickHandler : function () {
+            var holder = this.data.dialog;
+            var propName = "visible";
+
+            this.$json.setValue(holder, propName, !holder[propName]);
+        }
+    }
+});

--- a/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
+++ b/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
@@ -14,13 +14,14 @@
  */
 
 Aria.classDefinition({
-    $classpath: "test.aria.templates.keyboardNavigation.NavigationTestSuite",
-    $extends: "aria.jsunit.TestSuite",
-    $constructor: function () {
+    $classpath : "test.aria.templates.keyboardNavigation.NavigationTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.templates.keyboardNavigation.TableNavTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.KeyMapTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.enter.EnterTestCase");
+        this.addTests("test.aria.templates.keyboardNavigation.DialogNavTestCase");
     }
 });


### PR DESCRIPTION
when an escape keystroke is registered before a dialog is opened, the navigation keymap contains 2 objects, and when the dialog is closed, the wrong one is removed.
This fix introduces a comparison between the "modal" property that is used in the dialog keymap configuration, so that the right object is deleted and the user defined one is still handled by its callback.

closes #
