### PR TITLE
Package Aria Templates with the ATFillCache builder

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
             sourceDirectories : packagingSettings.prod.sourceDirectories,
             sourceFiles : ['**/*', '!aria/node.js', '!' + packagingSettings.bootstrap.bootstrapFileName],
             defaultBuilder : {
-                type : 'ATMultipart',
+                type : 'ATFillCache',
                 cfg : {
                     header : packagingSettings.licenseMin
                 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "at-noder-converter": "1.0.1",
-    "atpackager": "0.2.6",
+    "atpackager": "0.2.7",
     "gzip-js": "0.3.2",
     "noder-js": "1.6.1"
   },

--- a/src/aria/core/DownloadMgr.js
+++ b/src/aria/core/DownloadMgr.js
@@ -87,6 +87,12 @@ module.exports = Aria.classDefinition({
          * @type Number
          */
         this._syncLoadCounter = 0;
+
+        /**
+         * If lastLoadedFiles is an object (not null), aria.core.DownloadMgr.loadFileContent adds an entry to this
+         * object for each call. The key in the object is the logical path and the value is 1.
+         */
+        this.lastLoadedFiles = null;
     },
     $destructor : function () {
         this._cache = null;
@@ -414,7 +420,6 @@ module.exports = Aria.classDefinition({
             }
             // dispose
             loader.$dispose();
-            loader = cache = itm = lps = null;
         },
 
         /**
@@ -430,7 +435,9 @@ module.exports = Aria.classDefinition({
                 itm.value = content;
                 itm.status = this._cache.STATUS_AVAILABLE;
             }
-            itm = null;
+            if (this.lastLoadedFiles) {
+                this.lastLoadedFiles[logicalPath] = 1;
+            }
         },
 
         /**

--- a/tasks/easypackage/configuration.js
+++ b/tasks/easypackage/configuration.js
@@ -35,7 +35,7 @@ module.exports = function (grunt, args) {
         sourceDirectories : args.sourceDirectories,
         sourceFiles : args.sourceFiles.concat(['!' + packagingSettings.bootstrap.bootstrapFileName]),
         defaultBuilder : {
-            type : 'ATMultipart',
+            type : 'ATFillCache',
             cfg : {
                 header : args.license
             }

--- a/test/aria/core/DownloadMgrMock.js
+++ b/test/aria/core/DownloadMgrMock.js
@@ -36,6 +36,9 @@ Aria.classDefinition({
             if (content) {
                 content = content.replace(/\r\n|\r/g, '\n');
             }
+            if (this.lastLoadedFiles) {
+                this.lastLoadedFiles[logicalPath] = 1;
+            }
             this.$raiseEvent({
                 name : 'loadFileContent',
                 logicalPath : logicalPath,

--- a/test/node/gruntTasks.js
+++ b/test/node/gruntTasks.js
@@ -73,7 +73,7 @@ describe("easypackage grunt task", function () {
 
             var packageContent = fs.readFileSync(testProjectPath + "target/one/" + packageName, 'utf8');
             assert.ok(/abcdefg/.test(packageContent), "License has not been added");
-            assert.ok(/require\("ariatemplates\/Aria"\)/.test(packageContent), "Conversion to noderJS syntax missing");
+            assert.ok(/require\(\\"ariatemplates\/Aria\\"\)/.test(packageContent), "Conversion to noderJS syntax missing");
             assert.ok(!/\{Template/.test(packageContent), "Template compilation missing");
             callback();
         });
@@ -83,7 +83,7 @@ describe("easypackage grunt task", function () {
 
             // Retrieving this file without error implictly checks that the hash:false has been taken into account
             var packageContent = fs.readFileSync(testProjectPath + "target/two/plugins.js", 'utf8');
-            assert.ok(!/require\("ariatemplates\/Aria"\)/.test(packageContent), "Conversion to noderJS syntax has been done");
+            assert.ok(!/require\(\\"ariatemplates\/Aria\\"\)/.test(packageContent), "Conversion to noderJS syntax has been done");
             assert.ok(/\{Template/.test(packageContent), "Template compilation has been done");
             assert.ok(!/Apache\sLicense/.test(packageContent), "stripBanner option didn't work");
 


### PR DESCRIPTION
This pull request changes the format in which Aria Templates is packaged. Instead of using the previous ATMultipart format (which does not allow packages to be evaluated in a script tag), it is now using the ATFillCache format (cf [this commit in atpackager](https://github.com/ariatemplates/atpackager/commit/9fe83ae8fb9cc0630cc4dee3617139bccb8f5b4c)) which fills the cache when packages are directly evaluated in a script tag.