### PR TITLE
Loading Overlay for Safari once again (obsoletes #1377)

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -518,11 +518,23 @@ module.exports = Aria.classDefinition({
         _getViewportSize : function () {
             var document = Aria.$window.document;
             var docEl = document.documentElement;
-            var size = {
-                'width' : docEl.clientWidth,
-                'height' : docEl.clientHeight
-            };
-            return size;
+            if (ariaCoreBrowser.isIOS || ariaCoreBrowser.isAndroid) {
+                // On ipad, normally window's dimensions are the same as documentElement's
+                // But the viewport resizes when scrolling the page (the address bar is shrinked
+                // gradually) and documentElement's size is unaffected while window's size changes
+
+                // On android/chrome however, docEl.clientHeight is the virtual viewport's size
+                // (which may be many times bigger), not the screen-visible viewport size
+                return {
+                    'width' : Aria.$window.innerWidth,
+                    'height' : Aria.$window.innerHeight
+                };
+            } else {
+                return {
+                    'width' : docEl.clientWidth,
+                    'height' : docEl.clientHeight
+                };
+            }
         },
 
         /**

--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -18,7 +18,6 @@ var ariaCoreBrowser = require("../core/Browser");
 var ariaUtilsString = require("./String");
 var ariaUtilsCssUnits = require("./css/Units");
 
-
 /**
  * This class contains utilities to manipulate the DOM.
  */
@@ -516,20 +515,22 @@ module.exports = Aria.classDefinition({
          * @private
          */
         _getViewportSize : function () {
-            var document = Aria.$window.document;
-            var docEl = document.documentElement;
-            if (ariaCoreBrowser.isIOS || ariaCoreBrowser.isAndroid) {
-                // On ipad, normally window's dimensions are the same as documentElement's
-                // But the viewport resizes when scrolling the page (the address bar is shrinked
-                // gradually) and documentElement's size is unaffected while window's size changes
+            if (ariaCoreBrowser.isIOS || ariaCoreBrowser.isAndroid || ariaCoreBrowser.isWindowsPhone) {
+                // Initially (without user-initiated zoom) window's dimensions are the same or nearly the same as
+                // documentElement's.
+                // Note however that documentElement's clientWidth/Height is unaffected by user zoom while window's
+                // innerWidth/Height change on zoom.
+                // Also, in Safari on ipad, the viewport resizes when scrolling the page (the address bar is shrinked
+                // gradually) and documentElement's size is unaffected, while window's size changes (but in Chrome on
+                // mobile, both change).
 
-                // On android/chrome however, docEl.clientHeight is the virtual viewport's size
-                // (which may be many times bigger), not the screen-visible viewport size
+                // See also http://jakub-g.github.io/quirksmode/widthtest.html
                 return {
                     'width' : Aria.$window.innerWidth,
                     'height' : Aria.$window.innerHeight
                 };
             } else {
+                var docEl = Aria.$window.document.documentElement;
                 return {
                     'width' : docEl.clientWidth,
                     'height' : docEl.clientHeight
@@ -538,7 +539,21 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * @return {aria.utils.DomBeans:Size} Size object width 'width' and 'height' properties
+         * @return {aria.utils.DomBeans:Size} Size object width 'width' and 'height' properties.<br>
+         * This method returns the size in pixels of the <strong>visible on screen portion of the viewport</strong> (in
+         * contrast to the so called "virtual viewport" on the mobile devices). It is suitable for usages like
+         * determining the size of the overlays covering whole or part of the page.<br>
+         * <br>
+         * Note that viewport size may change in many situations, such as when the user:<br> - resizes the browser,<br> -
+         * rotates the mobile device,<br> - scrolls the page (on mobile devices),<br> - zooms the page (on mobile
+         * devices),<br>
+         * as well as on desktop browsers when some elements are added to/removed from the DOM (since viewport size
+         * excludes scrollbars, which may or may not appear on the page in desktop browsers).<br>
+         * <br>
+         * If you depend on the precise viewport size information, you should listen to <tt>window.onresize</tt> and
+         * <tt>document.onscroll</tt> events.<br>
+         * <br>
+         * See also http://jakub-g.github.io/quirksmode/widthtest.html
          */
         getViewportSize : function () {
             return this._getViewportSize();

--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -95,10 +95,19 @@ module.exports = Aria.classDefinition({
             var overlayGeometry = null;
 
             if (geometry) {
-                overlayGeometry = {
-                    x : Math.max(geometry.x, 0),
-                    y : Math.max(geometry.y, 0)
-                };
+                if (overlay.style.position == "absolute") {
+                    // geometry is relative to viewport
+                    var documentScroll = aria.utils.Dom._getDocumentScroll();
+                    overlayGeometry = {
+                        x : Math.max(geometry.x + documentScroll.scrollLeft, 0),
+                        y : Math.max(geometry.y + documentScroll.scrollTop, 0)
+                    };
+                } else { // fixed
+                    overlayGeometry = {
+                        x : Math.max(geometry.x, 0),
+                        y : Math.max(geometry.y, 0)
+                    };
+                }
 
                 overlayGeometry.width = Math.min(geometry.width + Math.min(geometry.x, 0), viewportSize.width
                         - overlayGeometry.x);

--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -95,24 +95,36 @@ module.exports = Aria.classDefinition({
             var overlayGeometry = null;
 
             if (geometry) {
+                var width1, width2, height1, height2;
+
+                var overlayGeometryViewportRelative = {
+                    x : Math.max(geometry.x, 0),
+                    y : Math.max(geometry.y, 0)
+                };
                 if (overlay.style.position == "absolute") {
                     // geometry is relative to viewport
+                    // overlayGeometry will be relative to the page!
                     var documentScroll = aria.utils.Dom._getDocumentScroll();
                     overlayGeometry = {
                         x : Math.max(geometry.x + documentScroll.scrollLeft, 0),
                         y : Math.max(geometry.y + documentScroll.scrollTop, 0)
                     };
                 } else { // fixed
-                    overlayGeometry = {
-                        x : Math.max(geometry.x, 0),
-                        y : Math.max(geometry.y, 0)
-                    };
+                    // geometry is relative to viewport
+                    // overlayGeometry will be relative to the viewport too
+                    overlayGeometry = overlayGeometryViewportRelative;
                 }
 
-                overlayGeometry.width = Math.min(geometry.width + Math.min(geometry.x, 0), viewportSize.width
-                        - overlayGeometry.x);
-                overlayGeometry.height = Math.min(geometry.height + Math.min(geometry.y, 0), viewportSize.height
-                        - overlayGeometry.y);
+                // "cut-off" the overlay if the element stands out of the viewport to the left / top
+                width1 = geometry.width + Math.min(geometry.x, 0);
+                height1 = geometry.height + Math.min(geometry.y, 0);
+
+                // "cut-off" the overlay if the element stands out of the viewport to the right / bottom
+                width2 = viewportSize.width - overlayGeometryViewportRelative.x;
+                height2 = viewportSize.height - overlayGeometryViewportRelative.y;
+
+                overlayGeometry.width = Math.min(width1, width2);
+                overlayGeometry.height = Math.min(height1, height2);
             }
 
             var style = overlay.style;

--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -106,8 +106,8 @@ module.exports = Aria.classDefinition({
                     // overlayGeometry will be relative to the page!
                     var documentScroll = aria.utils.Dom._getDocumentScroll();
                     overlayGeometry = {
-                        x : Math.max(geometry.x + documentScroll.scrollLeft, 0),
-                        y : Math.max(geometry.y + documentScroll.scrollTop, 0)
+                        x : Math.max(geometry.x, 0) + documentScroll.scrollLeft,
+                        y : Math.max(geometry.y, 0) + documentScroll.scrollTop
                     };
                 } else { // fixed
                     // geometry is relative to viewport

--- a/src/aria/utils/overlay/Overlay.js
+++ b/src/aria/utils/overlay/Overlay.js
@@ -70,7 +70,16 @@ module.exports = Aria.classDefinition({
                 overlay.id = "xOverlay" + params.id;
             }
             overlay.className = params.className || "xOverlay";
-            overlay.style.position = params.position || "fixed";
+
+            // absolute positioning is preferred over fixed since Safari Mobile doesn't repaint fixed elements on scroll
+            var position = params.position || "absolute";
+
+            // Place it in the top-left corner of the page, otherwise if it happens to be inserted far in the DOM, it
+            // may temporarily create unnecessary scrollbars on the page - this may affect proper positioning of the
+            // overlay. We'll set left/top later.
+            overlay.style.left = 0;
+            overlay.style.top = 0;
+            overlay.style.position = position;
 
             return overlay;
         },

--- a/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
+++ b/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
@@ -43,6 +43,7 @@ Aria.classDefinition({
         _addLoadingIndicatorOnSpan : function () {
             this.domOverlay.create(this.spanWithLoader, "just a message");
             this.domOverlay.create(this.body, "just a message");
+
             this._testOverlay(this.spanWithLoader, "none");
             this._testBodyOverlay();
 
@@ -65,7 +66,6 @@ Aria.classDefinition({
                 scope : this,
                 delay : 300
             });
-
         },
 
         _afterSecondScroll : function () {
@@ -140,15 +140,16 @@ Aria.classDefinition({
             tolHeight = tolHeight || 0;
             var overlay = this.domOverlay.__getOverlay(element).overlay.overlay;
             if (display) {
-                this.assertEquals(overlay.style.display, display);
+                var msg = "The overlay on " + element.tagName + " had display: %1 instead of %2";
+                this.assertEquals(overlay.style.display, display, msg);
             }
             if (width) {
                 var actualWidth = parseInt(overlay.style.width, 10);
-                this.assertTrue(Math.abs(actualWidth - width) <= tolWidth, "Wrong width");
+                this.assertEqualsWithTolerance(actualWidth, width, tolWidth, "Wrong width, expected %2, got %1");
             }
             if (height) {
                 var actualHeight = parseInt(overlay.style.height, 10);
-                this.assertTrue(Math.abs(actualHeight - height) <= tolHeight, "Wrong height");
+                this.assertEqualsWithTolerance(actualHeight, height, tolHeight, "Wrong height, expected %2, got %1");
             }
         },
 

--- a/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
+++ b/test/aria/utils/overlay/loadingIndicator/scrollableBody/ScrollableBodyTest.js
@@ -21,8 +21,12 @@ Aria.classDefinition({
 
         this.setTestEnv({
             template : "test.aria.utils.overlay.loadingIndicator.scrollableBody.TestTemplate",
-            iframe : true
+            iframe : true,
+            iframePageCss : "body {margin:0; padding:0;}"
         });
+
+        this.__scrollTop = 0;
+        this.__scrollLeft = 0;
     },
     $prototype : {
 
@@ -132,6 +136,9 @@ Aria.classDefinition({
         },
 
         _setScroll : function (scrollTop, scrollLeft) {
+            // save scroll values for reference in assertions
+            this.__scrollTop = scrollTop;
+            this.__scrollLeft = scrollLeft;
             this.testWindow.scrollTo(scrollLeft, scrollTop);
         },
 
@@ -142,6 +149,19 @@ Aria.classDefinition({
             if (display) {
                 var msg = "The overlay on " + element.tagName + " had display: %1 instead of %2";
                 this.assertEquals(overlay.style.display, display, msg);
+            }
+            // check overlay's positioning if it's visible
+            if (display != "none") {
+                var overlayTop = this.testWindow.aria.utils.Dom.getStylePx(overlay, "top");
+                var overlayLeft = this.testWindow.aria.utils.Dom.getStylePx(overlay, "left");
+
+                // leveraging facts that element's offsetParent is BODY
+                // and BODY has 0 margins / paddings due to iframePageCss
+                var expectedTop = Math.max(element.offsetTop, this.__scrollTop);
+                var expectedLeft = Math.max(element.offsetLeft, this.__scrollLeft);
+
+                this.assertEquals(overlayTop, expectedTop, "Overlay top position is %1, expected %2");
+                this.assertEquals(overlayLeft, expectedLeft, "Overlay left position is %1, expected %2");
             }
             if (width) {
                 var actualWidth = parseInt(overlay.style.width, 10);


### PR DESCRIPTION
Fixed a test failure introduced in the commit 2aa83bb279c1f10d11fca7ee46e52869b3c4ee67 (PR #1377) causing the loading overlay not to be displayed when page is scrolled too far and some other related issues.