### PR TITLE
Allow CSSMgr to reuse existing tags

### DIFF
--- a/src/aria/templates/CSSMgr.js
+++ b/src/aria/templates/CSSMgr.js
@@ -18,6 +18,7 @@ var ariaUtilsArray = require("../utils/Array");
 var ariaUtilsObject = require("../utils/Object");
 var ariaUtilsAriaWindow = require("../utils/AriaWindow");
 var ariaCoreClassMgr = require("../core/ClassMgr");
+var ariaUtilsDom = require("../utils/Dom");
 
 /**
  * CSS Manager manages the insertion of CSS Template output in the page. It is responsible for prefixing the CSS
@@ -651,25 +652,30 @@ module.exports = Aria.classDefinition({
          * @private
          */
         __buildStyleIfMissing : function (tagName) {
-            // A pointer to the style might be already there
+
+            // A pointer to the style might be already there or an element with the correct id might be there
             var tag = this.__styleTagPool[tagName];
 
             if (!tag) {
-                // If missing, create one
-                var document = Aria.$window.document;
-                var head = document.getElementsByTagName("head")[0];
-                tag = document.createElement("style");
+                var id = this.__TAG_PREFX + tagName;
+                tag = ariaUtilsDom.getElementById(id);
 
-                tag.id = this.__TAG_PREFX + tagName;
-                tag.type = "text/css";
-                tag.media = "all"; // needed as the default media is screen in FF but all in IE
+                if (!tag) {
+                    // If missing, create one
+                    var document = Aria.$window.document;
+                    var head = document.getElementsByTagName("head")[0];
+                    tag = document.createElement("style");
 
-                head.appendChild(tag);
-                tag = head.lastChild;
+                    tag.id = id;
+                    tag.type = "text/css";
+                    tag.media = "all"; // needed as the default media is screen in FF but all in IE
+
+                    head.appendChild(tag);
+                    tag = head.lastChild;
+                }
 
                 this.__styleTagPool[tagName] = tag;
             }
-
             return tag;
         },
 

--- a/test/aria/templates/css/CSSTestSuite.js
+++ b/test/aria/templates/css/CSSTestSuite.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.css.cssFolderPath.CSSFolderPathTestCase");
         this.addTests("test.aria.templates.css.cssMgr.CSSMgrTestCase");
         this.addTests("test.aria.templates.css.cssMgr.issue722.CSSMgrIssue722TestCase");
+        this.addTests("test.aria.templates.css.cssMgr.tagReuse.TagReuseTestCase");
         this.addTests("test.aria.templates.css.ctxtMgr.CtxtMgrTestCase");
         this.addTests("test.aria.templates.css.cssScripts.CSSScriptTestCase");
         this.addTests("test.aria.templates.css.dataReadyRefresh.RefreshTest");

--- a/test/aria/templates/css/cssMgr/tagReuse/TagReuseTestCase.js
+++ b/test/aria/templates/css/cssMgr/tagReuse/TagReuseTestCase.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.css.cssMgr.tagReuse.TagReuseTestCase",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.templates.CSSMgr", "aria.utils.Dom"],
+    $css : ["test.aria.templates.css.cssMgr.tagReuse.TestCss"],
+    $constructor : function () {
+        this.$TestCase.constructor.call(this);
+    },
+    $prototype : {
+        testCSSMgrReusesExistingTags : function () {
+            this.__addTag();
+            var head = this.__getHead();
+            this._count = head.children.length;
+
+            aria.templates.CSSMgr.loadClassPathDependencies(this.$classpath, this.$css);
+            this.assertEquals(this.__getHead().children.length, this._count, "A tag with has been created instead of using the one with the same id");
+
+            aria.templates.CSSMgr.unloadClassPathDependencies(this.$classpath, this.$css);
+        },
+
+        __addTag : function () {
+            var cssMgr = aria.templates.CSSMgr;
+
+            var document = Aria.$window.document;
+            var head = this.__getHead();
+            var tag = document.createElement("style");
+
+            this._id = tag.id = cssMgr.__TAG_PREFX + "pool" + cssMgr.__NEXT_TAG_INDEX;
+
+            head.appendChild(tag);
+            this._tag = head.lastChild;
+        },
+
+        __getHead : function () {
+            return Aria.$window.document.getElementsByTagName("head")[0];
+        }
+
+    }
+});

--- a/test/aria/templates/css/cssMgr/tagReuse/TestCss.tpl.css
+++ b/test/aria/templates/css/cssMgr/tagReuse/TestCss.tpl.css
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath: "test.aria.templates.css.cssMgr.tagReuse.TestCss"
+}}
+
+  {macro main()}
+
+    div.cl {
+    	background: red;
+    }
+  {/macro}
+
+{/CSSTemplate}


### PR DESCRIPTION
It is important for an application to decide the order
in which widgets and templates-related css rules
(coming from CSS templates) are inserted in the head tag.

In order to do that, the application can insert tags with the correct id. This commit allows to use existing tags for the css insertion.