### PR TITLE
Dialog widget: clicking on the close button interferes with drag/drop

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -26,7 +26,6 @@ var ariaWidgetsContainerDialogStyle = require("./DialogStyle.tpl.css");
 var ariaWidgetsContainerContainer = require("./Container");
 var ariaCoreTimer = require("../../core/Timer");
 
-
 /**
  * Dialog widget
  */
@@ -234,8 +233,12 @@ module.exports = Aria.classDefinition({
          */
         __writeTitlebarButton : function (out, delegateId, cssClassPostfix, skinIcon) {
             var cfg = this._cfg;
-            out.write(['<span class="x', this._skinnableClass, '_', cssClassPostfix, ' x', this._skinnableClass, '_',
-                    cfg.sclass, '_', cssClassPostfix, '" ', ariaUtilsDelegate.getMarkup(delegateId), '>'].join(''));
+            // Adding atdraggable="" to make sure clicking on the button does not start the drag operation
+            // Using the atdraggable attribute directly instead of the aria.utils.Mouse.DRAGGABLE_ATTRIBUTE
+            // variable because aria.utils.Mouse may not be loaded yet.
+            out.write(['<span atdraggable="" class="x', this._skinnableClass, '_', cssClassPostfix, ' x',
+                    this._skinnableClass, '_', cfg.sclass, '_', cssClassPostfix, '" ',
+                    ariaUtilsDelegate.getMarkup(delegateId), '>'].join(''));
             var button = new ariaWidgetsIcon({
                 icon : this._skinObj[skinIcon]
             }, this._context, this._lineNumber);

--- a/test/aria/widgets/container/dialog/DialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/DialogTestSuite.js
@@ -22,6 +22,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.dialog.maximizable.MaximizableDialogTest");
         this.addTests("test.aria.widgets.container.dialog.closeOutside.Issue389TestCase");
         this.addTests("test.aria.widgets.container.dialog.MovableDialogTestSuite");
+        this.addTests("test.aria.widgets.container.dialog.closeOrDrag.CloseOrDragTest");
 
         this.addTests("test.aria.widgets.container.dialog.resize.DialogResizeTestSuite");
         this.addTests("test.aria.widgets.container.dialog.closeOnClick.CloseDialogOnClickTestCase");

--- a/test/aria/widgets/container/dialog/closeOrDrag/CloseOrDragTest.js
+++ b/test/aria/widgets/container/dialog/closeOrDrag/CloseOrDragTest.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.closeOrDrag.CloseOrDragTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Json", "aria.utils.dragdrop.Drag", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {
+            dialogVisible : true
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.closeOrDrag.CloseOrDragTpl",
+            data : this.data
+        });
+    },
+    $prototype : {
+        _getCloseIcon : function (dialogId) {
+            var titleBar = this.getWidgetInstance("myDialog")._titleBarDomElt;
+            return this.getElementsByClassName(titleBar, "xDialog_close")[0] || null;
+        },
+
+        runTemplateTest : function () {
+            var self = this;
+            var step0 = function () {
+                var closeButton = self._getCloseIcon();
+                self.initialGeometry = aria.utils.Dom.getGeometry(closeButton);
+                self.assertNotNull(self.initialGeometry);
+                var destination = self.getElementById("myItem");
+                self.synEvent.drag({
+                    duration : 500,
+                    to : destination
+                }, closeButton, step1);
+            };
+
+            var step1 = function () {
+                var closeButton = self._getCloseIcon();
+                self.finalGeometry = aria.utils.Dom.getGeometry(closeButton);
+                self.assertNotNull(self.finalGeometry);
+                self.assertJsonEquals(self.initialGeometry, self.finalGeometry);
+                self.synEvent.click(closeButton, step2);
+            };
+
+            var step2 = function () {
+                self.assertNull(self._getCloseIcon());
+                self.assertFalse(self.data.dialogVisible);
+                self.end();
+            };
+
+            setTimeout(step0, 200);
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/closeOrDrag/CloseOrDragTpl.tpl
+++ b/test/aria/widgets/container/dialog/closeOrDrag/CloseOrDragTpl.tpl
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.closeOrDrag.CloseOrDragTpl"
+}}
+
+	{macro main ()}
+        <div {id "myItem"/}></div>
+        {@aria:Dialog {
+            id : "myDialog",
+            modal : true,
+            movable : true,
+            movableProxy: {
+                type : "CloneOverlay"
+            },
+            title: "This should not move",
+            macro : "dialogContent",
+            bind : {
+                visible : {
+                    to : "dialogVisible",
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+
+	{macro dialogContent()}
+
+		<br/>
+		<br/>
+		<div style="overflow:auto;width:300px;height:300px;" {id "myDiv"/}>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec mauris turpis, gravida et porta vel, auctor vel lectus. Quisque leo felis, malesuada et ornare id, tempus non neque. Donec turpis mauris, dignissim sit amet rutrum non, vehicula vitae est. Duis velit leo, condimentum in euismod nec, luctus eu sem. Sed pretium sagittis nisl sed posuere. Sed ut leo nibh, sit amet sollicitudin ligula. Aliquam non purus nisl. Nunc ut tellus nec diam convallis elementum sit amet a purus. Ut molestie, sem et vulputate facilisis, urna nulla ultricies metus, in aliquet turpis eros non nunc. Donec at turpis vel ante dapibus dignissim tincidunt quis eros. Integer eleifend congue tortor, tempor egestas eros mollis posuere. Phasellus sit amet lorem sed turpis aliquam dignissim a sit amet nisl. Cras malesuada gravida pretium. Vestibulum luctus vehicula gravida. Cras ut est sed leo posuere venenatis nec non mauris. Vestibulum in tellus dui. Vivamus suscipit tempus dolor a varius.
+
+			Mauris ac ultrices nisl. Fusce sollicitudin placerat accumsan. Ut eu ante velit. Duis blandit tortor quis tellus sollicitudin eu interdum enim lacinia. Pellentesque vel leo ipsum. Nulla eget lorem quis quam laoreet luctus. Nam ut purus ut enim venenatis cursus in viverra metus. Pellentesque sed lorem odio. Vestibulum et ipsum et ante ullamcorper luctus. Cras eleifend quam sit amet mi ullamcorper non lacinia arcu hendrerit. Nulla leo metus, eleifend vel egestas at, consectetur nec enim. Donec dui orci, rutrum ac rhoncus et, ultrices non est. Integer magna leo, viverra a egestas ut, placerat in lorem. Donec felis purus, interdum cursus consectetur vel, suscipit sit amet sapien. Duis tempus euismod purus eu rhoncus. Maecenas vestibulum velit metus, in blandit leo. Curabitur nisl nulla, aliquam id convallis vitae, aliquam sit amet justo. Nunc erat eros, venenatis eget egestas at, blandit sit amet dui. Quisque fringilla, risus ac varius dignissim, ante risus porta nisl, a volutpat erat sem ut lectus.
+
+			Maecenas hendrerit porta ligula nec sollicitudin. In bibendum sagittis dolor ac feugiat. Cras ligula tellus, interdum sed elementum congue, mollis eu libero. Sed nibh massa, rhoncus id iaculis non, auctor in neque. Ut sollicitudin convallis ultricies. Mauris tempor tincidunt pharetra. Aliquam auctor arcu ac lectus ultrices imperdiet. Maecenas tristique, nulla eget dignissim faucibus, orci risus tempus ipsum, et commodo diam erat id ligula. Sed hendrerit tortor sem, eu molestie odio. Sed viverra eros nec diam mollis consequat. Morbi ultricies rhoncus velit, vel elementum tellus fringilla sit amet. Integer fringilla semper ante, sit amet mollis libero varius nec. Quisque sit amet sem libero. Suspendisse sed magna diam, quis faucibus lacus. Phasellus dictum, neque quis tincidunt tincidunt, augue sem varius ipsum, in interdum purus metus id mauris.
+
+			Nunc vitae lectus augue. Fusce eu tellus consequat orci facilisis sagittis. Sed eu adipiscing nibh. Maecenas hendrerit rutrum gravida. Vivamus consectetur velit in mauris accumsan dictum. Donec hendrerit, est nec accumsan eleifend, elit ipsum fermentum sem, et semper nulla purus sed nulla. Nunc sollicitudin pharetra massa. Praesent quis pulvinar purus. In imperdiet lectus nec ipsum gravida dapibus. Donec cursus laoreet ullamcorper.
+		</div>
+
+	{/macro}
+
+{/Template}


### PR DESCRIPTION
This PR fixes the following issue: on some browsers, clicking on the close button of the dialog is randomly interpreted as the beginning of a drag/drop operation, preventing the dialog from being closed.