### PR TITLE
fix Error tooltip not displayed in a datepicker

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -573,7 +573,9 @@ module.exports = Aria.classDefinition({
                         }
                         // if the text is incorrect, the bound property should
                         // be set to 'undefined'
-                        hasChange = this.setProperty("value", report.errorValue);
+                        if (!this._isPropertyEquals("value", report.errorValue)) {
+                            hasChange = this.setProperty("value", report.errorValue);
+                        }
                     }
                 }
 
@@ -618,16 +620,18 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Compare newValue with the one stored in _cfg[propertyName] Can be overrided to have a specific comparison
+         * Compare newValue with the one stored in _cfg[propertyName].
+         * Can be overridden to have a specific comparison.
+         * Two values are considered equal if they are strictly equal, or if they are both either null or undefined (we consider them as being "void").
          * @param {String} propertyName
          * @param {MultiTypes} newValue If transformation is used, this should be the widget value and not the data
          * model value
          * @private
-         * @return {Boolean} true if values are considered as equals.
+         * @return {Boolean} true if values are considered as equal.
          */
-        _isPropertyEquals : function (propertyName, value) {
+        _isPropertyEquals : function (propertyName, newValue) {
             var oldValue = this.getProperty(propertyName);
-            return oldValue === value;
+            return oldValue === newValue || (oldValue == null && newValue == null);
         },
         /**
          * Internal method called when one of the model property that the widget is bound to has changed Must be

--- a/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
@@ -127,6 +127,13 @@ Aria.classDefinition({
     },
     $prototype : {
 
+        /**
+         * Returns `null` in case the value is considered _void_, which means `undefined` or already `null`. Otherwise returns the value itself. Useful for contexts using strict equality comparison but in which we want to merge the meaning of `null` and `undefined` (through using the `null` value).
+         */
+        _normalizeNull : function(value) {
+            return value == null ? null : value;
+        },
+
         runTemplateTest : function () {
             this._runScenario("freetext");
         },
@@ -309,7 +316,8 @@ Aria.classDefinition({
                     }
                 }
             }
-            this.assertJsonEquals(dmValue, value, "Value in data model is not correct. Expected: \""
+
+            this.assertJsonEquals(this._normalizeNull(dmValue), this._normalizeNull(value), "Value in data model is not correct. Expected: \""
                     + jsonUtil.convertToJsonString(value) + "\", found \"" + jsonUtil.convertToJsonString(dmValue)
                     + "\" instead.");
         },

--- a/test/aria/widgets/form/datepicker/DatePickerTestSuite.js
+++ b/test/aria/widgets/form/datepicker/DatePickerTestSuite.js
@@ -26,6 +26,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.datepicker.checkFormat.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.checkBind.DatePicker");
         this.addTests("test.aria.widgets.form.datepicker.pickdate.PickDate");
-
+        this.addTests("test.aria.widgets.form.datepicker.validation.DatePickerWithValidatorTest");
     }
 });

--- a/test/aria/widgets/form/datepicker/validation/DatePickerCtrl.js
+++ b/test/aria/widgets/form/datepicker/validation/DatePickerCtrl.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.datepicker.validation.DatePickerCtrl",
+    $extends : 'aria.templates.ModuleCtrl',
+    $implements : ['test.aria.widgets.form.datepicker.validation.IDatePickerCtrl'],
+    $dependencies : ['aria.utils.validators.Mandatory'],
+    $constructor : function () {
+        this.$ModuleCtrl.constructor.call(this);
+        this._data = {
+            date : "",
+            errorMessages : []
+        };
+    },
+    $destructor : function () {
+        this.validator.$dispose();
+        this.validator = null;
+        this.$ModuleCtrl.$destructor.call(this);
+    },
+    $prototype : {
+        $publicInterfaceName : "test.aria.widgets.form.datepicker.validation.IDatePickerCtrl",
+        init : function (arg, cb) {
+            var startDateValidator = this.validator = new aria.utils.validators.Mandatory("date is mandatory");
+            aria.utils.Data.setValidator(this._data, "date", startDateValidator);
+
+            this.$callback(cb);
+        },
+        submit : function () {
+            var messages = {};
+            aria.utils.Data.validateModel(this._data, messages);
+            this.json.setValue(this._data, "errorMessages", messages.listOfMessages);
+        }
+    }
+});

