### PR TITLE
Fixing a problem inside aria.utils.dragdrop.Drag on Chrome with elements in position:fixed

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -736,14 +736,16 @@ module.exports = Aria.classDefinition({
          * @public
          */
         getOffset : function (element) {
-            var isAbsolute = this.getStyle(element, "position") === "absolute";
+            var positionStyle = this.getStyle(element, "position");
+            var isAbsolute = positionStyle === "absolute";
+            var isFixed = positionStyle === "fixed";
             var position = {};
             if (isAbsolute) {
                 position.left = this.getStylePx(element, "left", null);
                 position.top = this.getStylePx(element, "top", null);
             }
             if (position.left == null || position.top == null) {
-                var offsetParent = element.offsetParent;
+                var offsetParent = isFixed ? Aria.$window.document.body : element.offsetParent;
                 var offsetParentPosition = this.calculatePosition(offsetParent);
                 var elementPosition = this.calculatePosition(element);
                 if (position.left == null) {

--- a/test/aria/utils/dragdrop/DragTestSuite.js
+++ b/test/aria/utils/dragdrop/DragTestSuite.js
@@ -30,6 +30,7 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.dragdrop.DragProxyTest");
         this.addTests("test.aria.utils.dragdrop.DragDropBean");
         this.addTests("test.aria.utils.dragdrop.issue397.MovableScrollbarTest");
+        this.addTests("test.aria.utils.dragdrop.fixedElements.FixedElementTest");
 
     }
 });

--- a/test/aria/utils/dragdrop/fixedElements/FixedElementStyle.tpl.css
+++ b/test/aria/utils/dragdrop/fixedElements/FixedElementStyle.tpl.css
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+  $classpath : "test.aria.utils.dragdrop.fixedElements.FixedElementStyle"
+}}
+
+  {macro main()}
+        .fixed {
+            position : fixed;
+        }
+        .absolute {
+            position : absolute;
+        }
+
+        .modal {
+            width : 300px;
+            height : 200px;
+            border : 1px Solid black;
+        }
+
+        .title-bar {
+            height : 20px;
+            line-height : 20px;
+            width : 100%;
+            background : #3388ff;
+            color: white;
+            text-align : center;
+        }
+    {/macro}
+
+{/CSSTemplate}

--- a/test/aria/utils/dragdrop/fixedElements/FixedElementTest.js
+++ b/test/aria/utils/dragdrop/fixedElements/FixedElementTest.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Template Test case for different types of proxies available for dragging
+ */
+Aria.classDefinition({
+    $classpath : "test.aria.utils.dragdrop.fixedElements.FixedElementTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.dragdrop.Drag", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            template : "test.aria.utils.dragdrop.fixedElements.FixedElementTestTemplate"
+        });
+    },
+    $prototype : {
+
+        tearDown : function () {
+            this._draggable1.$dispose();
+            this._draggable2.$dispose();
+            this._draggable1 = null;
+            this._draggable2 = null;
+            this._draggableFixed = null;
+            this._draggableAbsolute = null;
+        },
+
+        runTemplateTest : function () {
+            var dom = aria.utils.Dom;
+            this._draggableFixed = dom.getElementById("draggable-fixed");
+            this._draggableAbsolute = dom.getElementById("draggable-absolute");
+
+            this._initDrag();
+            this._testDraggable(this._draggableFixed, false);
+        },
+
+        _initDrag : function () {
+            var dom = aria.utils.Dom;
+            this._draggable1 = new aria.utils.dragdrop.Drag(this._draggableFixed, {
+               cursor : 'move',
+               constrainTo : Aria.$window.document.body,
+               handle : dom.getElementsByClassName(this._draggableFixed, 'title-bar')[0]
+            });
+
+            this._draggable2 = new aria.utils.dragdrop.Drag(this._draggableAbsolute, {
+               cursor : 'move',
+               constrainTo : Aria.$window.document.body,
+               handle : dom.getElementsByClassName(this._draggableAbsolute, 'title-bar')[0]
+            });
+        },
+
+        _testDraggable : function (draggable, end) {
+            var dom = aria.utils.Dom;
+            var geometry = dom.getGeometry(draggable);
+            var geometryChild = dom.getGeometry(draggable.firstElementChild);
+
+            var from = {
+                x : geometry.x + geometry.width / 2,
+                y : geometry.y + geometryChild.height / 2
+            };
+            var options = {
+                duration : 1000,
+                to : {
+                    x : from.x - 10,
+                    y : from.y + 100
+                }
+            };
+            var assertCb = {
+                fn : this._testAsserts,
+                scope : this,
+                args : {draggable : draggable, geometry : geometry, endTest : end}
+            };
+
+            this.synEvent.drag(options, from, assertCb);
+        },
+
+        _testAsserts : function (_, args) {
+            var geometry = args.geometry;
+            var endTest = args.endTest;
+            var newGeometry = aria.utils.Dom.getGeometry(args.draggable);
+
+            this.assertNotEquals(geometry.x, newGeometry.x, "The element did not move horizontally. Starting xPos = " + geometry.x + ", Ending xPos = " + newGeometry.x + ".");
+            this.assertNotEquals(geometry.y, newGeometry.y, "The element did not move vertically. Starting yPos = " + geometry.y + ", Ending yPos = " + newGeometry.y + ".");
+
+            if (!endTest) {
+                this._testDraggable(this._draggableAbsolute, true);
+            } else {
+                this.end();
+            }
+        }
+    }
+});

--- a/test/aria/utils/dragdrop/fixedElements/FixedElementTestTemplate.tpl
+++ b/test/aria/utils/dragdrop/fixedElements/FixedElementTestTemplate.tpl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+  $classpath : "test.aria.utils.dragdrop.fixedElements.FixedElementTestTemplate",
+  $css : ["test.aria.utils.dragdrop.fixedElements.FixedElementStyle"]
+} }
+
+  {macro main ( )}
+
+    <div id="draggable-fixed" class="modal fixed">
+        <div class="title-bar">Fixed</div>
+        Cannot move :(
+    </div>
+    <div id="draggable-absolute" class="modal absolute" style="right:50px;">
+        <div class="title-bar">Absolute</div>
+        Will move just fine
+    </div>
+
+{/macro}
+
+{/Template}


### PR DESCRIPTION
This commit fixes a problem inside the getOffset method of the aria.utils.Dom class. We use the offsetParent property to compute the element position, but for a fixed element in Chrome the offsetParent is null and it breaks the code.
