### PR TITLE
Configuration beans link in documentation

### DIFF
--- a/src/aria/resources/handlers/LCRangeResourceHandler.js
+++ b/src/aria/resources/handlers/LCRangeResourceHandler.js
@@ -63,7 +63,7 @@ var ariaUtilsType = require("../../utils/Type");
              * Call the callback with an array of suggestions in its arguments. Suggestions that are exact match are
              * marked with parameter exactMatch set to true.
              * @param {String} textEntry Search string
-             * @param {aria.core.CfgBeans.Callback} callback Called when suggestions are ready
+             * @param {aria.core.CfgBeans:Callback} callback Called when suggestions are ready
              */
             getSuggestions : function (textEntry, callback) {
                 if (!typesUtil.isString(textEntry) || textEntry.length < this.threshold) {
@@ -112,7 +112,7 @@ var ariaUtilsType = require("../../utils/Type");
             /**
              * Internal method to call LCResourcesHandler
              * @param {String} textEntry Search string
-             * @param {aria.core.CfgBeans.Callback} callback Called when suggestions are ready
+             * @param {aria.core.CfgBeans:Callback} callback Called when suggestions are ready
              * @private
              */
             __getSuggestion : function (textEntry, callback) {

--- a/src/aria/touch/widgets/Popup.js
+++ b/src/aria/touch/widgets/Popup.js
@@ -36,7 +36,7 @@ module.exports = Aria.classDefinition({
     },
     /**
      * Popup Constructor.
-     * @param {aria.touch.widgets.PopupCfgBeans.PopupCfg} cfg popup configuration
+     * @param {aria.touch.widgets.PopupCfgBeans:PopupCfg} cfg popup configuration
      * @param {aria.templates.TemplateCtxt} context template context
      * @param {Number} lineNumber line number in the template
      */

--- a/src/aria/widgets/calendar/CalendarController.js
+++ b/src/aria/widgets/calendar/CalendarController.js
@@ -23,8 +23,8 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
 
 /**
  * Function to sort ranges by fromDate.
- * @param {aria.widgets.calendar.CfgBeans.Range} a
- * @param {aria.widgets.calendar.CfgBeans.Range} b
+ * @param {aria.widgets.calendar.CfgBeans:Range} a
+ * @param {aria.widgets.calendar.CfgBeans:Range} b
  * @return {Number} Returns -1 if a.fromDate < b.fromDate, 0 if a.fromDate == b.fromDate, and 1 if a.fromDate >
  * b.fromDate
  */

--- a/src/aria/widgets/calendar/ICalendarController.js
+++ b/src/aria/widgets/calendar/ICalendarController.js
@@ -121,7 +121,7 @@ module.exports = Aria.interfaceDefinition({
         /**
          * Return information about the position of the given JavaScript date in the calendar data model.
          * @param {Date} JavaScript date
-         * @return {aria.widgets.calendar.CfgBeans.DatePosition} position of the date in the calendar data model, or
+         * @return {aria.widgets.calendar.CfgBeans:DatePosition} position of the date in the calendar data model, or
          * null if the date cannot be found in the current calendar data model.
          */
         getDatePosition : function (jsDate) {},

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -33,7 +33,7 @@ module.exports = Aria.classDefinition({
     $css : [ariaWidgetsFormTextInputStyle],
     /**
      * TextInput constructor
-     * @param {aria.widgets.CfgBeans.TextInputCfg} cfg the widget configuration
+     * @param {aria.widgets.CfgBeans:TextInputCfg} cfg the widget configuration
      * @param {aria.templates.TemplateCtxt} ctxt template context
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      * @param {aria.widgets.controller.TextDataController} controller the data controller object

--- a/src/aria/widgets/form/Textarea.js
+++ b/src/aria/widgets/form/Textarea.js
@@ -31,7 +31,7 @@ module.exports = Aria.classDefinition({
     },
     /**
      * Textarea constructor
-     * @param {aria.widgets.CfgBeans.TextareaCfg} cfg the widget configuration
+     * @param {aria.widgets.CfgBeans:TextareaCfg} cfg the widget configuration
      * @param {aria.templates.TemplateCtxt} ctxt template context
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */

--- a/src/aria/widgets/form/TimeField.js
+++ b/src/aria/widgets/form/TimeField.js
@@ -26,7 +26,7 @@ module.exports = Aria.classDefinition({
     $extends : ariaWidgetsFormTextInput,
     /**
      * TimeField constructor
-     * @param{aria.widgets.CfgBeans.TimeFieldCfg} cfg the widget configuration
+     * @param{aria.widgets.CfgBeans:TimeFieldCfg} cfg the widget configuration
      * @param{aria.templates.TemplateCtxt} ctxt template context
      * @param {Number} lineNumber Line number corresponding in the .tpl file where the widget is created
      */

--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -310,7 +310,7 @@ module.exports = Aria.classDefinition({
 
         /**
          * Set the items property.
-         * @param {aria.widgets.form.list.CfgBeans.ItemsArray} newItems array of items
+         * @param {aria.widgets.form.list.CfgBeans:ItemsArray} newItems array of items
          * @protected
          */
         _setItems : function (newItems) {
@@ -474,7 +474,7 @@ module.exports = Aria.classDefinition({
 
         /**
          * Set the items property.
-         * @param {aria.widgets.form.list.CfgBeans.Items} newItems
+         * @param {aria.widgets.form.list.CfgBeans:Items} newItems
          */
         setItems : function (newItems) {
             var res = this._mergeItemsAndSelectionInfo(newItems, this.getSelectedValues());

--- a/src/aria/widgets/form/list/templates/ListTemplateScript.js
+++ b/src/aria/widgets/form/list/templates/ListTemplateScript.js
@@ -63,7 +63,7 @@ module.exports = Aria.tplScriptDefinition({
         /**
          * Called after a refresh. This method adds a timer callback to change scrollbar position for the selected item
          * to be displayed (if there is only one item selected).
-         * @param {aria.templates.CfgBeans.RefreshCfg} args arguments given for the refresh
+         * @param {aria.templates.CfgBeans:RefreshCfg} args arguments given for the refresh
          */
         $afterRefresh : function (args) {
             var sectionId = args ? args.section : null;


### PR DESCRIPTION
Few configuration beans were incorrectly referred to by the API documentation (using a dot instead of a colon). Fixed for beans called CfgBeans.