### PR TITLE
fix #1313 template error in _onTplLoad

### DIFF
--- a/src/aria/html/Template.js
+++ b/src/aria/html/Template.js
@@ -128,6 +128,7 @@ module.exports = Aria.classDefinition({
             this.subTplCtxt.$dispose();
             this.subTplCtxt = null;
         }
+        this._deleteTplcfg();
         this.$BaseWidget.$destructor.apply(this, arguments);
     },
     $prototype : {
@@ -151,7 +152,7 @@ module.exports = Aria.classDefinition({
             this._cfgOk = jsonValidator.validateCfg("aria.html.beans.TemplateCfg.Properties", cfg);
             if (this._needCreatingModuleCtrl) {
                 this._cfgOk = this._cfgOk
-                        && jsonValidator.validateCfg("aria.templates.CfgBeans.InitModuleCtrl", cfg.moduleCtrl);
+                && jsonValidator.validateCfg("aria.templates.CfgBeans.InitModuleCtrl", cfg.moduleCtrl);
             }
         },
 

--- a/src/aria/templates/TemplateTrait.js
+++ b/src/aria/templates/TemplateTrait.js
@@ -47,8 +47,8 @@ module.exports = Aria.classDefinition({
                 this._onTplLoad({
                     moduleCtrl : tplcfg.moduleCtrl
                 }, {
-                    autoDispose : false
-                });
+                        autoDispose : false
+                    });
             }
         },
 
@@ -63,16 +63,40 @@ module.exports = Aria.classDefinition({
             this.isDiffered = false;
         },
 
-         /**
-         * @param {Array} id contains the widget and template ids forming the focused widget path.
-         * @return {Boolean}
-         */
-         _focusHelper : function (id) {
+        /**
+        * @param {Array} id contains the widget and template ids forming the focused widget path.
+        * @return {Boolean}
+        */
+        _focusHelper : function (id) {
             if (!id || !id.length) {
                 return this.subTplCtxt.$focusFromParent();
             } else {
                 this.subTplCtxt.$focus(id);
                 return true;
+            }
+        },
+
+        /**
+         * Clean and delete template config. Dispose associated elements if needed. This is used if something has gone
+         * wrong during initialization (ex: early disposed). Otherwiser, this is done by the dispose of the template
+         * context.
+         * @protected
+         */
+        _deleteTplcfg : function () {
+            if (this._tplcfg) {
+                var tplcfg = this._tplcfg;
+                var toDispose = tplcfg.toDispose;
+                if (toDispose) {
+                    var toDisposeLength = toDispose.length;
+                    for (var i = 0; i < toDisposeLength; i++) {
+                        toDispose[i].$dispose();
+                    }
+                }
+                tplcfg.toDispose = null;
+                tplcfg.tplDiv = null;
+                tplcfg.div = null;
+                tplcfg.data = null;
+                this._tplcfg = null;
             }
         },
 

--- a/src/aria/widgets/Template.js
+++ b/src/aria/widgets/Template.js
@@ -136,30 +136,6 @@ module.exports = Aria.classDefinition({
         _directInit : true,
 
         /**
-         * Clean and delete template config. Dispose associated elements if needed. This is used if something has gone
-         * wrong during initialization (ex: early disposed). Otherwiser, this is done by the dispose of the template
-         * context.
-         * @protected
-         */
-        _deleteTplcfg : function () {
-            if (this._tplcfg) {
-                var tplcfg = this._tplcfg;
-                var toDispose = tplcfg.toDispose;
-                if (toDispose) {
-                    var toDisposeLength = toDispose.length;
-                    for (var i = 0; i < toDisposeLength; i++) {
-                        toDispose[i].$dispose();
-                    }
-                }
-                tplcfg.toDispose = null;
-                tplcfg.tplDiv = null;
-                tplcfg.div = null;
-                tplcfg.data = null;
-                this._tplcfg = null;
-            }
-        },
-
-        /**
          * Display an error message inside the template div. This might happen because the template context wasn't able
          * to initialize the template.
          * @protected

--- a/test/aria/html/HTMLTestSuite.js
+++ b/test/aria/html/HTMLTestSuite.js
@@ -32,5 +32,6 @@ Aria.classDefinition({
         this.addTests("test.aria.html.DisabledTraitTest");
         this.addTests("test.aria.html.radioButton.ieBug.RadioButtonTestCase");
         this.addTests("test.aria.html.textarea.TextAreaTestSuite");
+        this.addTests("test.aria.html.template.prematureDisposal.PrematureDisposalTest");
     }
 });

--- a/test/aria/html/template/prematureDisposal/PrematureDisposalTest.js
+++ b/test/aria/html/template/prematureDisposal/PrematureDisposalTest.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.html.template.prematureDisposal.PrematureDisposalTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+
+    $constructor : function () {
+
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.html.template.prematureDisposal.PrematureDisposalTpl"
+        });
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+
+            // the test implicitly calls the this.assertLogsEmpty() and checks if there are errors
+            this.end();
+        }
+    }
+});

--- a/test/aria/html/template/prematureDisposal/PrematureDisposalTpl.tpl
+++ b/test/aria/html/template/prematureDisposal/PrematureDisposalTpl.tpl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath:'test.aria.html.template.prematureDisposal.PrematureDisposalTpl',
+    $wlibs: {
+        "html" : "aria.html.HtmlLibrary"
+    },
+    $hasScript : true
+}}
+
+{macro main()}
+
+    {@html:Template {
+        classpath: "test.aria.html.template.prematureDisposal.SimpleSubTemplate"
+    }/}
+
+{/macro}
+
+{/Template}

--- a/test/aria/html/template/prematureDisposal/PrematureDisposalTplScript.js
+++ b/test/aria/html/template/prematureDisposal/PrematureDisposalTplScript.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath: 'test.aria.html.template.prematureDisposal.PrematureDisposalTplScript',
+    $prototype: {
+        $viewReady: function() {
+            this.$refresh();
+        }
+    }
+});

--- a/test/aria/html/template/prematureDisposal/SimpleSubTemplate.tpl
+++ b/test/aria/html/template/prematureDisposal/SimpleSubTemplate.tpl
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath : "test.aria.html.template.prematureDisposal.SimpleSubTemplate"
+}}
+
+{macro main ()}
+	<p id="subTemplateItem">
+		Sub template content loaded successfully.
+	</p>
+
+{/macro}
+
+{/Template}


### PR DESCRIPTION
If the disposal of a template is called before its loading, the `_onTplLoad` method could still access some not-disposed objects.
For this reason, the protected `_deleteTplcfg` method of `aria.widgets.Template` has been shared with and used by `aria.html.Template` through the class `aria.templates.TemplateTrait`

close #
