### PR TITLE
Removing isWindowsPhone in aria.utils.Dom.getViewportSize

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -515,7 +515,7 @@ module.exports = Aria.classDefinition({
          * @private
          */
         _getViewportSize : function () {
-            if (ariaCoreBrowser.isIOS || ariaCoreBrowser.isAndroid || ariaCoreBrowser.isWindowsPhone) {
+            if (ariaCoreBrowser.isIOS || ariaCoreBrowser.isAndroid) {
                 // Initially (without user-initiated zoom) window's dimensions are the same or nearly the same as
                 // documentElement's.
                 // Note however that documentElement's clientWidth/Height is unaffected by user zoom while window's


### PR DESCRIPTION
This fixes a regression on IE 7 and 8 introduced by commit 84ffd08ec7f10a8dcaeb6bad6a8375ae95ad60e4 because aria.core.Browser.isWindowsPhone is not correctly implemented (to be fixed later).