### PR TITLE
feat Improved the widget's default error messages customization and added backward compatibility

### DIFF
--- a/src/aria/widgets/WidgetsRes.js
+++ b/src/aria/widgets/WidgetsRes.js
@@ -36,6 +36,17 @@ Aria.resourcesDefinition({
             "AutoComplete" : {
                 "validation" : "There is no suggestion available for the given entry."
             }
+            /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+            ,
+            "40006_WIDGET_NUMBERFIELD_VALIDATION" : "Number field must be a numerical value.",
+            "40007_WIDGET_TIMEFIELD_VALIDATION" : "Please enter a valid time format, for example: 1000 or 10:00",
+            // For PTR 04203167, we must ensure that the error message below (for date validation) does not contain
+            // formats unsuitable for booking a flight (e.g. date in the past like -5)
+            "40008_WIDGET_DATEFIELD_VALIDATION" : "Please enter a valid date format, for example: 10/12 or 01MAR or +4",
+            "40018_WIDGET_DATEFIELD_MINVALUE" : "Date is before the minimum date.",
+            "40019_WIDGET_DATEFIELD_MAXVALUE" : "Date is after the maximum date.",
+            "40020_WIDGET_AUTOCOMPLETE_VALIDATION" : "There is no suggestion available for the given entry."
+            /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
         }
     }
 });

--- a/src/aria/widgets/controllers/TextDataController.js
+++ b/src/aria/widgets/controllers/TextDataController.js
@@ -321,11 +321,33 @@ module.exports = Aria.classDefinition({
 
             if (errorMessage == null) {
                 errorMessage = this.res.errors[widgetName][errorMessageName];
+                /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+                errorMessage = this.res.errors[this._newKeysToOldKeysMap[widgetName][errorMessageName]];
+                /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
             }
 
             // ---------------------------------------------------------- return
 
             return errorMessage;
         }
+        /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+        ,
+        _newKeysToOldKeysMap: {
+            "NumberField" : {
+                "validation" : "40006_WIDGET_NUMBERFIELD_VALIDATION"
+            },
+            "TimeField" : {
+                "validation" : "40007_WIDGET_TIMEFIELD_VALIDATION"
+            },
+            "DateField" : {
+                "validation" : "40008_WIDGET_DATEFIELD_VALIDATION",
+                "minValue" : "40018_WIDGET_DATEFIELD_MINVALUE",
+                "maxValue" : "40019_WIDGET_DATEFIELD_MAXVALUE"
+            },
+            "AutoComplete" : {
+                "validation" : "40020_WIDGET_AUTOCOMPLETE_VALIDATION"
+            }
+        }
+        /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
     }
 });

