### PR TITLE
fix #1411 load extrascripts in Classic Test Runner

### DIFF
--- a/src/aria/jsunit/TestWrapper.js
+++ b/src/aria/jsunit/TestWrapper.js
@@ -41,7 +41,7 @@ module.exports = Aria.classDefinition({
             this._startTest();
             var document = Aria.$window.document;
             this._frame = document.createElement("iframe");
-            this._frame.style.cssText = "z-index:100000;position:absolute;left:0px;top:0px;width:1024px;height:768px;border:1px solid black;visibility:hidden;display:block;background-color:white;";
+            this._frame.style.cssText = "opacity:0.6;filter:alpha(opacity=60);zoom:1;z-index:100000;position:absolute;left:0px;top:0px;width:1024px;height:768px;border:1px solid black;visibility:hidden;display:block;background-color:white;";
             document.body.appendChild(this._frame);
             this._subWindow = this._frame.contentWindow;
             ariaUtilsFrameATLoader.loadAriaTemplatesInFrame(this._frame, {

--- a/src/aria/jsunit/TestWrapper.js
+++ b/src/aria/jsunit/TestWrapper.js
@@ -91,8 +91,7 @@ module.exports = Aria.classDefinition({
                 this.$callback(callback);
             } else {
                 ariaUtilsScriptLoader.load(scriptsToLoad, callback, {
-                    document: subDocument,
-                    force: true
+                    document: subDocument
                 });
             }
         },

--- a/src/aria/jsunit/TestWrapper.js
+++ b/src/aria/jsunit/TestWrapper.js
@@ -72,7 +72,7 @@ module.exports = Aria.classDefinition({
         _injectExtraScriptsIntoFrame : function (subWindow, whereToInsert, callback) {
             var document = Aria.$window.document;
             var subDocument = subWindow.document;
-            var scripts = document.querySelectorAll('script') || document.scripts;
+            var scripts = document.scripts || document.getElementsByTagName('script');
 
             var scriptsToLoad = [];
             for (var i = 0; i < scripts.length; i++) {

--- a/src/aria/tester/runner/view/normal/Normal.tpl
+++ b/src/aria/tester/runner/view/normal/Normal.tpl
@@ -39,6 +39,10 @@
         </div>
         <div class="nameHeader" style="width: ${$hdim(180)}px;">
             Classic Test Runner
+            <small title="In isolated mode, each test is run in an IFRAME sandbox; otherwise they're run in a DIV"
+                style="font-size:10pt; cursor: help;">
+              isolated mode is ${data.campaign.runIsolated ? "ON" : "off"}
+            </small>
         </div>
         <div class="monitor" style="
             height : ${$vdim(282)}px;

--- a/src/aria/utils/ScriptLoader.js
+++ b/src/aria/utils/ScriptLoader.js
@@ -40,15 +40,22 @@ module.exports = Aria.classDefinition({
          * Load the scripts then call a callback function
          * @param {Array} scripts - An array of scripts to load
          * @param {Function} callback - A function to call once the whole set of scripts are loaded
+         * @param {Object} options - (optional) { document: Document, force: Boolean }
+         * `document` options specifies document into which the scripts should be injected.
+         * `force` (defaults to false) defines whether it should be checked if the script was loaded already
          */
-        load : function (scripts, callback) {
-            var i, ii, url, scriptNode, scriptCount, loadedScripts = this._loadedScripts,
+        load : function (scripts, callback, options) {
+            var i, ii, url, scriptNode, scriptCount;
 
-            queueIndex = this._queueIndex, document = Aria.$frameworkWindow.document,
+            var options = options || {};
+            var force = options.force || false;
+            var document = options.document || Aria.$frameworkWindow.document;
 
-            head = document.getElementsByTagName('head')[0], that = this,
-
-            onReadyStateChangeCallback = function (queueId, scriptNode) {
+            var loadedScripts = this._loadedScripts;
+            var queueIndex = this._queueIndex;
+            var head = document.getElementsByTagName('head')[0];
+            var that = this;
+            var onReadyStateChangeCallback = function (queueId, scriptNode) {
                 var key = "" + queueId;
                 that._queueCount[key]--;
                 if (that._queueCount[key] === 0) {
@@ -64,7 +71,7 @@ module.exports = Aria.classDefinition({
             scriptCount = 0;
             for (i = 0, ii = scripts.length; i < ii; i++) {
                 url = scripts[i];
-                if (!loadedScripts[url]) {
+                if (force || !loadedScripts[url]) {
                     scriptCount++;
                     loadedScripts[url] = true;
                     scriptNode = document.createElement('script');

--- a/src/aria/utils/ScriptLoader.js
+++ b/src/aria/utils/ScriptLoader.js
@@ -28,6 +28,10 @@ module.exports = Aria.classDefinition({
     $constructor : function () {
         this._queueIndex = 0;
         this._queueCount = {};
+        /**
+         * Array of scripts that were already loaded *in the main document*
+         * (`Aria.$frameworkWindow.document`).
+         */
         this._loadedScripts = [];
     },
     $destructor : function () {
@@ -42,14 +46,15 @@ module.exports = Aria.classDefinition({
          * @param {Function} callback - A function to call once the whole set of scripts are loaded
          * @param {Object} options - (optional) { document: Document, force: Boolean }
          * `document` options specifies document into which the scripts should be injected.
-         * `force` (defaults to false) defines whether it should be checked if the script was loaded already
+         * If the document is different than `Aria.$frameworkWindow.document` then the script
+         * won't be added to `_loadedScripts` array.
          */
         load : function (scripts, callback, options) {
             var i, ii, url, scriptNode, scriptCount;
 
             var options = options || {};
-            var force = options.force || false;
             var document = options.document || Aria.$frameworkWindow.document;
+            var isTargetMainDocument = (document === Aria.$frameworkWindow.document);
 
             var loadedScripts = this._loadedScripts;
             var queueIndex = this._queueIndex;
@@ -71,9 +76,11 @@ module.exports = Aria.classDefinition({
             scriptCount = 0;
             for (i = 0, ii = scripts.length; i < ii; i++) {
                 url = scripts[i];
-                if (force || !loadedScripts[url]) {
+                if (!loadedScripts[url] || !isTargetMainDocument) {
                     scriptCount++;
-                    loadedScripts[url] = true;
+                    if (isTargetMainDocument) {
+                        loadedScripts[url] = true;
+                    }
                     scriptNode = document.createElement('script');
                     scriptNode.setAttribute("type", "text/javascript");
                     if (callback) {


### PR DESCRIPTION
This PR adds the possibility to load in the Classic Test Runner
the extrascripts exposed in attester's config, when CTR is run
in isolated mode.

Previously, the extrascripts were injected by attester only to CTR's
index page, but CTR had no possibility to propagate those scripts
into the iframe when tests were run with `#runIsolated=true` in the URL.

This commit needs https://github.com/attester/attester/pull/121
integrated in attester in order for it to properly expose `before`
and `after` extrascripts.

---

The other 2 commits are just minor visual improvements