### PR TITLE
fix #1320 Path.resolve second arg is mandatory

### DIFF
--- a/src/aria/utils/Path.js
+++ b/src/aria/utils/Path.js
@@ -84,6 +84,7 @@ module.exports = Aria.classDefinition({
             if (ariaUtilsType.isString(path)) {
                 path = this.parse(path);
             }
+            inside = inside ? inside : Aria.$window;
             if (ariaUtilsType.isArray(path)) {
                 for (var index = 0, param, len = path.length; index < len; index++) {
                     param = path[index];

--- a/test/aria/utils/Path.js
+++ b/test/aria/utils/Path.js
@@ -52,6 +52,9 @@ Aria.classDefinition({
             // test that properties starting with the dollar sign are correctly resolved
             var pathWithDollar = "param1[0].$var";
 
+            // test that properties inside window object are correctly resolved (resolve method used without 2nd parameter)
+            var pathInsideWindow = "Aria.version";
+
             var obj = {
                 param1 : [{
                             param3 : 13,
@@ -62,6 +65,7 @@ Aria.classDefinition({
             this.assertTrue(aria.utils.Path.resolve(pathStr, obj) == 13);
             this.assertTrue(aria.utils.Path.resolve(pathArray, obj) === false);
             this.assertTrue(aria.utils.Path.resolve(pathWithDollar, obj) === "testString");
+            this.assertEquals(aria.utils.Path.resolve(pathInsideWindow), Aria.version, "resolve method without second parameter does not extract the correct information: %1 != %2");
         },
 
         /**


### PR DESCRIPTION
`aria.utils.Path.resolve()` second arg is mandatory even if the doc specifies:
@param {Object} inside If not specified, window is used.

closes #1320
