### PR TITLE
Failing TemplateManagerTest and SectionAsContainerTest on IE 7

### DIFF
--- a/test/aria/templates/TemplateManagerTest.js
+++ b/test/aria/templates/TemplateManagerTest.js
@@ -114,7 +114,7 @@ Aria.classDefinition({
                 if (errorObj.logDetails) {
                     errorObj.logDetails();
                 }
-                var error = errorObj + "";
+                var error = (errorObj.message || errorObj.description || errorObj) + "";
                 this.assertTrue(error.indexOf("line 23: Template parsing error: could not find corresponding '}'") > -1, "Missing details about the error.");
 
                 // ok, this time redirect to the good template

--- a/test/aria/templates/section/asContainer/SectionAsContainerTest.js
+++ b/test/aria/templates/section/asContainer/SectionAsContainerTest.js
@@ -30,7 +30,7 @@ Aria.classDefinition({
             if (errorObj.logDetails) {
                 errorObj.logDetails();
             }
-            var error = errorObj + "";
+            var error = (errorObj.message || errorObj.description || errorObj) + "";
             var expectedError = aria.templates.ClassGenerator.UNEXPECTED_CONTAINER.replace("%1", "section").replace("%2", "21");
             this.assertTrue(error.indexOf(expectedError) > -1, "Expected some details about the error ("
                     + expectedError + "), found: " + error);


### PR DESCRIPTION
This PR fixes a regression introduced in commit f9a167054598fdab57137f9a06cec83d36b6477b for TemplateManagerTest and SectionAsContainerTest on IE 7.

On IE 7, the toString method of an error object returns no information about the error (only the string "[object Error]"). It is necessary to use the description property instead.

This PR depends on the following pull request on noder-js: https://github.com/ariatemplates/noder-js/pull/30
