### PR TITLE
fix SplitterTestMoveLeftRight and SplitterTestMoveUpDown

### DIFF
--- a/test/aria/widgets/container/splitter/move/SplitterTestMoveLeftRight.js
+++ b/test/aria/widgets/container/splitter/move/SplitterTestMoveLeftRight.js
@@ -93,7 +93,7 @@ Aria.classDefinition({
             var elem = this.splitter._draggable.element;
             var geometry = dom.getGeometry(elem);
             var from = {
-                x : geometry.x,
+                x : geometry.x + geometry.width / 2,
                 y : geometry.y + 100
             };
             var options = {

--- a/test/aria/widgets/container/splitter/move/SplitterTestMoveUpDown.js
+++ b/test/aria/widgets/container/splitter/move/SplitterTestMoveUpDown.js
@@ -90,7 +90,7 @@ Aria.classDefinition({
             var geometry = dom.getGeometry(elem);
             var from = {
                 x : geometry.x + 100,
-                y : geometry.y
+                y : geometry.y + geometry.height / 2
             };
             var options = {
                 duration : 500,


### PR DESCRIPTION
When SplitterTestMoveLeftRight and SplitterTestMoveUpDown are run in attester, probably because of the added iframe, the actual splitter seems to be a few pixels on the right or on the bottom of the mouse position, resulting in a test failure. With this commit, instead of starting the drag operation at the edge of the handle, the mouse is now centered on the handle which makes those tests more reliable.