### PR TITLE
Fixing Robot tests failures on Firefox 3.x

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -695,6 +695,9 @@ module.exports = Aria.classDefinition({
          * @private
          */
         __cleanEnv : function (mctrl) {
+            if (!this.testWindow) {
+                return;
+            }
             var classRef = this.testWindow.Aria.getClassRef(this.env.template);
             var classMgr = this.testWindow.aria.core.ClassMgr;
             if (classRef && classRef.classDefinition.$hasScript) {

--- a/test/aria/templates/EmptyTestCase.js
+++ b/test/aria/templates/EmptyTestCase.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.EmptyTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $prototype : {
+        run : function () {
+            if (!this.skipTest) {
+                this._startTest();
+                this._endTest();
+            } else {
+                this.$TemplateTestCase.run.call(this);
+            }
+        }
+    }
+});

--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -19,6 +19,7 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.templates.EmptyTestCase");
         this.addTests("test.aria.templates.autorefresh.AutorefreshTestSuite");
         this.addTests("test.aria.templates.beforeRefresh.BeforeRefreshTestCase");
 


### PR DESCRIPTION
Robot tests are supposed to be ignored on Firefox 3.x, however, there were still indirect errors after commit e55822502a93ba95fdcf3b07f885d543c99692c0.