--- a/src/aria/widgets/controllers/TextDataController.js
+++ b/src/aria/widgets/controllers/TextDataController.js
@@ -279,7 +279,7 @@ module.exports = Aria.classDefinition({
          * </p>
          *
          * <p>
-         * Note that since there are hardcoded values, there will always be an error message for a valid message name. However, if the message name is not supported, an <em>unefined</em> value is returned in the end.
+         * Note that since there are hardcoded values, there will always be an error message for a valid message name. However, if the message name is not supported, an <em>undefined</em> value is returned in the end.
          * </p>
          *
          * @param {String} errorMessageName The name of the error message to retrieve (it is the key to the requested message in the collection).
@@ -295,60 +295,32 @@ module.exports = Aria.classDefinition({
 
             // ------------------------------------------------------ processing
 
-            // configurations settings -----------------------------------------
+            var errorMessage;
 
             var widgetName = this._widgetName;
 
-            var configurations = [
-                // widget internal configuration -------------------------------
-                {
-                    getDefaultErrorMessages : function () {
-                        return this._defaultErrorMessages;
-                    }
-                },
-                // widgets global configuration --------------------------------
-                {
-                    getWidgetsDefaultErrorMessages : function () {
-                        var widgetsSettings = ariaWidgetsSettings.getWidgetSettings();
+            // local -----------------------------------------------------------
 
-                        return widgetsSettings["defaultErrorMessages"];
-                    }
-                },
-                // hardcoded defaults ------------------------------------------
-                {
-                    getWidgetsDefaultErrorMessages : function () {
-                        return this.res.errors;
+            if (errorMessage == null) {
+                errorMessage = this._defaultErrorMessages[errorMessageName];
+            }
+
+            // global ----------------------------------------------------------
+
+            if (errorMessage == null) {
+                var allMessages = ariaWidgetsSettings.getWidgetSettings()["defaultErrorMessages"];
+                if (allMessages != null) {
+                    var widgetMessages = allMessages[widgetName];
+                    if (widgetMessages != null) {
+                        errorMessage = widgetMessages[errorMessageName];
                     }
                 }
-            ];
+            }
 
-            // configurations lookup -------------------------------------------
+            // hardcoded -------------------------------------------------------
 
-            var errorMessage;
-            var defaultErrorMessages;
-
-            var index = 0;
-            var length = configurations.length;
-            var configuration;
-            while (errorMessage == null && index < length) {
-                configuration = configurations[index];
-
-                var getDefaultErrorMessages = configuration.getDefaultErrorMessages;
-
-                if (getDefaultErrorMessages == null) {
-                    getDefaultErrorMessages = function () {
-                        var widgetsDefaultErrorMessages = configuration.getWidgetsDefaultErrorMessages.call(this);
-                        return widgetsDefaultErrorMessages[widgetName];
-                    };
-                }
-
-                defaultErrorMessages = getDefaultErrorMessages.call(this);
-
-                if (defaultErrorMessages != null) {
-                    errorMessage = defaultErrorMessages[errorMessageName];
-                }
-
-                index++;
+            if (errorMessage == null) {
+                errorMessage = this.res.errors[widgetName][errorMessageName];
             }
 
             // ---------------------------------------------------------- return

--- a/test/aria/widgets/form/BaseDefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/BaseDefaultErrorMessagesTest.js
@@ -52,6 +52,9 @@ Aria.classDefinition({
 
         this.globalMessage = "global message";
         this.instanceMessage = "instance message";
+        /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+        this.resourceMessageOldKey = "resource message (old key)";
+        /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
     },
     $prototype : {
         runTemplateTest : function () {
@@ -79,6 +82,10 @@ Aria.classDefinition({
                 "BoundConfiguration",
                 "GlobalConfiguration",
                 "HardCodedDefault"
+                /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+                ,
+                "HardCodedDefaultTweaking"
+                /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
             ], function(step) {
                 this["_test" + step](name);
                 this._resetMessage(name);
@@ -190,6 +197,40 @@ Aria.classDefinition({
             this._setGlobalDefault(messageName, expectedValue);
             this._checkMessage(widget, messageName, expectedValue);
         },
+        /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1428) */
+
+        /**
+         * Tests that the hardcoded default value can be modified since it is actually an accessible single object residing in memory.
+         *
+         * <p>
+         * Note that this is a feature only available with the old keys, since now there is a preferred and supported way to do it.
+         * </p>
+         */
+        _testHardCodedDefaultTweaking : function (messageName) {
+            var widgetName = this.widgetName;
+
+            // -----------------------------------------------------------------
+
+            var widget = this.boundWidget;
+            var expectedValue;
+
+            var resourceErrors = aria.widgets.WidgetsRes.errors;
+            var resourceWidgetErrors = resourceErrors[widgetName];
+
+            // -----------------------------------------------------------------
+
+            expectedValue = resourceWidgetErrors[messageName];
+            this._checkMessage(widget, messageName, expectedValue);
+
+            // -----------------------------------------------------------------
+
+            var map = widget.controller._newKeysToOldKeysMap;
+
+            expectedValue = this.resourceMessageOldKey;
+            resourceErrors[map[widgetName][messageName]] = expectedValue;
+            this._checkMessage(widget, messageName, expectedValue);
+        },
+        /* BACKWARD-COMPATIBILITY-END (GitHub #1428) */
 
         /**
          * Check that the queried error message (from its name) for the given widget is the expected one.

--- a/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTest.js
+++ b/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTest.js
@@ -34,7 +34,7 @@ Aria.classDefinition({
         var resourcesHandler = new aria.resources.handlers.LCResourcesHandler();
         resourcesHandler.setSuggestions(suggestions);
 
-        return this.data.resourcesHandler = resourcesHandler;
+        this.data.resourcesHandler = resourcesHandler;
     },
     $destructor : function () {
         this.data.resourcesHandler.$dispose();


### PR DESCRIPTION
## Improvement

The implementation code is now cleaner and more documented, as well as for the test. A little bit of redundancy checking has been introduced in the tests just to make sure that if the order of some methods changes or if some are removed or whatever the tests will still work and be comprehensive.

Also fixed a small mistake in AutoComplete's default error messages test.

An unwanted `return` statement was remaining at the end of the `$constructor` of the test. It was not breaking anything regarding our class system implementation, but this remains incorrect.

## Backward compatibility

Added backward compatibility for widget's default error messages customization. The non-backward change concerns the keys used inside a resource file to define the hardcoded fallback for default values.

There is no deprecation message or so on because the broken feature was not a public feature, but a commonly agreed hack.