### PR TITLE
feat Customization of widget's error messages

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -538,8 +538,33 @@ module.exports = Aria.beanDefinitions({
                     $properties : {
                         "referenceDate" : {
                             $type : "common:BindingRef"
+                        },
+                        "defaultErrorMessages" : {
+                            $type : "common:BindingRef"
                         }
                     }
+                },
+                "defaultErrorMessages" : {
+                    $type : "json:Object",
+                    $description : "Default values for error messages.",
+                    $properties : {
+                        "validation" : {
+                            $type : "json:String",
+                            $description : "Default message for validation error.",
+                            $default : null
+                        },
+                        "minValue": {
+                            $type : "json:String",
+                            $description : "Default message for minimum value validation error.",
+                            $default : null
+                        },
+                        "maxValue": {
+                            $type : "json:String",
+                            $description : "Default message for maximum value validation error.",
+                            $default : null
+                        }
+                    },
+                    $default : {}
                 }
             }
         },
@@ -551,6 +576,26 @@ module.exports = Aria.beanDefinitions({
                 "pattern" : {
                     $type : "environmentBase:FormatTypes",
                     $description : "Time pattern used to generate a value for the time entry"
+                },
+                "bind" : {
+                    $type : "TextInputCfg.bind",
+                    $properties : {
+                        "defaultErrorMessages" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
+                "defaultErrorMessages" : {
+                    $type : "json:Object",
+                    $description : "Default values for error messages.",
+                    $properties : {
+                        "validation" : {
+                            $type : "json:String",
+                            $description : "Default message for validation error.",
+                            $default : null
+                        }
+                    },
+                    $default : {}
                 }
             }
         },
@@ -571,9 +616,30 @@ module.exports = Aria.beanDefinitions({
                                 $type : "json:Float",
                                 $description : ""
                             }]
+                },
+                "bind" : {
+                    $type : "TextInputCfg.bind",
+                    $properties : {
+                        "defaultErrorMessages" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
+                "defaultErrorMessages" : {
+                    $type : "json:Object",
+                    $description : "Default values for error messages.",
+                    $properties : {
+                        "validation" : {
+                            $type : "json:String",
+                            $description : "Default message for validation error.",
+                            $default : null
+                        }
+                    },
+                    $default : {}
                 }
             }
         },
+
         "DropDownTextInputCfg" : {
             $type : "TextInputCfg",
             $description : "The base configuration for any widget extending DropDownInput",
@@ -977,6 +1043,26 @@ module.exports = Aria.beanDefinitions({
                     $default : [{
                                 key : "ENTER"
                             }]
+                },
+                "bind" : {
+                    $type : "DropDownTextInputCfg.bind",
+                    $properties : {
+                        "defaultErrorMessages" : {
+                            $type : "common:BindingRef"
+                        }
+                    }
+                },
+                "defaultErrorMessages" : {
+                    $type : "json:Object",
+                    $description : "Default values for error messages.",
+                    $properties : {
+                        "validation" : {
+                            $type : "json:String",
+                            $description : "Default message for validation error.",
+                            $default : null
+                        }
+                    },
+                    $default : {}
                 }
             }
         },

--- a/src/aria/widgets/WidgetsRes.js
+++ b/src/aria/widgets/WidgetsRes.js
@@ -20,16 +20,22 @@ Aria.resourcesDefinition({
     $classpath : 'aria.widgets.WidgetsRes',
     $resources : {
         errors : {
-            "40006_WIDGET_NUMBERFIELD_VALIDATION" : "Number field must be a numerical value.",
-            "40007_WIDGET_TIMEFIELD_VALIDATION" : "Please enter a valid time format, for example: 1000 or 10:00",
+            "NumberField" : {
+                "validation" : "Number field must be a numerical value."
+            },
+            "TimeField" : {
+                "validation" : "Please enter a valid time format, for example: 1000 or 10:00"
+            },
             // For PTR 04203167, we must ensure that the error message below (for date validation) does not contain
             // formats unsuitable for booking a flight (e.g. date in the past like -5)
-            "40008_WIDGET_DATEFIELD_VALIDATION" : "Please enter a valid date format, for example: 10/12 or 01MAR or +4",
-            "40018_WIDGET_DATEFIELD_MINVALUE" : "Date is before the minimum date.",
-            "40019_WIDGET_DATEFIELD_MAXVALUE" : "Date is after the maximum date.",
-            "40020_WIDGET_AUTOCOMPLETE_VALIDATION" : "There is no suggestion available for the given entry.",
-
-            "" : "" // empty entry to use commas at the end of each error description (!)
+            "DateField" : {
+                "validation" : "Please enter a valid date format, for example: 10/12 or 01MAR or +4",
+                "minValue" : "Date is before the minimum date.",
+                "maxValue" : "Date is after the maximum date."
+            },
+            "AutoComplete" : {
+                "validation" : "There is no suggestion available for the given entry."
+            }
         }
     }
 });

--- a/src/aria/widgets/controllers/AutoCompleteController.js
+++ b/src/aria/widgets/controllers/AutoCompleteController.js
@@ -19,7 +19,6 @@ var ariaTemplatesRefreshManager = require("../../templates/RefreshManager");
 var ariaWidgetsControllersReportsDropDownControllerReport = require("./reports/DropDownControllerReport");
 var ariaUtilsType = require("../../utils/Type");
 var ariaHtmlControllersSuggestions = require("../../html/controllers/Suggestions");
-var ariaWidgetsWidgetsRes = require("../../$resources").file(__dirname, "../WidgetsRes");
 var ariaWidgetsControllersDropDownListController = require("./DropDownListController");
 var ariaCoreJsonValidator = require("../../core/JsonValidator");
 
@@ -35,9 +34,6 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
     module.exports = Aria.classDefinition({
         $classpath : "aria.widgets.controllers.AutoCompleteController",
         $extends : ariaWidgetsControllersDropDownListController,
-        $resources : {
-            res : ariaWidgetsWidgetsRes
-        },
         $onload : function () {
             typeUtil = ariaUtilsType;
         },
@@ -45,6 +41,8 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
             typeUtil = null;
         },
         $constructor : function () {
+            this._widgetName = "AutoComplete";
+
             this.$DropDownListController.constructor.call(this);
 
             /**
@@ -174,7 +172,7 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
                             } else {
                                 report.ok = false;
                                 report.value = null;
-                                report.errorMessages.push(this.res.errors["40020_WIDGET_AUTOCOMPLETE_VALIDATION"]);
+                                report.errorMessages.push(this.getErrorMessage("validation"));
                             }
                         }
 
@@ -388,7 +386,7 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
                     } else {
                         if (!this.freeText && suggestionsAvailable && !hasSuggestions) {
                             report.ok = false;
-                            report.errorMessages.push(this.res.errors["40020_WIDGET_AUTOCOMPLETE_VALIDATION"]);
+                            report.errorMessages.push(this.getErrorMessage("validation"));
                         } else {
                             report.ok = true;
                         }
@@ -526,7 +524,6 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
                 }
                 return specialKey;
             }
-
         }
     });
 })();

--- a/src/aria/widgets/controllers/DateController.js
+++ b/src/aria/widgets/controllers/DateController.js
@@ -17,17 +17,14 @@ var ariaWidgetsControllersReportsControllerReport = require("./reports/Controlle
 var ariaUtilsDate = require("../../utils/Date");
 var ariaUtilsType = require("../../utils/Type");
 var ariaUtilsEnvironmentDate = require("../../utils/environment/Date");
-var ariaWidgetsWidgetsRes = require("../../$resources").file(__dirname, "../WidgetsRes");
 var ariaWidgetsControllersTextDataController = require("./TextDataController");
 
 
 module.exports = Aria.classDefinition({
     $classpath : "aria.widgets.controllers.DateController",
     $extends : ariaWidgetsControllersTextDataController,
-    $resources : {
-        "res" : ariaWidgetsWidgetsRes
-    },
     $constructor : function () {
+        this._widgetName = "DateField";
 
         this.$TextDataController.constructor.call(this);
 
@@ -150,10 +147,10 @@ module.exports = Aria.classDefinition({
                 internalValue = ariaUtilsDate.removeTime(internalValue);
                 if (this._minValue && internalValue < this._minValue) {
                     report.ok = false;
-                    report.errorMessages.push(this.res.errors["40018_WIDGET_DATEFIELD_MINVALUE"]);
+                    report.errorMessages.push(this.getErrorMessage("minValue"));
                 } else if (this._maxValue && internalValue > this._maxValue) {
                     report.ok = false;
-                    report.errorMessages.push(this.res.errors["40019_WIDGET_DATEFIELD_MAXVALUE"]);
+                    report.errorMessages.push(this.getErrorMessage("maxValue"));
                 } else {
                     report.ok = true;
                     this._dataModel.jsDate = internalValue;
@@ -196,7 +193,7 @@ module.exports = Aria.classDefinition({
                     } else {
                         report = new ariaWidgetsControllersReportsControllerReport();
                         report.ok = false;
-                        report.errorMessages.push(this.res.errors["40008_WIDGET_DATEFIELD_VALIDATION"]);
+                        report.errorMessages.push(this.getErrorMessage("validation"));
                     }
                 }
             }

--- a/src/aria/widgets/controllers/NumberController.js
+++ b/src/aria/widgets/controllers/NumberController.js
@@ -16,7 +16,6 @@ var Aria = require("../../Aria");
 var ariaWidgetsControllersReportsControllerReport = require("./reports/ControllerReport");
 var ariaUtilsNumber = require("../../utils/Number");
 var ariaCoreJsonValidator = require("../../core/JsonValidator");
-var ariaWidgetsWidgetsRes = require("../../$resources").file(__dirname, "../WidgetsRes");
 var ariaWidgetsControllersTextDataController = require("./TextDataController");
 var ariaUtilsType = require("../../utils/Type");
 
@@ -27,10 +26,9 @@ var ariaUtilsType = require("../../utils/Type");
 module.exports = Aria.classDefinition({
     $classpath : "aria.widgets.controllers.NumberController",
     $extends : ariaWidgetsControllersTextDataController,
-    $resources : {
-        "res" : ariaWidgetsWidgetsRes
-    },
     $constructor : function () {
+        this._widgetName = "NumberField";
+
         this.$TextDataController.constructor.call(this);
 
         /**
@@ -117,7 +115,7 @@ module.exports = Aria.classDefinition({
                     // Nothing changed
                     report.ok = !hasErrors;
                     if (!report.ok) {
-                        report.errorMessages[0] = this.res.errors["40006_WIDGET_NUMBERFIELD_VALIDATION"];
+                        report.errorMessages[0] = this.getErrorMessage("validation");
                     }
                 } else {
                     // Update the text datamodel
@@ -133,7 +131,7 @@ module.exports = Aria.classDefinition({
 
                         report.ok = true;
                     } else {
-                        report.errorMessages[0] = this.res.errors["40006_WIDGET_NUMBERFIELD_VALIDATION"];
+                        report.errorMessages[0] = this.getErrorMessage("validation");
                         // The text doesn't correspond to a valid number
                         this._dataModel.number = null;
                     }

--- a/src/aria/widgets/controllers/TextDataController.js
+++ b/src/aria/widgets/controllers/TextDataController.js
@@ -15,6 +15,10 @@
 var Aria = require("../../Aria");
 var ariaWidgetsControllersReportsControllerReport = require("./reports/ControllerReport");
 var ariaUtilsType = require("../../utils/Type");
+var ariaWidgetsWidgetsRes = require("../../$resources").file(__dirname, "../WidgetsRes");
+var ariaWidgetsSettings = require("../environment/WidgetSettings");
+
+
 
 
 /**
@@ -22,9 +26,12 @@ var ariaUtilsType = require("../../utils/Type");
  */
 module.exports = Aria.classDefinition({
     $classpath : "aria.widgets.controllers.TextDataController",
+    $resources : {
+        res : ariaWidgetsWidgetsRes
+    },
     $events : {
         "onCheck" : {
-            description : "Notifies that controller has finished am asynchronouse check (internal, of the value or of a keystroke)",
+            description : "Notifies that controller has finished an asynchronous check (internal, of the value or of a keystroke)",
             properties : {
                 report : "{aria.widgets.controllers.reports.ControllerReport} a check report"
             }
@@ -39,6 +46,8 @@ module.exports = Aria.classDefinition({
             value : null,
             displayText : ''
         };
+
+        this.setDefaultErrorMessages();
     },
     $prototype : {
 
@@ -93,6 +102,31 @@ module.exports = Aria.classDefinition({
          */
         getDataModel : function () {
             return this._dataModel;
+        },
+
+        /**
+         * Sets the default error messages map to the given value.
+         *
+         * <p>
+         * The input value type is specified in bean <em>aria.widgets.CfgBeans</em> for the widgets supporting it.
+         * </p>
+         *
+         * <p>
+         * If the given value is <em>null</em>, an empty object is set, meaning no default messages.
+         * </p>
+         *
+         * @param {Object} defaultErrorMessages The map of error messages to set for the controller.
+         *
+         * @return {Object} The final default error messages (as given or further processed ones).
+         */
+        setDefaultErrorMessages : function (defaultErrorMessages) {
+            if (defaultErrorMessages == null) {
+                defaultErrorMessages = {};
+            }
+
+            this._defaultErrorMessages = defaultErrorMessages;
+
+            return defaultErrorMessages;
         },
 
         /**
@@ -222,6 +256,104 @@ module.exports = Aria.classDefinition({
                 report : report,
                 arg : arg
             });
+        },
+
+        /**
+         * Retrieves the requested error message from different sets of configuration ordered by precedence.
+         *
+         * <p>
+         * An error message value is requested from this error message name.
+         * </p>
+         *
+         * <p>
+         * There can be three levels of configuration for the error messages of a widget, enumerated here by order of precedence:
+         * <ol>
+         *  <li>local: in the configuration of the widget's instance</li>
+         *  <li>global: in the application's environment configuration</li>
+         *  <li>hardcoded: in internal resources; it is used as a fallback</li>
+         * </ol>
+         * </p>
+         *
+         * <p>
+         * As soon as a configuration contains a non-void value for the requested error message, this one is used for the return value.
+         * </p>
+         *
+         * <p>
+         * Note that since there are hardcoded values, there will always be an error message for a valid message name. However, if the message name is not supported, an <em>unefined</em> value is returned in the end.
+         * </p>
+         *
+         * @param {String} errorMessageName The name of the error message to retrieve (it is the key to the requested message in the collection).
+         *
+         * @return {String} The retrieved error message if any, <em>undefined</em> if the message name is not supported.
+         */
+        getErrorMessage : function (errorMessageName) {
+            // ----------------------------------------------- early termination
+
+            if (errorMessageName == null) {
+                return "";
+            }
+
+            // ------------------------------------------------------ processing
+
+            // configurations settings -----------------------------------------
+
+            var widgetName = this._widgetName;
+
+            var configurations = [
+                // widget internal configuration -------------------------------
+                {
+                    getDefaultErrorMessages : function () {
+                        return this._defaultErrorMessages;
+                    }
+                },
+                // widgets global configuration --------------------------------
+                {
+                    getWidgetsDefaultErrorMessages : function () {
+                        var widgetsSettings = ariaWidgetsSettings.getWidgetSettings();
+
+                        return widgetsSettings["defaultErrorMessages"];
+                    }
+                },
+                // hardcoded defaults ------------------------------------------
+                {
+                    getWidgetsDefaultErrorMessages : function () {
+                        return this.res.errors;
+                    }
+                }
+            ];
+
+            // configurations lookup -------------------------------------------
+
+            var errorMessage;
+            var defaultErrorMessages;
+
+            var index = 0;
+            var length = configurations.length;
+            var configuration;
+            while (errorMessage == null && index < length) {
+                configuration = configurations[index];
+
+                var getDefaultErrorMessages = configuration.getDefaultErrorMessages;
+
+                if (getDefaultErrorMessages == null) {
+                    getDefaultErrorMessages = function () {
+                        var widgetsDefaultErrorMessages = configuration.getWidgetsDefaultErrorMessages.call(this);
+                        return widgetsDefaultErrorMessages[widgetName];
+                    };
+                }
+
+                defaultErrorMessages = getDefaultErrorMessages.call(this);
+
+                if (defaultErrorMessages != null) {
+                    errorMessage = defaultErrorMessages[errorMessageName];
+                }
+
+                index++;
+            }
+
+            // ---------------------------------------------------------- return
+
+            return errorMessage;
         }
     }
 });

--- a/src/aria/widgets/controllers/TimeController.js
+++ b/src/aria/widgets/controllers/TimeController.js
@@ -16,7 +16,6 @@ var Aria = require("../../Aria");
 var ariaWidgetsControllersReportsControllerReport = require("./reports/ControllerReport");
 var ariaUtilsDate = require("../../utils/Date");
 var ariaUtilsEnvironmentDate = require("../../utils/environment/Date");
-var ariaWidgetsWidgetsRes = require("../../$resources").file(__dirname, "../WidgetsRes");
 var ariaWidgetsControllersTextDataController = require("./TextDataController");
 var ariaUtilsType = require("../../utils/Type");
 
@@ -28,10 +27,9 @@ var ariaUtilsType = require("../../utils/Type");
 module.exports = Aria.classDefinition({
     $classpath : "aria.widgets.controllers.TimeController",
     $extends : ariaWidgetsControllersTextDataController,
-    $resources : {
-        "res" : ariaWidgetsWidgetsRes
-    },
     $constructor : function () {
+        this._widgetName = "TimeField";
+
         this.$TextDataController.constructor.call(this);
 
         /**
@@ -116,7 +114,7 @@ module.exports = Aria.classDefinition({
                             report.value = this._dataModel.jsDate;
                         }
                     } else {
-                        report.errorMessages[0] = this.res.errors["40007_WIDGET_TIMEFIELD_VALIDATION"];
+                        report.errorMessages[0] = this.getErrorMessage("validation");
                     }
                 }
             }
@@ -131,6 +129,5 @@ module.exports = Aria.classDefinition({
         getDisplayTextFromValue : function (time) {
             return (time && ariaUtilsType.isDate(time)) ? ariaUtilsDate.format(time, this._pattern) : "";
         }
-
     }
 });

--- a/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
+++ b/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
@@ -15,6 +15,7 @@
 var Aria = require("../../Aria");
 var ariaCoreJsonTypes = require("../../core/JsonTypes");
 var ariaUtilsDragdropDragDropBean = require("../../utils/dragdrop/DragDropBean");
+var ariaWidgetsCfgBeans = require("../CfgBeans");
 
 
 /**
@@ -24,7 +25,8 @@ module.exports = Aria.beanDefinitions({
     $package : "aria.widgets.environment.WidgetSettingsCfgBeans",
     $namespaces : {
         "json" : ariaCoreJsonTypes,
-        "dragDrop" : ariaUtilsDragdropDragDropBean
+        "dragDrop" : ariaUtilsDragdropDragDropBean,
+        "widgets" : ariaWidgetsCfgBeans
     },
     $description : "",
     $beans : {
@@ -70,7 +72,30 @@ module.exports = Aria.beanDefinitions({
                         },
                         "movableProxy" : {
                             $type : "dragDrop:ProxyCfg",
-                            $description : "Specifies the type of proxy dor the dialog motion."
+                            $description : "Specifies the type of proxy for the dialog motion."
+                        }
+                    },
+                    $default : {}
+                },
+                "defaultErrorMessages" : {
+                    $type : "json:Object",
+                    $description : "Default values for widgets' error messages.",
+                    $properties : {
+                        "NumberField" : {
+                            $type : "widgets:NumberFieldCfg.defaultErrorMessages",
+                            $description : "Default values for NumberField's error messages."
+                        },
+                        "TimeField" : {
+                            $type : "widgets:TimeFieldCfg.defaultErrorMessages",
+                            $description : "Default values for TimeField's error messages."
+                        },
+                        "DateField" : {
+                            $type : "widgets:DateFieldCfg.defaultErrorMessages",
+                            $description : "Default values for DateField's error messages."
+                        },
+                        "AutoComplete" : {
+                            $type : "widgets:AutoCompleteCfg.defaultErrorMessages",
+                            $description : "Default values for AutoComplete's error messages."
                         }
                     },
                     $default : {}

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -72,7 +72,7 @@ module.exports = Aria.classDefinition({
 
         this._isTextarea = false;
         /**
-         * Internal timer ID used to calidate a keyup event.
+         * Internal timer ID used to validate a keyup event.
          * @see _dom_onkeyup
          * @protected
          * @type String
@@ -88,7 +88,7 @@ module.exports = Aria.classDefinition({
         this._keepFocus = false;
 
         /**
-         * Use on keep focus to restaure selection. Keep selection start and end.
+         * Use on keep focus to restore selection. Keep selection start and end.
          * @protected
          * @type Object
          */
@@ -105,6 +105,8 @@ module.exports = Aria.classDefinition({
                 'onCheck' : this._reactToControllerReportEvent,
                 scope : this
             });
+
+            controller.setDefaultErrorMessages(cfg.defaultErrorMessages);
         }
 
         /**
@@ -143,9 +145,9 @@ module.exports = Aria.classDefinition({
         this._simpleHTML = this._skinObj.simpleHTML;
 
         /**
-         * Flag set to false after first focus, and set back to true after a blur. Used for the autoselect behaviour.<br />
+         * Flag set to false after first focus, and set back to true after a blur. Used for the autoselect behavior.<br />
          * This value is true when the field receives focus for the first time (user action) and false when the focus is
-         * giveng programmatically by the controller
+         * given programmatically by the controller
          * @type Boolean
          */
         this._firstFocus = true;
@@ -402,7 +404,7 @@ module.exports = Aria.classDefinition({
          *     value: {Object} - internal widget value,
          *     performCheckOnly: {Boolean} - perfom only value/text check do not update th widget display,
          *     resetErrorIfOK: {Boolean} (default:true) - tells if error display must be removed if check is OK
-         *         (usefull when check is done on 'strange' events like mouseover)
+         *         (useful when check is done on 'strange' events like mouseover)
          * }
          * </pre>
          *
@@ -754,6 +756,10 @@ module.exports = Aria.classDefinition({
                     this.setPrefillText(true, "", true);
                 } else if (newValue === false) {
                     this.setPrefillText(true, this._cfg.prefill, true);
+                }
+            } else if (propertyName == "defaultErrorMessages") {
+                if (this.controller) {
+                    this.controller.setDefaultErrorMessages(newValue);
                 }
             } else {
                 // delegate to parent class
@@ -1111,7 +1117,7 @@ module.exports = Aria.classDefinition({
 
         /**
          * Set the helptext of the field if needed
-         * @param {Boolean} enable Wheter to enable it or not
+         * @param {Boolean} enable Whether to enable it or not
          */
         setHelpText : function (enable) {
             var cfg = this._cfg;

--- a/test/aria/widgets/form/BaseDefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/BaseDefaultErrorMessagesTest.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.BaseDefaultErrorMessagesTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Array", "aria.utils.Json"],
+
+    /**
+     * @param {String} widgetName The name of the widget being tested, as present in the global default error messages configuration
+     * @param {Array} messagesList Array of message name (<em>String</em>) to be tested (as those present in the widget's default error messages configuration)
+     */
+    $constructor : function (widgetName, messagesList) {
+        // ---------------------------------------------------------------------
+
+        this.$TemplateTestCase.constructor.apply(this, arguments);
+
+        // ---------------------------------------------------------------------
+
+        this.widgetName = widgetName;
+        this.messagesList = messagesList;
+
+        // ---------------------------------------------------------------------
+
+        var data = this.data = {};
+
+        data.instanceHardCoded = "instance hardcoded";
+        data.defaultErrorMessages = {};
+
+        this.setTestEnv({
+            data: data,
+            template: "test.aria.widgets.form." + widgetName.toLowerCase() + ".defaultErrorMessages.DefaultErrorMessagesTestTpl"
+        });
+
+        // ---------------------------------------------------------------------
+
+        this.globalMessage = "global message";
+        this.instanceMessage = "instance message";
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            // -----------------------------------------------------------------
+
+            this.boundWidget = this.getWidgetInstance("bound");
+            this.hardcodedWidget = this.getWidgetInstance("hardcoded");
+
+            // -----------------------------------------------------------------
+
+            aria.utils.Array.forEach(this.messagesList, function(name) {
+                this._testMessageConfiguration(name);
+            }, this);
+
+            // -----------------------------------------------------------------
+
+            this.end();
+        },
+
+
+
+        _testMessageConfiguration : function (name) {
+            // Order of steps is important
+            aria.utils.Array.forEach([
+                "HardCodedConfiguration",
+                "BoundConfiguration",
+                "GlobalConfiguration", // HardCodedConfiguration & BoundConfiguration will already check that instance configuration has precedence over global configuration
+                "HardCodedDefault"
+            ], function(step) {
+                this["_test" + step](name);
+                this._resetMessage(name);
+            }, this);
+        },
+
+        _resetMessage : function (name) {
+            this._setInstanceDefault(name, null);
+            this._setGlobalDefault(name, null);
+        },
+
+
+
+        _testHardCodedConfiguration : function (name) {
+            this._checkMessage(this.hardcodedWidget, name, this.data.instanceHardCoded);
+
+            this._setGlobalDefault(name, this.globalMessage);
+            this._checkMessage(this.hardcodedWidget, name, this.data.instanceHardCoded);
+        },
+
+        _testBoundConfiguration : function (name) {
+            this._setInstanceDefault(name, this.instanceMessage);
+            this._checkMessage(this.boundWidget, name, this.instanceMessage);
+
+            this._setGlobalDefault(name, this.globalMessage);
+            this._checkMessage(this.boundWidget, name, this.instanceMessage);
+        },
+
+        _testGlobalConfiguration : function (name) {
+            this._setGlobalDefault(name, this.globalMessage);
+            this._checkMessage(this.boundWidget, name, this.globalMessage);
+        },
+
+        _testHardCodedDefault : function (name) {
+            this._checkMessage(this.boundWidget, name, this.boundWidget.controller.res.errors[this.widgetName][name]);
+        },
+
+
+
+        _checkMessage : function (widget, name, expectedValue) {
+            var stringify = function (value) {
+                return aria.utils.Json.convertToJsonString(value);
+            };
+
+            var actualValue = widget.controller.getErrorMessage(name);
+
+            var message = "The message value is not the expected one. Expected one is: " + stringify(expectedValue) + ", while actual one is: " + stringify(actualValue) + ".";
+
+            this.assertTrue(actualValue == expectedValue, message);
+        },
+
+
+
+        _setGlobalDefault : function (name, value) {
+            var messages = {};
+            messages[name] = value;
+
+            var widgets = {};
+            widgets[this.widgetName] = messages;
+
+            aria.core.AppEnvironment.setEnvironment({
+                "widgetSettings" : {
+                    defaultErrorMessages : widgets
+                }
+            }, null, true);
+        },
+
+        _setInstanceDefault : function (name, value) {
+            aria.utils.Json.setValue(this.data.defaultErrorMessages, name, value);
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
@@ -54,5 +54,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.autocomplete.errorhandling.AutoComplete2");
         this.addTests("test.aria.widgets.form.autocomplete.preselectAutofill.PreselectAutofillTestSuite");
         this.addTests("test.aria.widgets.form.autocomplete.popupWidth.AdaptToContentWidthTest");
+        this.addTests("test.aria.widgets.form.autocomplete.defaultErrorMessages.DefaultErrorMessagesTest");
     }
 });

--- a/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTest.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.defaultErrorMessages.DefaultErrorMessagesTest",
+    $extends : "test.aria.widgets.form.BaseDefaultErrorMessagesTest",
+    $dependencies : ["aria.utils.Array", "aria.utils.Json", "aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        // ---------------------------------------------------------------------
+
+        this.$BaseDefaultErrorMessagesTest.constructor.call(
+            this,
+            "AutoComplete",
+            [
+                "validation"
+            ]
+        );
+
+        // ---------------------------------------------------------------------
+
+        var suggestions = [];
+        var resourcesHandler = new aria.resources.handlers.LCResourcesHandler();
+        resourcesHandler.setSuggestions(suggestions);
+
+        return this.data.resourcesHandler = resourcesHandler;
+    },
+    $destructor : function () {
+        this.data.resourcesHandler.$dispose();
+        this.data.resourcesHandler = null;
+    }
+});

--- a/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
+++ b/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.autocomplete.defaultErrorMessages.DefaultErrorMessagesTestTpl"
+}}
+
+    {macro main()}
+        {@aria:AutoComplete {
+            id: "bound",
+
+            resourcesHandler: this.data.resourcesHandler,
+
+            bind : {
+                defaultErrorMessages: {
+                    inside : this.data,
+                    to : "defaultErrorMessages"
+                }
+            }
+        }/}
+
+        {@aria:AutoComplete {
+            id: "hardcoded",
+
+            resourcesHandler: this.data.resourcesHandler,
+
+            defaultErrorMessages : {
+                validation : this.data.instanceHardCoded
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/datefield/DateFieldTestSuite.js
+++ b/test/aria/widgets/form/datefield/DateFieldTestSuite.js
@@ -22,5 +22,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.datefield.issue303.InvalidState");
         this.addTests("test.aria.widgets.form.datefield.checkValue.DateField");
         this.addTests("test.aria.widgets.form.datefield.checkDate.DateField");
+        this.addTests("test.aria.widgets.form.datefield.defaultErrorMessages.DefaultErrorMessagesTest");
     }
 });

--- a/test/aria/widgets/form/datefield/defaultErrorMessages/DefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/datefield/defaultErrorMessages/DefaultErrorMessagesTest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Amadeus s.a.s.
+ * Copyright 2015 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,13 +14,20 @@
  */
 
 Aria.classDefinition({
-    $classpath : "test.aria.widgets.form.timefield.TimeFieldTestSuite",
-    $extends : "aria.jsunit.TestSuite",
+    $classpath : "test.aria.widgets.form.datefield.defaultErrorMessages.DefaultErrorMessagesTest",
+    $extends : "test.aria.widgets.form.BaseDefaultErrorMessagesTest",
+    $dependencies : ["aria.utils.Array", "aria.utils.Json"],
     $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+        // ---------------------------------------------------------------------
 
-        this.addTests("test.aria.widgets.form.timefield.checkFormat.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.checkValue.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.defaultErrorMessages.DefaultErrorMessagesTest");
+        this.$BaseDefaultErrorMessagesTest.constructor.call(
+            this,
+            "DateField",
+            [
+                "validation",
+                "minValue",
+                "maxValue"
+            ]
+        );
     }
 });

--- a/test/aria/widgets/form/datefield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
+++ b/test/aria/widgets/form/datefield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.datefield.defaultErrorMessages.DefaultErrorMessagesTestTpl"
+}}
+
+    {macro main()}
+        {@aria:DateField {
+            id: "bound",
+
+            bind : {
+                defaultErrorMessages: {
+                    inside : this.data,
+                    to : "defaultErrorMessages"
+                }
+            }
+        }/}
+
+        {@aria:DateField {
+            id: "hardcoded",
+
+            defaultErrorMessages : {
+                validation : this.data.instanceHardCoded,
+                minValue : this.data.instanceHardCoded,
+                maxValue : this.data.instanceHardCoded
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/numberfield/NumberFieldSuite.js
+++ b/test/aria/widgets/form/numberfield/NumberFieldSuite.js
@@ -22,5 +22,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.numberfield.NumberFieldTest");
         this.addTests("test.aria.widgets.form.numberfield.inputPattern.InputPattern");
         this.addTests("test.aria.widgets.form.numberfield.inputPattern.SeparatedInputPattern");
+        this.addTests("test.aria.widgets.form.numberfield.defaultErrorMessages.DefaultErrorMessagesTest");
     }
 });

--- a/test/aria/widgets/form/numberfield/defaultErrorMessages/DefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/numberfield/defaultErrorMessages/DefaultErrorMessagesTest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Amadeus s.a.s.
+ * Copyright 2015 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,13 +14,18 @@
  */
 
 Aria.classDefinition({
-    $classpath : "test.aria.widgets.form.timefield.TimeFieldTestSuite",
-    $extends : "aria.jsunit.TestSuite",
+    $classpath : "test.aria.widgets.form.numberfield.defaultErrorMessages.DefaultErrorMessagesTest",
+    $extends : "test.aria.widgets.form.BaseDefaultErrorMessagesTest",
+    $dependencies : ["aria.utils.Array", "aria.utils.Json"],
     $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+        // ---------------------------------------------------------------------
 
-        this.addTests("test.aria.widgets.form.timefield.checkFormat.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.checkValue.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.defaultErrorMessages.DefaultErrorMessagesTest");
+        this.$BaseDefaultErrorMessagesTest.constructor.call(
+            this,
+            "NumberField",
+            [
+                "validation"
+            ]
+        );
     }
 });

--- a/test/aria/widgets/form/numberfield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
+++ b/test/aria/widgets/form/numberfield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.numberfield.defaultErrorMessages.DefaultErrorMessagesTestTpl"
+}}
+
+    {macro main()}
+        {@aria:NumberField {
+            id: "bound",
+
+            bind : {
+                defaultErrorMessages: {
+                    inside : this.data,
+                    to : "defaultErrorMessages"
+                }
+            }
+        }/}
+
+        {@aria:NumberField {
+            id: "hardcoded",
+
+            defaultErrorMessages : {
+                validation : this.data.instanceHardCoded
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/timefield/defaultErrorMessages/DefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/timefield/defaultErrorMessages/DefaultErrorMessagesTest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Amadeus s.a.s.
+ * Copyright 2015 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,13 +14,18 @@
  */
 
 Aria.classDefinition({
-    $classpath : "test.aria.widgets.form.timefield.TimeFieldTestSuite",
-    $extends : "aria.jsunit.TestSuite",
+    $classpath : "test.aria.widgets.form.timefield.defaultErrorMessages.DefaultErrorMessagesTest",
+    $extends : "test.aria.widgets.form.BaseDefaultErrorMessagesTest",
+    $dependencies : ["aria.utils.Array", "aria.utils.Json"],
     $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+        // ---------------------------------------------------------------------
 
-        this.addTests("test.aria.widgets.form.timefield.checkFormat.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.checkValue.TimeField");
-        this.addTests("test.aria.widgets.form.timefield.defaultErrorMessages.DefaultErrorMessagesTest");
+        this.$BaseDefaultErrorMessagesTest.constructor.call(
+            this,
+            "TimeField",
+            [
+                "validation"
+            ]
+        );
     }
 });

--- a/test/aria/widgets/form/timefield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
+++ b/test/aria/widgets/form/timefield/defaultErrorMessages/DefaultErrorMessagesTestTpl.tpl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.timefield.defaultErrorMessages.DefaultErrorMessagesTestTpl"
+}}
+
+    {macro main()}
+        {@aria:TimeField {
+            id: "bound",
+
+            bind : {
+                defaultErrorMessages: {
+                    inside : this.data,
+                    to : "defaultErrorMessages"
+                }
+            }
+        }/}
+
+        {@aria:TimeField {
+            id: "hardcoded",
+
+            defaultErrorMessages : {
+                validation : this.data.instanceHardCoded
+            }
+        }/}
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
It is now possible for a user to customize the error messages used by the widgets.

There are 3 levels of error messages specifications, the two firsts being user configuration while the last is the hardcoded default.

This is resolved in this order of precedence:

- local: widget's configuration
- global: application's environment
- hardcoded: widget's resources