### PR TITLE
fix #1315 preserve amabuild in URL on test.htm

### DIFF
--- a/test/testLauncher.js
+++ b/test/testLauncher.js
@@ -77,6 +77,10 @@ Aria.load({
             if (qs.getKeyValue('dev') == "false") {
                 html += '<input type="hidden" name="dev" value="false">';
             }
+            if (qs.getKeyValue('amabuild') === "true") {
+                html += '<input type="hidden" name="amabuild" value="true">';
+            }
+
             var atversion = qs.getKeyValue('atversion');
             if (atversion) {
                 html += '<input type="hidden" name="atversion" value="' + atversion + '">';
@@ -90,7 +94,7 @@ Aria.load({
             html += '</form>';
             document.body.innerHTML = html;
             return;
-            //testToRun = "test.CoverageTestSuite";
+            // testToRun = "test.CoverageTestSuite";
         }
 
         var neededClasses = ["aria.jsunit.TestRunner", "aria.jsunit.JsCoverage", "aria.utils.Callback",


### PR DESCRIPTION
If someone opens a page `test.htm?amabuild=true` and types the classpath, the amabuild param
is not preserved. This commit fixes that issue.

(note that launching `test.htm?amabuild=true` makes sense only on deploy destination, not through the git repo folder - otherwise there's no 1.1-SNAPSHOT file available and page load breaks)
