### PR TITLE
Adding the ATValidateTemplates visitor in AT build and easypackage task

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
                             noCircularDependencies : false,
                             checkPackagesOrder : false
                         }
-                    }, 'ATCompileTemplates', 'ATRemoveDoc', {
+                    }, 'ATValidateTemplates', 'ATCompileTemplates', 'ATRemoveDoc', {
                         type : 'JSMinify',
                         cfg : {
                             files : atExtensions,

--- a/src/aria/ext/filesgenerator/tpl/FlowControllerInterface.tpl.txt
+++ b/src/aria/ext/filesgenerator/tpl/FlowControllerInterface.tpl.txt
@@ -19,5 +19,5 @@
         interfaceTxtTpl : 'aria.ext.filesgenerator.tpl.Interface'
     }
 }}
-{macro main()}${function(){data.$extends = "aria.templates.IFlowCtrl"}()}${interfaceTxtTpl.processTextTemplate(data)}{/macro}
+{macro main()}${function(){data.$extends = "aria.templates.IFlowCtrl";}()}${interfaceTxtTpl.processTextTemplate(data)}{/macro}
 {/TextTemplate}

--- a/src/aria/ext/filesgenerator/tpl/ModuleControllerInterface.tpl.txt
+++ b/src/aria/ext/filesgenerator/tpl/ModuleControllerInterface.tpl.txt
@@ -19,5 +19,5 @@
         interfaceTxtTpl : 'aria.ext.filesgenerator.tpl.Interface'
     }
 }}
-{macro main()}${function(){data.$extends = "aria.templates.IModuleCtrl"}()}${interfaceTxtTpl.processTextTemplate(data)}{/macro}
+{macro main()}${function(){data.$extends = "aria.templates.IModuleCtrl";}()}${interfaceTxtTpl.processTextTemplate(data)}{/macro}
 {/TextTemplate}

--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -520,7 +520,7 @@ module.exports = Aria.classDefinition({
                 // this is the new way of including template scripts
                 out.enterBlock("classInit");
                 out.addDependencies(["aria.core.TplClassLoader"]);
-                out.writeln("aria.core.TplClassLoader._importScriptPrototype(" + scriptClasspath + ",proto)");
+                out.writeln("aria.core.TplClassLoader._importScriptPrototype(" + scriptClasspath + ",proto);");
                 out.leaveBlock();
             }
             var classInit = out.getBlockContent("classInit");
@@ -583,7 +583,7 @@ module.exports = Aria.classDefinition({
             out.decreaseIndent();
             out.writeln("}");
             out.decreaseIndent();
-            out.writeln("})");
+            out.writeln("});");
             out.leaveBlock();
         },
 

--- a/tasks/easypackage/configuration.js
+++ b/tasks/easypackage/configuration.js
@@ -59,7 +59,8 @@ module.exports = function (grunt, args) {
                         noCircularDependencies : false,
                         checkPackagesOrder : false
                     }
-                } : null, args.compileTemplates ? 'ATCompileTemplates' : null, 'ATRemoveDoc', args.convertToNoderjs ? {
+                } : null, args.validateTemplates ? 'ATValidateTemplates' : null,
+                args.compileTemplates ? 'ATCompileTemplates' : null, 'ATRemoveDoc', args.convertToNoderjs ? {
                     type : 'ATNoderConverter',
                     cfg : {
                         files : args.convertToNoderjs

--- a/tasks/task-easypackage.js
+++ b/tasks/task-easypackage.js
@@ -38,6 +38,7 @@ module.exports = function (grunt) {
             clean : true,
             license : "",
             includeDependencies : true,
+            validateTemplates : false,
             compileTemplates : true,
             minify : true,
             hash : true,


### PR DESCRIPTION
This pull request adds the `ATValidateTemplates` visitor in the build and as a configurable option in the `easypackage` task, so that templates can be strictly validated during the build. This is especially useful to find extra commas in JSON configuration objects inside templates.

This pull request also adds some missing semicolons in the javascript code generated from templates, as this is required for the `ATValidateTemplates` visitor to accept templates.

This pull request depends on the following pull request on atpackager: ariatemplates/atpackager#14
