### PR TITLE
fix #1367 use `expando.value` instead of deprecated `.nodeValue`

### DIFF
--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -521,7 +521,7 @@ module.exports = Aria.classDefinition({
                     expandoValue = target.attributes[this.delegateExpando];
                     if (expandoValue) {
                         ATflag = true;
-                        expandoValue = expandoValue.nodeValue;
+                        expandoValue = expandoValue.value;
                         cacheStack = this.__stackCache[expandoValue];
 
                         // search the cache for existing hierachy


### PR DESCRIPTION
Chrome and Firefox dev tools log deprecation message of `.nodeValue`
which may unnecessarily pollute applications' logs.

The alternative `.value` seems to be supported by all browsers
(tested down to Firefox 3 and IE7)
