### PR TITLE
fix #1306 - focus wrongly assigned when a popup is destroyed

### DIFF
--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -22,7 +22,7 @@ var ariaTemplatesNavigationManager = require("../templates/NavigationManager");
 var ariaUtilsAriaWindow = require("../utils/AriaWindow");
 var ariaCoreBrowser = require("../core/Browser");
 var ariaCoreTimer = require("../core/Timer");
-
+var ariaUtilsDelegate = require("../utils/Delegate");
 
 (function () {
 
@@ -477,9 +477,15 @@ var ariaCoreTimer = require("../core/Timer");
                 });
 
                 var topPopup = openedPopups.length > 0 ? openedPopups[openedPopups.length - 1] : null;
-                if (topPopup) {
-                    ariaTemplatesNavigationManager.focusFirst(topPopup.domElement);
-                }
+
+                // the timeout waits for a possible focus change after the mousedown event that possibly triggered this
+                // method
+                setTimeout(function () {
+                    var focusedEl = ariaUtilsDelegate.getFocus();
+                    if (topPopup && !utilsDom.isAncestor(focusedEl, topPopup.domElement)) {
+                        ariaTemplatesNavigationManager.focusFirst(topPopup.domElement);
+                    }
+                }, 1);
             },
 
             /**

--- a/src/aria/templates/NavigationManager.js
+++ b/src/aria/templates/NavigationManager.js
@@ -143,7 +143,7 @@ module.exports = Aria.classDefinition({
          */
         focusFirst : function (container, reverse) {
             var cb;
-            if (container.nodeType == 1) {
+            if (container && container.nodeType == 1) {
                 var childNodes = container.childNodes, length = childNodes.length, index = reverse ? length - 1 : 0, child;
                 for (; index > -1 && index < length; reverse ? index-- : index++) {
                     child = childNodes[index];

--- a/test/aria/popups/focus/FocusTest.js
+++ b/test/aria/popups/focus/FocusTest.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test case to check the behavior of popups and the focus given by a user click
+ * see commented asserts
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.popups.focus.FocusTest",
+    $dependencies : ['aria.utils.Delegate'],
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            data : {
+                firstName : "",
+                lastName : ""
+            }
+        });
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+
+            this.input1 = this.getInputField("firstInput");
+            this.input2 = this.getInputField("secondInput");
+            this.span = this.getElementById("notFocusable");
+            this.anchor = this.getElementById("anchor");
+
+            this.synEvent.click(this.input1, {
+                scope : this,
+                fn : function () {
+                    aria.core.Timer.addCallback({
+                        fn : this.checkFirstInputFocused,
+                        scope : this,
+                        delay : 100
+                    });
+                }
+            });
+        },
+
+        checkFirstInputFocused : function () {
+            var focusedEl = Aria.$window.document.activeElement;
+            // when a focusable element in a popup is clicked, it should take the focus
+            this.assertEquals(this.input1, focusedEl, "The first input has not been focused by the click");
+            this.synEvent.click(this.input2, {
+                scope : this,
+                fn : function () {
+                    aria.core.Timer.addCallback({
+                        fn : this.checkSecondInputFocused,
+                        scope : this,
+                        delay : 100
+                    });
+                }
+            });
+        },
+
+        checkSecondInputFocused : function () {
+            var focusedEl = Aria.$window.document.activeElement;
+            // when a focusable element in a popup is clicked, it should take the focus even if the most recent popup
+            // has lost the focus and has been closed
+            this.assertEquals(this.input2, focusedEl, "The second input has not been focused by the click");
+            this.synEvent.click(this.span, {
+                scope : this,
+                fn : function () {
+                    aria.core.Timer.addCallback({
+                        fn : this.checkFirstElementFocused,
+                        scope : this,
+                        delay : 100
+                    });
+                }
+            });
+        },
+
+        checkFirstElementFocused : function () {
+            var focusedEl = Aria.$window.document.activeElement;
+            // when a not focusable element in a popup is clicked, the focus automatically goes to its first element
+            this.assertEquals(this.anchor, focusedEl, "The anchor has not been focused by the click on an inner, not focusable zone");
+            this.end();
+        }
+    }
+});

--- a/test/aria/popups/focus/FocusTestTpl.tpl
+++ b/test/aria/popups/focus/FocusTestTpl.tpl
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ {Template {
+	$classpath : "test.aria.popups.focus.FocusTestTpl",
+	$hasScript : true
+}}
+
+	{macro main()}
+
+	    {@aria:Dialog {
+	        title: "Dialog Sample",
+	        macro : "myMacro",
+	        icon: "std:info",
+	        width: 400,
+	        modal: true,
+	        visible: true
+	    }/}
+
+	{/macro}
+
+	{macro myMacro()}
+
+	    <a {id "anchor" /} {on click "anchorClick" /} style="color:blue" href="#">anchor.</a>
+	    <br/>
+	    <span {id "notFocusable" /}>not focusable span</span>
+	    <br/>
+
+        {@aria:TextField {
+			label: "First Name:",
+			id: "firstInput",
+			labelWidth: 100,
+			onblur: this.myMethod,
+			errorMessages: data.errorMessages,
+			bind: {
+				value: {
+					to: "firstName",
+					inside: data
+				}
+			}
+        }/}
+
+		{@aria:TextField {
+			label: "Last Name:",
+			id: "secondInput",
+			labelWidth: 100,
+			onblur: this.myMethod,
+				bind: {
+				value: {
+					to: "lastName",
+					inside: data
+				}
+			}
+		}/}
+
+	{/macro}
+
+{/Template}

--- a/test/aria/popups/focus/FocusTestTplScript.js
+++ b/test/aria/popups/focus/FocusTestTplScript.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.popups.focus.FocusTestTplScript",
+    $dependencies : ['aria.utils.validators.Mandatory'],
+    $prototype : {
+        $dataReady : function () {
+            aria.utils.Data.setValidator(this.data, "firstName", new aria.utils.validators.Mandatory("MANDATORY."));
+            aria.utils.Data.setValidator(this.data, "lastName", new aria.utils.validators.Mandatory("MANDATORY."));
+        },
+        $viewReady : function () {
+            this.myMethod();
+        },
+        myMethod : function () {
+            aria.utils.Data.validateModel(this.data, {});
+        },
+        submit : function () {
+            this.myMethod();
+        },
+        anchorClick : function () {
+            this.data.error = true;
+        }
+
+    }
+});


### PR DESCRIPTION
a timeout was inserted in order to check if the focus has to be moved by the user click or has to be forced (in case no focusable element is clicked)

closes #1306
