### PR TITLE
fix #1278 onclick broken if Icon has no tooltip

### DIFF
--- a/src/aria/widgets/Icon.js
+++ b/src/aria/widgets/Icon.js
@@ -82,16 +82,14 @@ module.exports = Aria.classDefinition({
             }
 
             var delegationMarkup = "";
-            if (cfg.tooltipId) {
-                var delegateManager = aria.utils.Delegate;
-                if (!this._delegateId) {
-                    this._delegateId = delegateManager.add({
-                        fn : this.delegate,
-                        scope : this
-                    });
-                }
-                delegationMarkup = delegateManager.getMarkup(this._delegateId) + " ";
+            var delegateManager = aria.utils.Delegate;
+            if (!this._delegateId) {
+                this._delegateId = delegateManager.add({
+                    fn : this.delegate,
+                    scope : this
+                });
             }
+            delegationMarkup = delegateManager.getMarkup(this._delegateId) + " ";
 
             if (!iconInfo.spriteURL && cfg.icon) {
                 var classes = aria.widgets.AriaSkinInterface.getSkinObject("Icon", cfg.icon.split(":")[0], true).content[cfg.icon.split(":")[1]];

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -44,6 +44,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.action.iconbutton.issue276.IconButtonTestCase");
         this.addTests("test.aria.widgets.verticalAlign.VerticalAlignTestCase");
         this.addTests("test.aria.widgets.icon.IconTest");
+        this.addTests("test.aria.widgets.icon.notooltip.NoTooltipIconTest");
         this.addTests("test.aria.widgets.splitter.scrollbars.ScrollbarTestCase");
         this.addTests("test.aria.widgets.issue746.SkinClassFallbackTestCase");
         this.addTests("test.aria.widgets.form.text.textcontentissue.TextContentTest");

--- a/test/aria/widgets/icon/notooltip/NoTooltipIconTest.js
+++ b/test/aria/widgets/icon/notooltip/NoTooltipIconTest.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.icon.notooltip.NoTooltipIconTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            data : {
+                value : 0
+            }
+        });
+
+        this.defaultTestTimeout = 5000; // fail fast if can't get past waitFor
+    },
+    $prototype : {
+
+        runTemplateTest : function () {
+            var icon = this.getWidgetInstance("testIcon").getDom();
+            this.assertEquals(this.templateCtxt.data.value, 0);
+            this.synEvent.click(icon, {
+                scope : this,
+                fn : this._afterClick
+            });
+        },
+        _afterClick : function () {
+            this.waitFor({
+                condition : function () {
+                    return this.templateCtxt.data.value === 1;
+                },
+                callback : {
+                    fn : this._afterWait,
+                    scope : this
+                }
+            });
+        },
+        _afterWait : function () {
+            this.assertEquals(this.templateCtxt.data.value, 1);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/icon/notooltip/NoTooltipIconTestTpl.tpl
+++ b/test/aria/widgets/icon/notooltip/NoTooltipIconTestTpl.tpl
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ {Template {
+	$classpath : "test.aria.widgets.icon.notooltip.NoTooltipIconTestTpl",
+	$hasScript : true
+}}
+
+	{macro main()}
+		<div>
+			{@aria:Icon {
+				id : "testIcon",
+				icon : "std:info",
+				onclick : "myClickHandler"
+			}/}
+		</div>
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/icon/notooltip/NoTooltipIconTestTplScript.js
+++ b/test/aria/widgets/icon/notooltip/NoTooltipIconTestTplScript.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.icon.notooltip.NoTooltipIconTestTplScript",
+    $dependencies : ["aria.utils.Json"],
+    $prototype : {
+        myClickHandler : function() {
+            aria.utils.Json.setValue(this.data, "value", 1);
+        }
+    }
+});


### PR DESCRIPTION
When Icon widget had no tooltip, but `onclick` defined, the method was never invoked.

The commit only removes the conditional statement around delegate definition (ugly diff due to whitespace change)

close #1279
close #1366
