### PR TITLE
increase timeout for slow tests (IE7/8)

### DIFF
--- a/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
@@ -49,8 +49,8 @@ Aria.classDefinition({
             "aria.utils.Type", "aria.core.Browser"],
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
-        if (aria.core.Browser.isPhantomJS || aria.core.Browser.isIE7) {
-            this.defaultTestTimeout = 40000;
+        if (aria.core.Browser.isPhantomJS || aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 120000;
         }
         this.resourcesHandler = this.resourcesHandler || new aria.resources.handlers.LCResourcesHandler();
         this.resourcesHandler.setSuggestions([{

--- a/test/aria/widgets/form/datepicker/errorstate/DatePicker.js
+++ b/test/aria/widgets/form/datepicker/errorstate/DatePicker.js
@@ -21,8 +21,8 @@ Aria.classDefinition({
         this.$RobotTestCase.constructor.call(this);
         // TODO this test is ridiculously long, split it
         this.defaultTestTimeout = 40000;
-        if (aria.core.Browser.isIE7) {
-            this.defaultTestTimeout = 50000;
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 120000;
         } else if (aria.core.Browser.isPhantomJS) {
             this.defaultTestTimeout = 60000;
         }

--- a/test/aria/widgets/form/multiautocomplete/test11/MultiAutoInvalidDataModel.js
+++ b/test/aria/widgets/form/multiautocomplete/test11/MultiAutoInvalidDataModel.js
@@ -19,8 +19,8 @@ Aria.classDefinition({
     $dependencies : ["aria.core.Browser"],
     $constructor : function () {
         this.$BaseMultiAutoCompleteTestCase.constructor.call(this);
-        if (aria.core.Browser.isPhantomJS) {
-            this.defaultTestTimeout = 40000;
+        if (aria.core.Browser.isPhantomJS || aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 120000;
         }
         this.data.freeText = false;
     },

--- a/test/aria/widgets/form/selectbox/checkValue/MainTemplateTestCase.js
+++ b/test/aria/widgets/form/selectbox/checkValue/MainTemplateTestCase.js
@@ -53,6 +53,9 @@ Aria.classDefinition({
             data : this.data
         });
         this.defaultTestTimeout = 10000;
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 60000;
+        }
     },
     $prototype : {
         /**

--- a/test/aria/widgets/form/textinput/onblur/OnBlurTest.js
+++ b/test/aria/widgets/form/textinput/onblur/OnBlurTest.js
@@ -18,6 +18,10 @@ Aria.classDefinition({
     $extends : "test.aria.widgets.form.textinput.onclick.OnClickTest",
     $constructor : function () {
         this.$OnClickTest.constructor.call(this);
+        this.defaultTestTimeout = 40000;
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 120000;
+        }
         this.setTestEnv({
             template : "test.aria.widgets.form.textinput.onblur.OnBlurTemplate",
             data : {

--- a/test/aria/widgets/form/textinput/onclick/OnClickTest.js
+++ b/test/aria/widgets/form/textinput/onclick/OnClickTest.js
@@ -25,6 +25,9 @@ Aria.classDefinition({
             }
         });
         this.defaultTestTimeout = 10000;
+        if (aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
+            this.defaultTestTimeout = 60000;
+        }
         this._delay = 200;
         this._widgetIds = ["df", "tf", "nf", "pf", "dp", "ac", "ms", "time", "sb", "mac"];
         this._currentIndex = null;


### PR DESCRIPTION
timeout increased from 40s to 120ms for the following failing tests:
-  test.aria.widgets.form.multiautocomplete.test11.MultiAutoInvalidDataModel
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.StrictTrueTest
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.AlwaysFalseTest
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.NoneTrueTest
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.NoneFalseTest
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.StrictTrueWithTabTest
-  test.aria.widgets.form.multiautocomplete.preselectAutofill.AlwaysTrueTest

and specifically on IE7:
-  test.aria.widgets.form.autocomplete.preselectAutofill.AlwaysTrueTest
-  test.aria.widgets.form.datepicker.errorstate.DatePicker
-  test.aria.widgets.form.textinput.onblur.OnBlurTest
-  test.aria.widgets.form.selectbox.checkValue.MainTemplateTestCase
-  test.aria.widgets.form.textinput.onclick.OnClickTest
