### PR TITLE
fix #1055 option stayed selected in Select after removal from options list

### DIFF
--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -432,7 +432,7 @@ module.exports = Aria.classDefinition({
                     this.controller.setListOptions(newValue);
                     var report = this.controller.checkValue(selectValue);
                     this._reactToControllerReport(report, {
-                        stopValueProp : true
+                        stopValueProp : false
                     });
                 } else {
                     // markup for the options

--- a/test/aria/widgets/form/select/SelectTestSuite.js
+++ b/test/aria/widgets/form/select/SelectTestSuite.js
@@ -25,6 +25,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.select.checkFeatures.SelectTemplateTestCase",
                 "test.aria.widgets.form.select.dispose.DisposeTestCase",
                 "test.aria.widgets.form.select.downArrowKey.SelectTestCase",
-                "test.aria.widgets.form.select.popupWidth.SelectTestCase"];
+                "test.aria.widgets.form.select.popupWidth.SelectTestCase",
+                "test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTestCase"];
     }
 });

--- a/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTest.tpl
+++ b/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTest.tpl
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath:"test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTest",
+   $hasScript:true
+}}
+    {macro main()}
+        {@aria:Select {
+            id: "mySelect1",
+            label: "Select Widget1: ",
+            labelWidth:220,
+            width:530,
+            options: data.options1,
+            bind: {
+                value: {
+                    to : "select1Value",
+                    inside : data
+                }
+            }
+        }/}
+        {@aria:Select {
+            id: "mySelect2",
+            label: "Select Widget2: ",
+            labelWidth:220,
+            width:530,
+            bind: {
+                value: {
+                    to : "select2Value",
+                    inside : data
+                },
+                options: {
+                    inside: data,
+                    to: "select1Value",
+                    transform: function(value) {
+                        var options = this.getSelectOptions(value);
+                        return options;
+                    }
+                }
+            }
+        }/}
+
+        {@aria:Text {
+            id: "myBoundText2",
+            bind : {
+                text : {
+                    to : "select2Value",
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+{/Template}

--- a/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTestCase.js
+++ b/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTestCase.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Dom", "aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            select1Value : "A",
+            select2Value : "A",
+            options1 : [{
+                        label : "Type A",
+                        value : "A"
+                    }, {
+                        label : "Type B",
+                        value : "B"
+                    }]
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTest",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            // check initial values
+            this.assertEquals(this.data.select1Value, "A", "Select 1 value should be %2, got %1");
+            this.assertEquals(this.data.select2Value, "A", "Select 2 value should be %2, got %1");
+
+            // select2 should have 2 options initially
+            var select2widget = this.getWidgetInstance("mySelect2");
+            this.assertEquals(select2widget._cfg.options.length, 2);
+
+            var select1 = this.getWidgetInstance("mySelect1").getSelectField();
+            this.synEvent.click(select1, {
+                fn : this.onSelect1Focused,
+                scope : this
+            });
+        },
+
+        onSelect1Focused : function () {
+            // change first select -> should update values to B, A
+            var select1 = this.getWidgetInstance("mySelect1").getSelectField();
+            this.synEvent.type(select1, "[down][enter]", {
+                fn : this.onSelect1Change,
+                scope : this
+            });
+        },
+
+        onSelect1Change : function () {
+            // Since select1 value was changed, the options of select2 bound to it should have also changed
+            this.assertEquals(this.data.select1Value, "B", "Select 1 value should be %2, got %1");
+            this.assertEquals(this.data.select2Value, "A", "Select 2 value should be %2, got %1");
+
+            // Now select2 should have third option "C" available, let's select it
+            var select2widget = this.getWidgetInstance("mySelect2");
+            this.assertEquals(select2widget._cfg.options.length, 3);
+
+            var select2 = select2widget.getSelectField();
+            this.synEvent.type(select2, "[down][down][enter]", {
+                fn : this.onSelect2Change,
+                scope : this
+            });
+        },
+
+        onSelect2Change : function () {
+            this.assertEquals(this.data.select1Value, "B", "Select 1 value should be %2, got %1");
+            this.assertEquals(this.data.select2Value, "C", "Select 2 value should be %2, got %1");
+
+            // let's change the value of select1 once again, so that select2 doesn't have "C" as possible option anymore
+            var select1 = this.getWidgetInstance("mySelect1").getSelectField();
+            this.synEvent.type(select1, "[up][enter]", {
+                fn : this.checkSelectValues,
+                scope : this
+            });
+        },
+
+        checkSelectValues : function () {
+            // Essence of this test: the value of select2 should be hence updated accordingly - it must not stay as "C"
+            // It will be reset to the first possible option instead
+            this.assertEquals(this.data.select1Value, "A", "Select 1 value should be %2, got %1");
+            this.assertEquals(this.data.select2Value, "A", "Select 2 value should be %2, got %1");
+
+            // Make sure that widgets bound to select2 are refreshed too
+            var boundTextWidget = this.getWidgetInstance("myBoundText2");
+            this.assertEquals(boundTextWidget._cfg.text, "A", "Bound text value should be %2, got %1");
+
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTestScript.js
+++ b/test/aria/widgets/form/select/boundOptionsRemoval/SelectTemplateTestScript.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTestScript',
+    $prototype : {
+        getSelectOptions : function (select1Value) {
+            if (select1Value === "A") {
+                return [{
+                            value : "A",
+                            label : "Option A"
+                        }, {
+                            value : "B",
+                            label : "Option B"
+                        }];
+            } else {
+                return [{
+                            value : "A",
+                            label : "Option A"
+                        }, {
+                            value : "B",
+                            label : "Option B"
+                        }, {
+                            value : "C",
+                            label : "Option C"
+                        }];
+            }
+        }
+    }
+});


### PR DESCRIPTION
This is a follow-up of PR #1218

I've changed the test scenario from the first one to the second one reported in #1055 and added some more asserts (the first one was no longer reproducible since it was fixed in 1.6.5, moreover the second scenario was better showing the issue).

---

When `@aria:Select` options were bound to the data model,
and the currently selected option was removed from the option list
through the binding, it still remained as the data model value
of the widget (although no longer available in the UI).

Close #1218
Close #1309
