### PR TITLE
fix #1340 compatibility with bing map

### DIFF
--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -106,11 +106,14 @@ module.exports = Aria.classDefinition({
         }
 
         /**
-         * Delegated events on window. On modern browser, if focus is not on an element, event are not caught by the
+         * Delegated events on window. Only on Firefox 3, if focus is not on an element, event are not caught by the
          * body but the window.
          * @type Array
          */
-        this.delegatedOnWindow = ["keydown", "keyup", "keypress"];
+        this.delegatedOnWindow = [];
+
+        var elemDelegationArray = (ariaCoreBrowser.isFirefox && ariaCoreBrowser.majorVersion == 3)? this.delegatedOnWindow : this.delegatedOnBody;
+        elemDelegationArray.push("keydown", "keyup", "keypress");
 
         /**
          * Map of delegated events for gestures and their class paths.

--- a/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
+++ b/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
@@ -23,5 +23,6 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.keyboardNavigation.KeyMapTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.enter.EnterTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.DialogNavTestCase");
+        this.addTests("test.aria.templates.keyboardNavigation.bingCompatibility.KeyMapBingCompatibility");
     }
 });

--- a/test/aria/templates/keyboardNavigation/bingCompatibility/KeyMapBingCompatibility.js
+++ b/test/aria/templates/keyboardNavigation/bingCompatibility/KeyMapBingCompatibility.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test the compatibility of AT with the bing map
+ * The Bing map javascript intercepts the events on body and prevents their propagation, so
+ * it is very important to be sure that the AT delegation system catches all the events at
+ * body level (i.e. not window)
+ *
+ * This test verifies that the keydown event is correctly handled by the Select widget
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.templates.keyboardNavigation.bingCompatibility.KeyMapBingCompatibility",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.map.MapManager", "aria.utils.FireDomEvent", "aria.core.Browser"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.mapMgr = aria.map.MapManager;
+        this.setTestEnv({
+            template : "test.aria.templates.keyboardNavigation.bingCompatibility.KeyMapBingCompatibilityTpl",
+            data : {
+                countries : [
+                    {
+                        value : "FR",
+                        label : "France"
+                    },
+                    {
+                        value : "CH",
+                        label : "Switzerland"
+                    },
+                    {
+                        value : "UK",
+                        label : "United Kingdom"
+                    }
+                ]
+            }
+        });
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+        /*
+         * The test is not working on FF3 because only on FF3, if focus is not on an element, event are not caught by the
+         * body but the window. So the keydown, keyup and keypress are delegated to the window making Bing map incompatible with AT
+         * (Bing map prevent the propagation of all the events to the window)
+         */
+            if (aria.core.Browser.isFirefox && aria.core.Browser.majorVersion == 3) {
+                this.end();
+                return;
+            }
+            this.mapMgr.$onOnce({
+                "mapReady" : {
+                    fn : this._changeSelected,
+                    scope : this
+                }
+            });
+        },
+
+        _changeSelected : function () {
+            this.templateCtxt.$focus("select");
+            this.synEvent.type(this.getElementById("select"), "[down]", {
+                fn : this._focusOut,
+                scope : this
+            });
+        },
+
+        _focusOut : function () {
+            this.templateCtxt.$focus("justToFocusOut");
+            aria.core.Timer.addCallback({
+                fn : this._checkCountry,
+                scope : this,
+                delay : 200
+            });
+
+        },
+
+        _checkCountry : function () {
+            this.assertEquals(this.templateCtxt.data.country, "CH", "wrong country selected: %1 =! %2");
+            this.end();
+        }
+    }
+});

--- a/test/aria/templates/keyboardNavigation/bingCompatibility/KeyMapBingCompatibilityTpl.tpl
+++ b/test/aria/templates/keyboardNavigation/bingCompatibility/KeyMapBingCompatibilityTpl.tpl
@@ -1,0 +1,41 @@
+{Template {
+  $classpath : "test.aria.templates.keyboardNavigation.bingCompatibility.KeyMapBingCompatibilityTpl",
+  $wlibs: {
+          "embed": "aria.embed.EmbedLib"
+  }
+}}
+
+  {macro main()}
+    <div class="mapSampleContainer">
+    {@embed:Map {
+        id : "map",
+        provider : "microsoft7",
+        loadingIndicator : true,
+        type : "DIV",
+        attributes : {
+          classList : ["mapContainer"]
+        }
+    }/}
+
+
+    </div>
+
+    {@aria:Select {
+        id : "select",
+        label : "All Countries: ",
+        labelWidth : 220,
+        options : data.countries,
+        bind : {
+            value : {
+                to : "country",
+                inside : data
+            }
+        }
+    }/}
+
+    <input {id "justToFocusOut"/}>
+
+
+  {/macro}
+
+{/Template}


### PR DESCRIPTION
The Bing map javascript intercepts the events on body and prevents their propagation, so it is very important to be sure that the AT delegation system catches all the events at body level (i.e. not window)
close #1340
