### PR TITLE
Movable dialog is not working inside a page with some scroll

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1030,13 +1030,8 @@ module.exports = Aria.classDefinition({
             geometry.width = geometry.width || 0;
             geometry.height = geometry.height || 0;
             if (container == this.VIEWPORT) {
-                return this.fitInViewport({
-                    left : geometry.x,
-                    top : geometry.y
-                }, {
-                    width : geometry.width,
-                    height : geometry.height
-                });
+                container = this.getViewportSize();
+                container.x = container.y = 0;
             }
             container.width = container.width || 0;
             container.height = container.height || 0;

--- a/test/aria/widgets/container/dialog/movable/test5/MovableDialogTemplateFive.tpl
+++ b/test/aria/widgets/container/dialog/movable/test5/MovableDialogTemplateFive.tpl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.container.dialog.movable.test5.MovableDialogTemplateFive"
+}}
+
+    {macro main()}
+        {@aria:Dialog {
+            id : "firstDialog",
+            macro : "displayDialogContent",
+            icon : "std:info",
+            width : 500,
+            maxHeight : 500,
+            visible : true,
+            modal : false,
+            movable : true
+        }/}
+    {/macro}
+
+    {macro displayDialogContent()}
+
+          {@aria:Text {
+            text : "Content of the dialog"
+          }/}
+
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/movable/test5/MovableDialogTestCaseFive.js
+++ b/test/aria/widgets/container/dialog/movable/test5/MovableDialogTestCaseFive.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Json", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+
+        this.data = {};
+
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.movable.test5.MovableDialogTemplateFive",
+            css : "position:relative;top:400px;border:15px solid blue;",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            Aria.$window.scrollBy(0,150);
+            aria.core.Timer.addCallback({
+                fn : this._firstDrag,
+                scope : this,
+                delay : 1000
+            });
+        },
+
+        _firstDrag : function () {
+            var dom = aria.utils.Dom;
+            this.assertEquals(dom.getDocumentScrollElement().scrollTop, 150, "The page should have %2 px of scroll, but it has %1 px instead");
+            var handleGeometry = dom.getGeometry(this._getHandle("firstDialog"));
+            this.dialogPos = {
+                x : handleGeometry.x,
+                y : handleGeometry.y
+            };
+
+            var from = {
+                x : handleGeometry.x + handleGeometry.width / 2,
+                y : handleGeometry.y + handleGeometry.height / 2
+            };
+            var options = {
+                duration : 2000,
+                to : {
+                    x : from.x,
+                    y : from.y - 200
+                }
+            };
+
+            this.synEvent.execute([["drag", options, from]], {
+                fn : this._afterFirstDrag,
+                scope : this
+            });
+        },
+
+        _afterFirstDrag : function () {
+            var handleGeometry = aria.utils.Dom.getGeometry(this._getHandle("firstDialog"));
+
+            this.assertEquals(this.dialogPos.x, handleGeometry.x, "The dialog xpos position is not corrrectly set, expected %1, actual %2.");
+            this.assertEquals(this.dialogPos.y - 200, handleGeometry.y, "The dialog ypos position is not corrrectly set, expected %1, actual %2.");
+
+            this.end();
+        },
+
+        _getHandle : function (dialogId) {
+            return this.getWidgetInstance(dialogId)._titleBarDomElt;
+        }
+    }
+});


### PR DESCRIPTION
This fix is restoring the right behave for the movable dialog even if the page has some scroll.
