### PR TITLE
fix AdaptToContentWidthTest on Safari

### DIFF
--- a/src/aria/utils/Size.js
+++ b/src/aria/utils/Size.js
@@ -15,6 +15,7 @@
 var Aria = require("../Aria");
 var ariaUtilsMath = require("./Math");
 var ariaUtilsType = require("./Type");
+var ariaTemplatesLayout = require("../templates/Layout");
 
 /**
  * Handles sizes measurements and application for DOM elements
@@ -129,7 +130,7 @@ module.exports = Aria.classDefinition({
                     changedHeight = true;
                     changedOverflowY = (newValue < measured);
                     if (changedOverflowY) {
-                        var additionalWidth = aria.templates.Layout.getScrollbarsWidth() + 1;
+                        var additionalWidth = ariaTemplatesLayout.getScrollbarsMeasuredWidth() + 1;
                         // recalculate the width
                         var newWidth = ariaUtilsMath.normalize(element.offsetWidth + additionalWidth, widthConf.min, widthConf.max);
 

--- a/test/aria/widgets/container/dialog/resize/test1/DialogOnResizeTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test1/DialogOnResizeTestCase.js
@@ -64,7 +64,7 @@ Aria.classDefinition({
 
         _checkResize : function () {
             // Only for this case, the scrollbar is taken into account because the maximum width is not reached
-            var scrollbarSize = aria.templates.Layout.getScrollbarsWidth() + 1;
+            var scrollbarSize = aria.templates.Layout.getScrollbarsMeasuredWidth() + 1;
             // Check position
             this._checkOffsets(this.divDialog, {
                 offsetTop : 0,


### PR DESCRIPTION
This commit fixes test.aria.widgets.form.autocomplete.popupWidth.AdaptToContentWidthTest on Safari.