### PR TITLE
Data not passed to template from placeholder page engine configuration

### DIFF
--- a/src/aria/pageEngine/PageEngine.js
+++ b/src/aria/pageEngine/PageEngine.js
@@ -802,6 +802,9 @@ module.exports = Aria.classDefinition({
                 templateCfg.moduleCtrl = module;
                 this._modulesInPage.push(module);
             }
+            if (item.data) {
+                templateCfg.data = item.data;
+            }
             return templateCfg;
         },
 

--- a/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
+++ b/test/aria/pageEngine/pageEngine/PageEngineTemplateTestSuite.js
@@ -37,5 +37,6 @@ Aria.classDefinition({
         this.addTests("test.aria.pageEngine.pageEngine.externalHashNavigation.ExternalHashNavigationTest");
         this.addTests("test.aria.pageEngine.pageEngine.pageEngineDisposal.DisposalTest");
         this.addTests("test.aria.pageEngine.pageEngine.customPageConfig.CustomPageConfigTest");
+        this.addTests("test.aria.pageEngine.pageEngine.placeholderTemplateData.PlaceholderTemplateDataTestCase");
     }
 });

--- a/test/aria/pageEngine/pageEngine/placeholderTemplateData/MyPageProvider.js
+++ b/test/aria/pageEngine/pageEngine/placeholderTemplateData/MyPageProvider.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.placeholderTemplateData.MyPageProvider",
+    $implements : ["aria.pageEngine.pageProviders.PageProviderInterface"],
+    $prototype : {
+
+        /**
+         * @override
+         */
+        loadSiteConfig : function (callback) {
+            var siteConfig = {
+                appData : {},
+                containerId : "at-main"
+            };
+
+            this.$callback(callback.onsuccess, siteConfig);
+        },
+
+        /**
+         * @override
+         */
+        loadPageDefinition : function (pageRequest, callback) {
+            this.$callback(callback.onsuccess, {
+                pageId : "aaa",
+                url : "/pageEngine/aaa",
+                pageComposition : {
+                    template : "test.aria.pageEngine.pageEngine.site.templates.MainLayout",
+                    placeholders : {
+                        body : {
+                            template : "test.aria.pageEngine.pageEngine.placeholderTemplateData.MyTemplate",
+                            data : {
+                                message : "This is the message to be displayed on the page !!"
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+});

--- a/test/aria/pageEngine/pageEngine/placeholderTemplateData/MyTemplate.tpl
+++ b/test/aria/pageEngine/pageEngine/placeholderTemplateData/MyTemplate.tpl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+{Template {
+  $classpath : "test.aria.pageEngine.pageEngine.placeholderTemplateData.MyTemplate"
+}}
+
+{macro main ()}
+     <div id="divToCheck">${data.message}</div>
+{/macro}
+
+
+{/Template}

--- a/test/aria/pageEngine/pageEngine/placeholderTemplateData/PlaceholderTemplateDataTestCase.js
+++ b/test/aria/pageEngine/pageEngine/placeholderTemplateData/PlaceholderTemplateDataTestCase.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.pageEngine.pageEngine.placeholderTemplateData.PlaceholderTemplateDataTestCase",
+    $extends : "test.aria.pageEngine.pageEngine.PageEngineBaseTestCase",
+    $constructor : function () {
+        this.$PageEngineBaseTestCase.constructor.call(this);
+        this._dependencies.push("test.aria.pageEngine.pageEngine.placeholderTemplateData.MyPageProvider");
+    },
+    $prototype : {
+        /**
+         * @override
+         */
+        runTestInIframe : function () {
+            this.pageProvider = new this._testWindow.test.aria.pageEngine.pageEngine.placeholderTemplateData.MyPageProvider();
+            this.pageEngine = new this._testWindow.aria.pageEngine.PageEngine();
+
+            this.pageEngine.start({
+                pageProvider : this.pageProvider,
+                oncomplete : {
+                    fn : this._onPageEngineStart,
+                    scope : this
+                }
+            });
+        },
+
+        _onPageEngineStart : function () {
+            var divToCheck = this._testWindow.document.getElementById("divToCheck");
+            this.assertEquals(divToCheck.innerHTML, "This is the message to be displayed on the page !!");
+            this.end();
+        },
+
+        /**
+         * @override
+         */
+        end : function () {
+            this.pageEngine.$dispose();
+            this.pageProvider.$dispose();
+            this.$PageEngineBaseTestCase.end.call(this);
+        }
+    }
+});


### PR DESCRIPTION
The `data` property, specified in [aria.pageEngine.CfgBeans.Placeholder](http://www.ariatemplates.com/aria/guide/apps/apidocs/#aria.pageEngine.CfgBeans:Placeholder), was not taken into account by the page engine. This pull request fixes the issue, the `data` property is now properly passed to the template.