--- a/test/aria/widgets/form/datepicker/validation/DatePickerWithValidatorTest.js
+++ b/test/aria/widgets/form/datepicker/validation/DatePickerWithValidatorTest.js
@@ -1,0 +1,48 @@
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.datepicker.validation.DatePickerWithValidatorTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            moduleCtrl : {
+                classpath : "test.aria.widgets.form.datepicker.validation.DatePickerCtrl"
+            }
+        });
+    },
+
+    $prototype : {
+        runTemplateTest : function () {
+            this._datePickerField = this.getInputField("datePicker");
+            this.synEvent.click(this._datePickerField, {
+                fn : this._afterClicking,
+                scope : this
+            });
+
+        },
+        _afterClicking : function () {
+            this.synEvent.type(this._datePickerField, "a", {
+                fn : this._afterTyping,
+                scope : this
+            });
+        },
+        _afterTyping : function () {
+            var widget = this.getWidgetInstance("btn");
+            this.synEvent.click(widget.getDom(), {
+                fn : this._afterValidation,
+                scope : this
+            });
+        },
+        _afterValidation : function () {
+            this.synEvent.click(this._datePickerField, {
+                fn : this._check,
+                scope : this
+            });
+        },
+        _check : function () {
+            var dom = this.getWidgetInstance("datePicker").getDom();
+            var span = dom.children[0];
+            this.assertTrue(span.className.indexOf("normalError") > -1, "The datepicker should have the error state");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/datepicker/validation/DatePickerWithValidatorTestTpl.tpl
+++ b/test/aria/widgets/form/datepicker/validation/DatePickerWithValidatorTestTpl.tpl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.datepicker.validation.DatePickerWithValidatorTestTpl"
+}}
+    {macro main()}
+        {@aria:DatePicker {
+            id: "datePicker",
+            bind: {
+                value: {
+                    inside: data,
+                    to: "date"
+                }
+            },
+            directOnBlurValidation : false
+        } /}
+
+        {@aria:Button {
+            label: "Validate",
+            id: "btn",
+            onclick: {
+                fn: "submit",
+                scope: moduleCtrl
+            }
+        } /}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/datepicker/validation/IDatePickerCtrl.js
+++ b/test/aria/widgets/form/datepicker/validation/IDatePickerCtrl.js
@@ -1,0 +1,7 @@
+Aria.interfaceDefinition({
+    $classpath : 'test.aria.widgets.form.datepicker.validation.IDatePickerCtrl',
+    $extends : 'aria.templates.IModuleCtrl',
+    $interface : {
+        submit : function () {}
+    }
+});

--- a/test/aria/widgets/form/selectbox/preselect/PreselectTestCase.js
+++ b/test/aria/widgets/form/selectbox/preselect/PreselectTestCase.js
@@ -96,7 +96,7 @@ Aria.classDefinition({
         _afterThirdSelection : function () {
             var field = this.getInputField("selectbox");
             this.assertEquals(field.value, "S");
-            this.assertUndefined(this.data.value);
+            this.assertUndefined(this.data.value == null ? undefined : this.data.value);
             this.data.value = null;
             this._refreshTestTemplate();
             field = this.getInputField("selectbox");
@@ -109,7 +109,7 @@ Aria.classDefinition({
         _afterFourthSelection : function () {
             var field = this.getInputField("selectbox");
             this.assertEquals(field.value, "Swe");
-            this.assertUndefined(this.data.value);
+            this.assertUndefined(this.data.value == null ? undefined : this.data.value);
             this.end();
         }
 


### PR DESCRIPTION
It happens when the datepicker is not initialized yet and an invalid value is entered : null is compared to undefined, resetting the DP state
