### PR TITLE
fix Selection was lost when a multiselect was open with the arrow down key

### DIFF
--- a/src/aria/widgets/controllers/MultiSelectController.js
+++ b/src/aria/widgets/controllers/MultiSelectController.js
@@ -311,15 +311,12 @@ module.exports = Aria.classDefinition({
          */
         _checkInputKey : function (charCode, keyCode, currentText, caretPosStart, caretPosEnd) {
             if (ariaDomEvent.KC_ARROW_DOWN === keyCode) {
-                var report = this.checkValue(currentText.split(this._separator));
-                if (report != null) {
-                    report.$dispose();
-                }
+                return this.toggleDropdown(currentText, false);
             }
             var report = new ariaWidgetsControllersReportsDropDownControllerReport();
             report.ok = true;
             report.cancelKeyStroke = false;
-            report.displayDropDown = keyCode === ariaDomEvent.KC_ARROW_DOWN;
+            report.displayDropDown = false;
             return report;
         },
 

--- a/test/aria/widgets/form/multiselect/upArrowKey/test1/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/upArrowKey/test1/MultiSelect.js
@@ -27,6 +27,7 @@ Aria.classDefinition({
          * popup.
          */
         runTemplateTest : function () {
+            this.inputField = this.getInputField("ms1");
             this.toggleMultiSelectOn("ms1", this.onMsOpened);
         },
 
@@ -47,7 +48,7 @@ Aria.classDefinition({
             var domRef = aria.utils.Dom.getElementById("clickM"), that = this;
             this.getWidgetInstance("ms1")._dom_onblur = function () {};
             that.synEvent.click(domRef, {
-                fn : that.finishTest,
+                fn : that.checkAndReopen,
                 scope : that
             });
         },
@@ -55,10 +56,21 @@ Aria.classDefinition({
         /**
          * Finalize the test, check the widgets value has been correctly updated when the up key was triggered.
          */
-        finishTest : function () {
+        checkAndReopen : function () {
             var test = aria.utils.Dom.getElementById("test1");
             this.assertTrue(test.innerHTML === 'KF');
-            this.notifyTemplateTestEnd();
+
+            // Reopen the MS with the down arrow
+            this.clickAndType("ms1", "[down]", {
+                fn : this.finishTest,
+                scope : this
+            }, false);
+        },
+
+        finishTest : function() {
+            var checkBox = this.getWidgetInstance("listItem0").getDom();
+            this.assertTrue(checkBox.getElementsByTagName("input")[0].checked, "The checkbox 'King Fischer' should be checked");
+            this.end();
         }
     }
 });


### PR DESCRIPTION
It happens when some checkboxes are checked first : reopen the multiselected with the arrow down key showed all checkboxes unchecked.