### PR TITLE
Resource provider mistakenly disposed on class unload

### DIFF
--- a/src/aria/core/TplClassLoader.js
+++ b/src/aria/core/TplClassLoader.js
@@ -270,17 +270,19 @@ var ariaCoreJsonValidator = require("./JsonValidator");
 
                 var scriptResources = scriptClass.classDefinition.$resources;
                 if (scriptResources) {
-                    if (!tplPrototype.$resources) {
-                        tplPrototype.$resources = {};
+                    var tplPrototypeRes = {};
+                    if (tplPrototype.$resources) {
+                        Aria.copyObject(tplPrototype.$resources, tplPrototypeRes);
                     }
+                    tplPrototype.$resources = tplPrototypeRes;
                     var scriptTransformedProto = scriptClass.prototype;
                     for (var member in scriptResources) {
                         if (scriptResources.hasOwnProperty(member)) {
-                            if (tplPrototype[member] && !tplPrototype.$resources[member]) {
+                            if (tplPrototype[member] && !tplPrototypeRes[member]) {
                                 this.$logError(Aria.RESOURCES_HANDLE_CONFLICT, [member, scriptDef.$classpath]);
                             } else {
                                 proto[member] = scriptTransformedProto[member];
-                                tplPrototype.$resources[member] = scriptResources[member];
+                                tplPrototypeRes[member] = scriptResources[member];
                             }
                         }
                     }
@@ -288,16 +290,18 @@ var ariaCoreJsonValidator = require("./JsonValidator");
 
                 var scriptTexts = scriptClass.classDefinition.$texts;
                 if (scriptTexts) {
-                    if (!tplPrototype.$texts) {
-                        tplPrototype.$texts = {};
+                    var tplPrototypeText = {};
+                    if (tplPrototype.$texts) {
+                        Aria.copyObject(tplPrototype.$texts, tplPrototypeText);
                     }
+                    tplPrototype.$texts = tplPrototypeText;
                     for (var member in scriptTexts) {
                         if (scriptTexts.hasOwnProperty(member)) {
-                            if (tplPrototype[member] && !tplPrototype.$texts[member]) {
+                            if (tplPrototype[member] && !tplPrototypeText[member]) {
                                 this.$logError(Aria.TEXT_TEMPLATE_HANDLE_CONFLICT, [member, scriptDef.$classpath]);
                             } else {
                                 proto[member] = scriptClass.prototype[member];
-                                tplPrototype.$texts[member] = scriptTexts[member];
+                                tplPrototypeText[member] = scriptTexts[member];
                             }
                         }
                     }

--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -86,6 +86,8 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.issue727.RefreshManagerExceptionTestCase");
         this.addTests("test.aria.templates.issue833.CaretPositionTestCase");
 
+        this.addTests("test.aria.templates.issue1319.TplDefinitionChangedTestCase");
+
         this.addTests("test.aria.templates.tabsRefresh.TabsRefreshTestCase");
         this.addTests("test.aria.templates.macrolibs.MacrolibsTestCase");
         this.addTests("test.aria.templates.textTemplates.TextTemplatesTestCase");

--- a/test/aria/templates/issue1319/TplDefinitionChanged.tpl
+++ b/test/aria/templates/issue1319/TplDefinitionChanged.tpl
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath:'test.aria.templates.issue1319.TplDefinitionChanged',
+   $hasScript:true,
+   $texts:{
+      bootstrapTpl: "aria.ext.filesgenerator.tpl.Bootstrap"
+   },
+   $res:{
+      calendarRes: "aria.resources.CalendarRes"
+   }
+}}
+    {macro main()}
+        OK
+    {/macro}
+{/Template}

--- a/test/aria/templates/issue1319/TplDefinitionChangedScript.js
+++ b/test/aria/templates/issue1319/TplDefinitionChangedScript.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.templates.issue1319.TplDefinitionChangedScript',
+    $resources : {
+        dateRes : "aria.resources.DateRes"
+    },
+    $texts : {
+        classTpl : "aria.ext.filesgenerator.tpl.Class"
+    },
+    $prototype : {}
+});

--- a/test/aria/templates/issue1319/TplDefinitionChangedTestCase.js
+++ b/test/aria/templates/issue1319/TplDefinitionChangedTestCase.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : 'test.aria.templates.issue1319.TplDefinitionChangedTestCase',
+    $extends : 'aria.jsunit.TemplateTestCase',
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.templates.issue1319.TplDefinitionChanged"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var tplDef = test.aria.templates.issue1319.TplDefinitionChanged.classDefinition;
+            var tplScriptDef = test.aria.templates.issue1319.TplDefinitionChangedScript.classDefinition;
+            var tpl = this.templateCtxt._tpl;
+
+            // Defined in the template script:
+            this.assertJsonEquals(tplScriptDef.$resources, {
+                dateRes : "aria.resources.DateRes"
+            });
+            this.assertJsonEquals(tplScriptDef.$texts, {
+                classTpl : "aria.ext.filesgenerator.tpl.Class"
+            });
+
+            // Defined in the template:
+            this.assertJsonEquals(tplDef.$resources, {
+                calendarRes : "aria.resources.CalendarRes"
+            });
+            this.assertJsonEquals(tplDef.$texts, {
+                bootstrapTpl : "aria.ext.filesgenerator.tpl.Bootstrap"
+            });
+
+            // The template prototype has everything:
+            this.assertJsonEquals(tpl.$resources, {
+                calendarRes : "aria.resources.CalendarRes",
+                dateRes : "aria.resources.DateRes"
+            });
+            this.assertJsonEquals(tpl.$texts, {
+                bootstrapTpl : "aria.ext.filesgenerator.tpl.Bootstrap",
+                classTpl : "aria.ext.filesgenerator.tpl.Class"
+            });
+            this.assertEquals(tpl.calendarRes, aria.resources.CalendarRes);
+            this.assertEquals(tpl.dateRes, aria.resources.DateRes);
+            this.assertEquals(tpl.bootstrapTpl, aria.ext.filesgenerator.tpl.Bootstrap);
+            this.assertEquals(tpl.classTpl, aria.ext.filesgenerator.tpl.Class);
+
+            this.end();
+        }
+    }
+});


### PR DESCRIPTION
If a template class is associated to a template script which uses a resource provider, the resource provider is mistakenly disposed when unloading the template class (even if the template script is still loaded).
This is an issue especially in some skin reloads scenarios, in which the template script is not reloaded, while the template class is reloaded, which leads to a situation in which the reloaded template can no longer use the resource provider which was mistakenly disposed.
