### PR TITLE
fix #1436 Check widget destruction before reacting to data change

### DIFF
--- a/src/aria/html/Element.js
+++ b/src/aria/html/Element.js
@@ -22,7 +22,6 @@ var ariaUtilsDom = require("../utils/Dom");
 var ariaUtilsType = require("../utils/Type");
 var ariaWidgetLibsBindableWidget = require("../widgetLibs/BindableWidget");
 
-
 (function () {
     /**
      * This function is called when the widget validation fails. It sets every public function to Aria.empty so that we
@@ -273,7 +272,9 @@ var ariaWidgetLibsBindableWidget = require("../widgetLibs/BindableWidget");
              * @override
              */
             _notifyDataChange : function (args, propertyName) {
-                this.onbind(propertyName, this._transform(this._cfg.bind[propertyName].transform, args.newValue, "toWidget"), args.oldValue);
+                if (this._cfg) {
+                    this.onbind(propertyName, this._transform(this._cfg.bind[propertyName].transform, args.newValue, "toWidget"), args.oldValue);
+                }
             },
 
             /**

--- a/test/aria/html/HTMLTestSuite.js
+++ b/test/aria/html/HTMLTestSuite.js
@@ -33,5 +33,6 @@ Aria.classDefinition({
         this.addTests("test.aria.html.radioButton.ieBug.RadioButtonTestCase");
         this.addTests("test.aria.html.textarea.TextAreaTestSuite");
         this.addTests("test.aria.html.template.prematureDisposal.PrematureDisposalTest");
+        this.addTests("test.aria.html.radioButton.listenerAfterDestruction.ListenerCalledAfterDestructionTest");
     }
 });

--- a/test/aria/html/radioButton/listenerAfterDestruction/ListenerCalledAfterDestruction.tpl
+++ b/test/aria/html/radioButton/listenerAfterDestruction/ListenerCalledAfterDestruction.tpl
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.html.radioButton.listenerAfterDestruction.ListenerCalledAfterDestruction",
+    $wlibs : {
+        html : "aria.html.HtmlLibrary"
+    }
+}}
+
+    {macro main()}
+
+        {section {
+            bindRefreshTo : [{
+                to : "selectedValue",
+                inside : data
+            }],
+            macro : "content"
+        }/}
+
+    {/macro}
+
+    {macro content()}
+
+
+
+        {@html:RadioButton {
+            value : "a",
+            bind : {
+                selectedValue : {
+                    inside : data,
+                    to : "selectedValue"
+                }
+            }
+        }/}
+
+        {@html:RadioButton {
+            value : "b",
+            bind : {
+                selectedValue : {
+                    inside : data,
+                    to : "selectedValue"
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/html/radioButton/listenerAfterDestruction/ListenerCalledAfterDestructionTest.js
+++ b/test/aria/html/radioButton/listenerAfterDestruction/ListenerCalledAfterDestructionTest.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.html.radioButton.listenerAfterDestruction.ListenerCalledAfterDestructionTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this._data = {
+            selectedValue : "a"
+        };
+
+        this.setTestEnv({
+            template : "test.aria.html.radioButton.listenerAfterDestruction.ListenerCalledAfterDestruction",
+            data : this._data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            aria.utils.Json.setValue(this._data, "selectedValue", "b");
+
+            //this. assertLogsEmpty();
+            this.end();
+        }
+
+    }
+});


### PR DESCRIPTION
This commit introduces a check on the status of the widget before reacting to data change.

It can happen that the `_notifyDataChange` method is called after the widget destruction.