### PR TITLE
Blur after destroying a TextInput

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -24,7 +24,6 @@ var ariaUtilsArray = require("../../utils/Array");
 var ariaCoreBrowser = require("../../core/Browser");
 var ariaCoreTimer = require("../../core/Timer");
 
-
 /**
  * Specialize the input classes for Text input and manage the HTML input element
  */
@@ -153,6 +152,11 @@ module.exports = Aria.classDefinition({
 
     },
     $destructor : function () {
+        if (this._hasFocus) {
+            // In IE, blurring is important in order to release properly the focus before destroying the element
+            this._dom_onblur = Aria.empty;
+            this._textInputField.blur();
+        }
         this._textInputField = null;
 
         if (this.controller) {

--- a/test/aria/widgets/form/textinput/TextInputTestSuite.js
+++ b/test/aria/widgets/form/textinput/TextInputTestSuite.js
@@ -24,6 +24,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.textinput.blurvalidation.BlurValidationTestCase",
                 "test.aria.widgets.form.textinput.quotes.QuotesTestCase",
                 "test.aria.widgets.form.textinput.onclick.OnClickTest",
-                "test.aria.widgets.form.textinput.onfocus.OnFocusTest"];
+                "test.aria.widgets.form.textinput.onfocus.OnFocusTest",
+                "test.aria.widgets.form.textinput.blurOnDestroy.ClickButtonAfterDestroyTest"];
     }
 });

--- a/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTest.js
+++ b/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTest.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.textinput.blurOnDestroy.ClickButtonAfterDestroyTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+
+        this._data = {
+            rep : [{
+                        a : "a",
+                        val : null
+                    }],
+            clicks : 0,
+            refresh : false
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.textinput.blurOnDestroy.ClickButtonAfterDestroyTpl",
+            data : this._data
+        });
+
+    },
+
+    $prototype : {
+
+        runTemplateTest : function () {
+            var tf = this.getInputField("tf0");
+            var btn = this.getElementById("testButton");
+
+            this.synEvent.execute([["click", tf], ["type", tf, "aaa[enter]"], ["click", btn]], {
+                fn : this.__afterClick,
+                scope : this
+            });
+        },
+
+        __afterClick : function () {
+            this.assertEquals(this._data.refresh, true, "The section was not refreshed. This compromises the validity of the test");
+            this.assertEquals(this._data.clicks, 1, "The click handler has not been called.");
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTpl.tpl
+++ b/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTpl.tpl
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath : "test.aria.widgets.form.textinput.blurOnDestroy.ClickButtonAfterDestroyTpl",
+	$hasScript : true
+}}
+
+	{macro main()}
+
+		<table>
+			{repeater {
+				id : "testRep",
+				content : data.rep,
+				loopType: "array",
+				type : "tbody",
+				childSections : {
+					id : "childSec",
+					macro : "singleEntry",
+					type : "tr"
+				}
+			}/}
+		</table>
+		<table>
+			<tr>
+				<td width = "50%" align="left">
+					<table {id "addMoreLink"/}>
+						<tr><td></td><td></td></tr>
+					</table>
+				</td>
+				<td width = "50%" align="right">
+					{@aria:Button {
+						label : "find",
+						id : "testButton",
+						onclick : function () {
+							$json.setValue(data, "clicks", data.clicks + 1);
+						},
+						margins : "10 0 0 100"
+					}/}
+				</td>
+				<td></td>
+			</tr>
+		</table>
+	{/macro}
+
+	{macro singleEntry (args)}
+		<td style="width:10%"></td>
+		<td style="width:45%">
+			<div id="div${args.index}">
+				{@aria:TextField {
+					id : "tf" + args.index,
+					helptext : "whatever",
+					labelPos : "left",
+					width : 300,
+					requireFocus : true,
+					onchange : {
+						fn : "_onChange",
+						scope : this,
+						args : []
+					},
+					bind : {
+						value : {
+							to : "val",
+							inside : args.item
+						}
+					}
+
+				}/}
+			</div>
+		</td>
+		<td style="width:5%">&nbsp;&nbsp;&nbsp;&nbsp;</td>
+		<td style="width:30%">
+			<div id="divSelect${args.index}"></div>
+		</td>
+		<td style="width:10%"></td>
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTplScript.js
+++ b/test/aria/widgets/form/textinput/blurOnDestroy/ClickButtonAfterDestroyTplScript.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.textinput.blurOnDestroy.ClickButtonAfterDestroyTplScript',
+    $prototype : {
+
+        _onChange : function () {
+            this.data.refresh = true;
+            var ar = this.data.rep;
+            var oldV = ar[0];
+            this.$json.removeAt(ar, 0);
+            this.$json.add(ar, oldV);
+        }
+    }
+});


### PR DESCRIPTION
In IE, after destroying a TextInput having focus, the focus was not correctly released.
This had an impact on the behaviour of the application.

For example, when clicking on a button after the refresh operation, the click event was not being raised.