### PR TITLE
Allowing the robot not to be available immediately (waits for 2s)

### DIFF
--- a/src/aria/jsunit/$RobotSelection.js
+++ b/src/aria/jsunit/$RobotSelection.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Promise = require("noder-js/promise");
+var Aria = require("../Aria");
+var computedRobotClasspath = null;
+
+var waitTimeLimit = new Date().getTime() + 2000; // waits max 2s
+
+var computeRobotClasspath = function () {
+    if (Aria.$frameworkWindow.top.phantomJSRobot) {
+        return "aria.jsunit.RobotPhantomJS";
+    }
+    if (Aria.$frameworkWindow.top.SeleniumJavaRobot) {
+        return "aria.jsunit.RobotJavaSelenium";
+    }
+    return null;
+};
+
+var initialization = new Promise(function (resolve) {
+    var check = function () {
+        computedRobotClasspath = computeRobotClasspath();
+        if (computedRobotClasspath || new Date().getTime() > waitTimeLimit) {
+            resolve();
+        } else {
+            setTimeout(check, 100);
+        }
+    };
+    check();
+});
+
+var getRobotClasspath = exports.getRobotClasspath = function () {
+    return computedRobotClasspath;
+};
+
+getRobotClasspath.$preload = function () {
+    return initialization;
+};

--- a/src/aria/jsunit/Robot.js
+++ b/src/aria/jsunit/Robot.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 var Aria = require("../Aria");
+var robotClasspath = require("./$RobotSelection").getRobotClasspath();
 
 /**
  * This class is still experimental, its interface may change without notice. This class gives access to a robot
@@ -43,13 +44,7 @@ module.exports = Aria.classDefinition({
          * @return {String}
          */
         getRobotClasspath : function () {
-            if (Aria.$frameworkWindow.top.phantomJSRobot) {
-                return "aria.jsunit.RobotPhantomJS";
-            }
-            if (Aria.$frameworkWindow.top.SeleniumJavaRobot) {
-                return "aria.jsunit.RobotJavaSelenium";
-            }
-            return null;
+            return robotClasspath;
         },
 
         /**
@@ -68,7 +63,6 @@ module.exports = Aria.classDefinition({
             if (this.robot) {
                 this.robot.initRobot(cb);
             } else {
-                var robotClasspath = this.getRobotClasspath();
                 if (!robotClasspath) {
                     this.$logError(this.ROBOT_UNAVAILABLE);
                     return;
@@ -79,7 +73,6 @@ module.exports = Aria.classDefinition({
                         fn : this._robotLoaded,
                         scope : this,
                         args : {
-                            robotClasspath : robotClasspath,
                             cb : cb
                         }
                     }
@@ -93,7 +86,7 @@ module.exports = Aria.classDefinition({
          */
         _robotLoaded : function (args) {
             if (!this.robot) {
-                this.robot = Aria.getClassRef(args.robotClasspath).$interface("aria.jsunit.IRobot");
+                this.robot = Aria.getClassRef(robotClasspath).$interface("aria.jsunit.IRobot");
             }
             this.robot.initRobot(args.cb);
         }


### PR DESCRIPTION
Sometimes, if the first test to be executed by a browser is a robot test, it can fail with the error "The robot is not available." even if the browser was started with `selenium-java-robot` because `selenium-java-robot` has not yet injected the `SeleniumJavaRobot` object in the page. This PR makes sure we wait up to 2s before raising the error that the robot is not available.