### PR TITLE
Fixed an issue of widgets not working on some tactile devices.

### DIFF
--- a/src/aria/html/Select.js
+++ b/src/aria/html/Select.js
@@ -168,7 +168,7 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * return true if the index is a number within the valid boudaries
+         * return true if the index is a number within the valid boundaries
          * @param {MultiTypes} index
          */
         isIndexValid : function (index) {

--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -354,7 +354,14 @@ module.exports = Aria.classDefinition({
          * @param {String} id
          */
         getMarkup : function (id) {
-            return this.delegateExpando + "='" + id + "'";
+            var output = this.delegateExpando + "='" + id + "'";
+
+            // for iOS, see: https://developer.apple.com/library/IOS/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW3
+            if (ariaCoreBrowser.isIOS) {
+                output += " onclick='void(0)'";
+            }
+
+            return output;
         },
 
         /**
@@ -364,6 +371,13 @@ module.exports = Aria.classDefinition({
          */
         addExpando : function (domElt, id) {
             domElt.setAttribute(this.delegateExpando, id);
+
+            // for iOS, refer to method getMarkup
+            if (ariaCoreBrowser.isIOS) {
+                if (domElt.onclick == null) {
+                    domElt.onclick = Aria.empty;
+                }
+            }
         },
 
         /**

--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -104,7 +104,7 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Used to check that the value for the widget when it is initialised, is set.
+         * Used to check that the value for the widget when it is initialized, is set.
          */
         _checkCfgConsistency : function () {
             this.$DropDownInput._checkCfgConsistency.call(this);


### PR DESCRIPTION
On tactile devices, browsers use touch events, and can simulate mouse events as well.

Those mouse events are required for some of our widgets to work. This is notably the case with the `mousedown` event, and for the widgets:
- `Select`
- `RadioButton`
- `CheckBox`

However, the simulation of events does not always work as expected, and in practice the browser Safari on iOS does it only for clickable elements. This means that this doesn't work out of the box for `span` elements for instance, yet that's what we use in a lot of widgets.

Fortunately Apple provides a simple workaround in its documentation there: https://developer.apple.com/library/IOS/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW3

That's what has been implemented. Potential further issues related to the fact that now the concerned widgets are _unblocked_ are not tackled by this commit.

Apart from that, this commit fixes a few typos found in the code while investigating.
