### PR TITLE
fix #1377 loading overlay juddering on scroll in Safari Mobile

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -604,7 +604,8 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Get the absolute position in a page of an element
+         * Get the position in a page of an element. It is relative to the current viewport (i.e. depends on scroll of
+         * the page)
          * @param {HTMLElement} element
          * @param {Boolean} stopAbsolute <i>[optional, default=false]</i> if true, it will stop calculating the
          * position when it encounters the first ancestor of the element with absolute positioning
@@ -714,7 +715,8 @@ module.exports = Aria.classDefinition({
 
         /**
          * Get the client geometry of an element. It means the coordinates of the top/left corner and the width and
-         * height of the area inside the element which can be used by its child elements.
+         * height of the area inside the element which can be used by its child elements. Returned value is relative to
+         * the current viewport.
          * @param {HTMLElement} element Element whose client geometry is requested.
          * @return {aria.utils.DomBeans:Geometry} Geometry object
          */
@@ -729,8 +731,8 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Get the offset top and left of an element, based either on the style or the offset element. Useful to manage
-         * some internet explorer offset issues.
+         * Get the offset top and left of an element (relative to its offset parent), based either on the style or the
+         * offset element. Useful to manage some internet explorer offset issues.
          * @param {HTMLElement} element Element whose offset is requested.
          * @return {Object} JSON with the top ad left properties.
          * @public
@@ -763,9 +765,9 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Get the geometry of an element. It means the coordinates of top/left corner and its width and height. If the
-         * element is the body, the geometry corresponds to the whole page, otherwise it's the visible part of the
-         * element.
+         * Get the geometry of an element, relative to the current viewport. It means the coordinates of top/left corner
+         * and its width and height. If the element is the body, the geometry corresponds to the whole page, otherwise
+         * it's the visible part of the element.
          * @param {HTMLElement} element Element whose geometry is requested.
          * @return {aria.utils.DomBeans:Geometry} Geometry object
          * @public

--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -95,10 +95,19 @@ module.exports = Aria.classDefinition({
             var overlayGeometry = null;
 
             if (geometry) {
-                overlayGeometry = {
-                    x : Math.max(geometry.x, 0),
-                    y : Math.max(geometry.y, 0)
-                };
+                if (overlay.style.position == "absolute") {
+                    // geometry is relative to viewport
+                    var documentScroll = aria.utils.Dom._getDocumentScroll();
+                    overlayGeometry = {
+                        x : Math.max(geometry.x + documentScroll.scrollLeft, 0),
+                        y : Math.max(geometry.y + documentScroll.scrollTop, 0)
+                    };
+                } else { // fixed
+                    overlayGeometry = {
+                        x : Math.max(geometry.x, 0),
+                        y : Math.max(geometry.y, 0)
+                    };
+                }
 
                 overlayGeometry.width = Math.min(geometry.width + Math.min(geometry.x, 0), viewportSize.width
                         - overlayGeometry.x);

--- a/src/aria/utils/overlay/Overlay.js
+++ b/src/aria/utils/overlay/Overlay.js
@@ -70,7 +70,16 @@ module.exports = Aria.classDefinition({
                 overlay.id = "xOverlay" + params.id;
             }
             overlay.className = params.className || "xOverlay";
-            overlay.style.position = params.position || "fixed";
+
+            // absolute positioning is preferred over fixed since Safari Mobile doesn't repaint fixed elements on scroll
+            var position = params.position || "absolute";
+
+            // Place it in the top-left corner of the page, otherwise if it happens to be inserted far in the DOM, it
+            // may temporarily create unnecessary scrollbars on the page - this may affect proper positioning of the
+            // overlay. We'll set left/top later.
+            overlay.style.left = 0;
+            overlay.style.top = 0;
+            overlay.style.position = position;
 
             return overlay;
         },


### PR DESCRIPTION
This PR changes default overlay position from fixed to absolute to prevent an issue on Safari Mobile where fixed-positioned overlay is not repainted on screen during scrolling until the scrolling ends.

I've tested the fix on the requesting application and on the following sample, on ipad (Safari 8), galaxy tab with Chrome, and on desktop browsers to check for regressions (Firefox, Chrome, IE7-9)

* http://ariatemplates.com/samples/?path=samples.templates.domInteractions.processingIndicator.Sample

I also tested those samples in major desktop browsers (Fx, Ch, IE7-9) for non-regression:

* http://ariatemplates.com/samples/?path=samples.widgets.dialog.resizable.TemplateResizableDialog
* http://ariatemplates.com/samples/?path=samples.widgets.dialog.movable.TemplateMovableDialog
