### PR TITLE
Disabled state in html:RadioButton widget

### DIFF
--- a/src/aria/html/DisabledTrait.js
+++ b/src/aria/html/DisabledTrait.js
@@ -49,7 +49,7 @@ module.exports = Aria.classDefinition({
          * @param {Object} oldValue Value of the property before the change happened
          */
         onDisabledBind : function (name, value, oldValue) {
-            if (name === "disabled") {
+            if (this._domElt && name === "disabled") {
                 this._domElt.disabled = value;
             }
         }

--- a/test/aria/html/HTMLTestSuite.js
+++ b/test/aria/html/HTMLTestSuite.js
@@ -34,5 +34,6 @@ Aria.classDefinition({
         this.addTests("test.aria.html.textarea.TextAreaTestSuite");
         this.addTests("test.aria.html.template.prematureDisposal.PrematureDisposalTest");
         this.addTests("test.aria.html.radioButton.listenerAfterDestruction.ListenerCalledAfterDestructionTest");
+        this.addTests("test.aria.html.radioButton.disabled.DisabledStateTest");
     }
 });

--- a/test/aria/html/radioButton/disabled/DisabledStateTest.js
+++ b/test/aria/html/radioButton/disabled/DisabledStateTest.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.html.radioButton.disabled.DisabledStateTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this._data = {
+            selectedValue : "a",
+            disabled : null
+        };
+
+        this.setTestEnv({
+            data : this._data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            aria.utils.Json.setValue(this._data, "disabled", true);
+            this.assertTrue(this.getElementById("rba").disabled);
+            this.assertTrue(this.getElementById("rbb").disabled);
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/html/radioButton/disabled/DisabledStateTestTpl.tpl
+++ b/test/aria/html/radioButton/disabled/DisabledStateTestTpl.tpl
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.html.radioButton.disabled.DisabledStateTestTpl",
+    $wlibs : {
+        html : "aria.html.HtmlLibrary"
+    }
+}}
+
+    {macro main()}
+
+
+        {@html:RadioButton {
+            id : "rba",
+            value : "a",
+            bind : {
+                selectedValue : {
+                    inside : data,
+                    to : "selectedValue"
+                },
+                disabled : {
+                    inside : data,
+                    to : "disabled"
+                }
+            }
+        }/}
+
+        {@html:RadioButton {
+            id : "rbb",
+            value : "b",
+            bind : {
+                selectedValue : {
+                    inside : data,
+                    to : "selectedValue"
+                },
+                disabled : {
+                    inside : data,
+                    to : "disabled"
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
When two `html:RadioButton`s disabled state is bound to the same non-initialized data model, an error was triggered.
This was due to the fact that when the `initWidget` method of the first one was called, a `setValue` was done on the data model, which triggered some listeners to modify the disabled state of the second one, for which the `initWidget` method had not been called yet, so that property `this._domElt` had not been set yet.