### PR TITLE
feat #1327 validation stopOnError option

### DIFF
--- a/src/aria/utils/Data.js
+++ b/src/aria/utils/Data.js
@@ -32,6 +32,7 @@ module.exports = Aria.classDefinition({
     $constructor : function () {
         this.utilsType = ariaUtilsType;
         this.utilsArray = ariaUtilsArray;
+        this.errorNbrKey = this.NBROF_PREFIX + this.TYPE_ERROR;
     },
     $statics : {
         NBROF_PREFIX : "nbrOf",
@@ -365,17 +366,25 @@ module.exports = Aria.classDefinition({
          * @param {Object} messages
          * @param {Array} groups an optional parameter that contains the group(s) to be validated, if no group is
          * specified then validation will occur on the model as normal.
+         * @param {Boolean} stopOnError an optional parameter that (when set to true) stops the validation as soon as an error is detected in
+         * the model provided (defaults to false)
          */
-        validateModel : function (dataHolder, messages, groups) {
+        validateModel : function (dataHolder, messages, groups, stopOnError) {
             if (this.utilsType.isObject(dataHolder)) {
                 for (var key in dataHolder) {
                     if (dataHolder.hasOwnProperty(key)) {
-                        this.__subValidateModel(dataHolder, key, messages, groups);
+                        this.__subValidateModel(dataHolder, key, messages, groups, stopOnError);
+                        if (stopOnError && messages && messages[this.errorNbrKey] > 0){
+                            return;
+                        }
                     }
                 }
             } else if (this.utilsType.isArray(dataHolder)) {
                 for (var index = 0, l = dataHolder.length; index < l; index++) {
-                    this.__subValidateModel(dataHolder, index, messages, groups);
+                    this.__subValidateModel(dataHolder, index, messages, groups, stopOnError);
+                    if (stopOnError && messages && messages[this.errorNbrKey] > 0){
+                        return;
+                    }
                 }
             }
         },
@@ -387,15 +396,20 @@ module.exports = Aria.classDefinition({
          * @param {String} parameter
          * @param {Object} messages
          * @param {Array} group an optional parameter that contains the group(s) to be validated.
+         * @param {Boolean} stopOnError an optional parameter that (when set to true) stops the validation as soon as an error is detected in
+         * the model provided (defaults to false)
          */
-        __subValidateModel : function (dataHolder, parameter, messages, groups) {
+        __subValidateModel : function (dataHolder, parameter, messages, groups, stopOnError) {
             // filters meta marker and aria metadata
             if (!ariaUtilsJson.isMetadata(parameter)) {
                 if (dataHolder[this.META_PREFIX + parameter]) {
                     this.validateValue(dataHolder, parameter, messages, groups);
+                    if (stopOnError && messages && messages[this.errorNbrKey] > 0){
+                        return;
+                    }
                 }
                 var value = dataHolder[parameter];
-                this.validateModel(value, messages, groups);
+                return this.validateModel(value, messages, groups, stopOnError);
             }
         },
 

--- a/test/aria/utils/Data.js
+++ b/test/aria/utils/Data.js
@@ -137,6 +137,68 @@ Aria.classDefinition({
         },
 
         /**
+         * Test the validateModel method with the stopOnError parameter set to true
+         */
+        test_validateModelStopOnError : function (group) {
+            var data = {
+                param1 : 'value1',
+                param2 : [{
+                            elem1 : 'value2'
+                        }, {
+                            elem2 : 'value3'
+                        }, "thirdElement", null]
+            }, utilData = aria.utils.Data;
+
+            var numberValidator = new aria.utils.validators.Number();
+            var mandatoryValidator = new aria.utils.validators.Mandatory();
+            var length2Validator = new aria.utils.validators.Validator();
+            length2Validator.validate = function (value) {
+                if (value && value.length == 2) {
+                    return this._validationSucceeded();
+                } else {
+                    return this._validationFailed();
+                }
+            };
+
+            var notNullValidator = new aria.utils.validators.Validator();
+            notNullValidator.validate = function (value) {
+                if (value) {
+                    return this._validationSucceeded();
+                } else {
+                    return this._validationFailed();
+                }
+            };
+
+            utilData.setValidator(data, 'param1', mandatoryValidator);
+            utilData.setValidator(data.param2[1], 'elem2', numberValidator);
+            utilData.setValidator(data, 'param2', length2Validator);
+            utilData.setValidator(data.param2, 3, notNullValidator);
+
+            this._checkValidation(data, length2Validator);
+
+            utilData.setValidator(data, 'param2', mandatoryValidator);
+
+            this._checkValidation(data, numberValidator);
+
+            // updates datamodel to make things valid
+            data.param2[1].elem2 = "13";
+
+            this._checkValidation(data, notNullValidator);
+
+            numberValidator.$dispose();
+            mandatoryValidator.$dispose();
+            length2Validator.$dispose();
+            notNullValidator.$dispose();
+        },
+
+        _checkValidation : function (data, validator) {
+            var messages = {};
+            aria.utils.Data.validateModel(data, messages, null, true);
+            this.assertEquals(messages.nbrOfE, 1, "There should be only 1 message in the list of messages");
+            this.assertEquals(messages.listOfMessages[0].metaDataRef.validator, validator, "The validator that returned error does not correspond to the expected one: %1 != %2");
+        },
+
+        /**
          * test processMessages method
          */
         test_processMessages : function () {


### PR DESCRIPTION
a new parameter in the `validateModel()` method of the `aria.utils.Data` class stops the validation as soon as an error is detected and ignores the following ones.
close #1327
