### PR TITLE
Escape html in @aria:Textarea widget

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -333,7 +333,7 @@ module.exports = Aria.classDefinition({
                         ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth,
                         'px;"', 'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
                         (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck,
-                        '>', stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text),
+                        '>', stringUtils.escapeHTML(((this._helpTextSet) ? cfg.helptext : text) || ""),
                         '</textarea>'
 
                 ].join(''));

--- a/test/aria/widgets/form/TextareaTest.js
+++ b/test/aria/widgets/form/TextareaTest.js
@@ -395,6 +395,24 @@ Aria.classDefinition({
             }, false);
 
             aria.core.AppEnvironment.setEnvironment({});
+        },
+
+        testEncodedCharacters : function () {
+            var data = {
+                value : "&currency&cent"
+            };
+            var tf = this._createTextarea({
+                label : "TESTLABEL",
+                bind : {
+                    value : {
+                        to : "value",
+                        inside : data
+                    }
+                }
+            });
+            var instance = tf.instance;
+            this.assertEquals(tf.dom.getElementsByTagName('textarea')[0].value, data.value, "Value has been transformed incorrectly");
+            this._destroyTextarea(instance);
         }
     }
 });


### PR DESCRIPTION
If the data model contains, for example, "&pound" the field should display it as it is. Before this commit the content of the text area would be a pound sign.