### PR TITLE
Changing the template compilation result to use the new syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "at-noder-converter": "1.0.1",
     "atpackager": "0.2.6",
     "gzip-js": "0.3.2",
-    "noder-js": "1.6.1"
+    "noder-js": "1.6.2"
   },
   "devDependencies": {
     "attester": "2.0.1",

--- a/src/aria/$resources.js
+++ b/src/aria/$resources.js
@@ -69,5 +69,9 @@ loadResourceFile.$preload = function (reference, staticFile) {
 
 module.exports = {
     module : loadResourceModule,
-    file : loadResourceFile
+    file : loadResourceFile,
+    unload : function (referencePath, staticFile, cleanCache, timestampNextTime, onlyIfError) {
+        var baseLogicalPath = resolveBaseLogicalPathResource(referencePath, staticFile);
+        return resMgr.unloadResource(baseLogicalPath, cleanCache, timestampNextTime, onlyIfError);
+    }
 };

--- a/src/aria/core/ResMgr.js
+++ b/src/aria/core/ResMgr.js
@@ -214,10 +214,13 @@ var resMgr = module.exports = Aria.classDefinition({
             }
         },
 
-        unloadResource : function (baseLogicalPath, cleanCache, timestampNextTime) {
+        unloadResource : function (baseLogicalPath, cleanCache, timestampNextTime, onlyIfError) {
             baseLogicalPath = normalizeBaseLogicalPath(baseLogicalPath);
             var res = resources[baseLogicalPath];
             if (res) {
+                if (onlyIfError && !(res.loading && res.loading.promise && res.loading.promise.isRejected())) {
+                    return false;
+                }
                 delete resources[baseLogicalPath];
                 var content = res.content;
                 if (content) {

--- a/src/aria/core/loaders/TplBasePreprocessor.js
+++ b/src/aria/core/loaders/TplBasePreprocessor.js
@@ -21,7 +21,14 @@ module.exports = function (classGenerator) {
         return new Promise(function (resolve, reject) {
             classGenerator.parseTemplate(content, false, function (res) {
                 if (res.classDef) {
-                    resolve(res.classDef);
+                    var logicalPath = res.logicalPath;
+                    if (logicalPath === fileName || require.resolve(logicalPath) === fileName) {
+                        resolve(res.classDef);
+                    } else {
+                        reject(new Error("Module '"
+                                + fileName
+                                + "' does not contain the expected Aria Templates class. Please check the classpath inside the file."));
+                    }
                 } else {
                     var errorDetails;
                     var log = aria.core.Log; // log may not be included in the bootstrap

--- a/src/aria/jsunit/Test.js
+++ b/src/aria/jsunit/Test.js
@@ -15,7 +15,6 @@
 var Aria = require("../Aria");
 var ariaCoreClassMgr = require("../core/ClassMgr");
 
-
 /**
  * Base class for all Test objects (Test Case and TestSuite). Defines the interface expected by the Test Runner
  */
@@ -262,6 +261,9 @@ module.exports = Aria.classDefinition({
          * @param {String} optMsg optional message to add to the error description
          */
         raiseError : function (err, optMsg) {
+            if (err.logDetails) {
+                err.logDetails();
+            }
             var msg = (err.description) ? err.description : err.message;
             msg = '[' + msg + ']';
             if (optMsg) {

--- a/src/aria/templates/ClassWriter.js
+++ b/src/aria/templates/ClassWriter.js
@@ -220,36 +220,34 @@ module.exports = Aria.classDefinition({
         /**
          * Add a list of classpath dependencies
          * @param {Array} dependencies list of classpath
+         * @param {String} extension dependencies extension (default: ".js")
          */
-        addDependencies : function (dependencies) {
-            for (var i = dependencies.length - 1; i >= 0; i--) {
-                this.addDependency(dependencies[i]);
+        addDependencies : function (dependencies, extension) {
+            if (dependencies) {
+                for (var i = dependencies.length - 1; i >= 0; i--) {
+                    this.addDependency(dependencies[i], extension);
+                }
             }
         },
 
         /**
          * Add a single classpath dependency
          * @param {String} dependency classpath
+         * @param {String} extension dependency extension (default: ".js")
          */
-        addDependency : function (dependency) {
-            this._dependencies[dependency] = 1;
+        addDependency : function (dependency, extension) {
+            var logicalPath = Aria.getLogicalPath(dependency, extension || ".js");
+            this._dependencies[logicalPath] = 1;
         },
 
         /**
-         * Get the list of unique dependencies as a string preceded by $dependencies.
-         * @return {String} empty string if no dependencies
+         * Writes the list of unique dependencies as a set of calls to require in the current block.
          */
-        getDependencies : function () {
-            var res = [];
+        writeDependencies : function () {
             for (var i in this._dependencies) {
                 if (this._dependencies.hasOwnProperty(i)) {
-                    res.push(this.stringify(i));
+                    this.writeln("require(", this.stringify(i), ");");
                 }
-            }
-            if (res.length > 0) {
-                return ["$dependencies: [", res.join(","), "],"].join('');
-            } else {
-                return "";
             }
         },
 
@@ -339,10 +337,7 @@ module.exports = Aria.classDefinition({
          * @param {Object} expression Expression to be converted into a string
          * @return {String}
          */
-        stringify : function (expression) {
-            this.stringify = ariaUtilsString.stringify;
-            return this.stringify(expression);
-        },
+        stringify : ariaUtilsString.stringify,
 
         /**
          * Create a new unique var name

--- a/test/aria/templates/ClassGeneratorTest.js
+++ b/test/aria/templates/ClassGeneratorTest.js
@@ -13,6 +13,29 @@
  * limitations under the License.
  */
 
+var getGeneratedClassDef = function (classDef) {
+    var code = "var module=arguments[2],require=module.require,exports=module.exports,__filename=module.filename,__dirname=module.dirname;\n"
+            + classDef + "\nreturn module.exports;";
+    var moduleObject = {
+        require : function (logicalPath) {
+            if (logicalPath == "ariatemplates/Aria") {
+                return {
+                    classDefinition : function (arg) {
+                        return arg;
+                    }
+                };
+            }
+            return {
+                requiredPath : logicalPath
+            };
+        },
+        filename : "",
+        dirname : "",
+        exports : {}
+    };
+    return Aria["eval"](code, null, moduleObject);
+};
+
 Aria.classDefinition({
     $classpath : "test.aria.templates.ClassGeneratorTest",
     $extends : "aria.jsunit.TestCase",
@@ -251,14 +274,10 @@ Aria.classDefinition({
 
         _onReceivingTemplateOKGenerated : function (args) {
             try {
-                var res = args.classDef;
-                // check the syntax of the class definition
-                res = res.replace("Aria.classDefinition", "return "); // do not really load the class (it would not be the
-                // proper way)
-                var classDef = Aria['eval'](res);
+                var classDef = getGeneratedClassDef(args.classDef);
                 // check class definition properties
                 this.assertTrue(classDef.$classpath == "test.aria.templates.test.TemplateOK");
-                this.assertTrue(classDef.$extends == "aria.templates.Template");
+                this.assertTrue(classDef.$extends.requiredPath == "ariatemplates/templates/Template.js");
                 this.assertTrue(typeof(classDef.$prototype.__$initTemplate) == "function");
                 this.assertTrue(typeof(classDef.$prototype.macro_main) == "function");
                 this.assertTrue(typeof(classDef.$prototype.macro_myMacroWithParams) == "function");
@@ -297,11 +316,7 @@ Aria.classDefinition({
 
         _onReceivingTemplateKO_RuntimeGenerated : function (args) {
             try {
-                var res = args.classDef;
-                // check the syntax of the class definition
-                res = res.replace("Aria.classDefinition", "return "); // do not really load the class (it would not be the
-                // proper way)
-                var classDef = Aria["eval"](res);
+                var classDef = getGeneratedClassDef(args.classDef);
                 var classDefProto = classDef.$prototype;
                 var tplProto = aria.templates.Template.prototype;
 

--- a/test/aria/templates/issue1319/TplDefinitionChangedTestCase.js
+++ b/test/aria/templates/issue1319/TplDefinitionChangedTestCase.js
@@ -16,6 +16,7 @@
 Aria.classDefinition({
     $classpath : 'test.aria.templates.issue1319.TplDefinitionChangedTestCase',
     $extends : 'aria.jsunit.TemplateTestCase',
+    $dependencies : ['aria.utils.Object'],
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
         this.setTestEnv({
@@ -37,22 +38,18 @@ Aria.classDefinition({
             });
 
             // Defined in the template:
-            this.assertJsonEquals(tplDef.$resources, {
-                calendarRes : "aria.resources.CalendarRes"
-            });
-            this.assertJsonEquals(tplDef.$texts, {
-                bootstrapTpl : "aria.ext.filesgenerator.tpl.Bootstrap"
-            });
+            this.assertJsonEquals(aria.utils.Object.keys(tplDef.$resources), ["calendarRes"]);
+            this.assertEquals(Aria.getClasspath(tplDef.$resources.calendarRes), "aria.resources.CalendarRes");
+            this.assertJsonEquals(aria.utils.Object.keys(tplDef.$texts), ["bootstrapTpl"]);
+            this.assertEquals(Aria.getClasspath(tplDef.$texts.bootstrapTpl), "aria.ext.filesgenerator.tpl.Bootstrap");
 
             // The template prototype has everything:
-            this.assertJsonEquals(tpl.$resources, {
-                calendarRes : "aria.resources.CalendarRes",
-                dateRes : "aria.resources.DateRes"
-            });
-            this.assertJsonEquals(tpl.$texts, {
-                bootstrapTpl : "aria.ext.filesgenerator.tpl.Bootstrap",
-                classTpl : "aria.ext.filesgenerator.tpl.Class"
-            });
+            this.assertJsonEquals(aria.utils.Object.keys(tpl.$resources).sort(), ["calendarRes", "dateRes"]);
+            this.assertEquals(Aria.getClasspath(tpl.$resources.calendarRes), "aria.resources.CalendarRes");
+            this.assertEquals(Aria.getClasspath(tpl.$resources.dateRes), "aria.resources.DateRes");
+            this.assertJsonEquals(aria.utils.Object.keys(tpl.$texts).sort(), ["bootstrapTpl", "classTpl"]);
+            this.assertEquals(Aria.getClasspath(tpl.$texts.bootstrapTpl), "aria.ext.filesgenerator.tpl.Bootstrap");
+            this.assertEquals(Aria.getClasspath(tpl.$texts.classTpl), "aria.ext.filesgenerator.tpl.Class");
             this.assertEquals(tpl.calendarRes, aria.resources.CalendarRes);
             this.assertEquals(tpl.dateRes, aria.resources.DateRes);
             this.assertEquals(tpl.bootstrapTpl, aria.ext.filesgenerator.tpl.Bootstrap);

--- a/test/aria/templates/reloadParentTemplate/ReloadParentTemplateTestCase.js
+++ b/test/aria/templates/reloadParentTemplate/ReloadParentTemplateTestCase.js
@@ -69,7 +69,7 @@ Aria.classDefinition({
                     + "test/aria/templates/reloadParentTemplate/reloadGrandParentTemplate/GrandParentTemplate";
 
             // Testing the initial values
-            this.assertTrue(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends == test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
+            this.assertEquals(Aria.getClasspath(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends), test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
             this.assertTrue(this.data.something === 0, "Data.something is not zero");
             this.assertTrue(this.data.anything === 0, "Data.anything is not zero");
 

--- a/test/aria/templates/reloadParentTemplate/reloadGrandParentTemplate/ReloadGrandParentTemplateTestCase.js
+++ b/test/aria/templates/reloadParentTemplate/reloadGrandParentTemplate/ReloadGrandParentTemplateTestCase.js
@@ -55,7 +55,7 @@ Aria.classDefinition({
                     + "test/aria/templates/reloadParentTemplate/reloadGrandParentTemplate/GrandParentTemplate";
 
             // Testing the initial values
-            this.assertTrue(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends == test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
+            this.assertEquals(Aria.getClasspath(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends), test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
             this.assertTrue(this.data.something === 0, "Data.something is not zero");
             this.assertTrue(this.data.anything === 0, "Data.anything is not zero");
 

--- a/test/aria/templates/reloadParentTemplate/usecase/ReloadBrotherTemplateTestCase.js
+++ b/test/aria/templates/reloadParentTemplate/usecase/ReloadBrotherTemplateTestCase.js
@@ -48,8 +48,8 @@ Aria.classDefinition({
             var url = Aria.rootFolderPath + "test/aria/templates/reloadParentTemplate/ParentTemplate";
 
             // Testing the initial values
-            this.assertTrue(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends == test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
-            this.assertTrue(test.aria.templates.reloadParentTemplate.usecase.BrotherTemplate.classDefinition.$extends == test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Brother doesn't extend parent");
+            this.assertEquals(Aria.getClasspath(test.aria.templates.reloadParentTemplate.ChildTemplate.classDefinition.$extends), test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Child doesn't extend parent");
+            this.assertEquals(Aria.getClasspath(test.aria.templates.reloadParentTemplate.usecase.BrotherTemplate.classDefinition.$extends), test.aria.templates.reloadParentTemplate.ParentTemplate.classDefinition.$classpath, "Brother doesn't extend parent");
             this.assertTrue(this.data.something === 0, "Data.something is not zero");
 
             // Listen for requests sent to the server


### PR DESCRIPTION
This pull request changes template class generators to generate code with the new syntax (with `require`) instead of the old one (with `$dependencies`).

A specific use case (tested by `test.aria.templates.reloadResources.ReloadResourcesTestCase`) requires some changes in noder-js (cf ariatemplates/noder-js#31). It is handled in a separate commit.

Before integrating this PR:
- [x] wait for ariatemplates/noder-js#31 to be integrated in noder-js
- [x] use the new version of noder-js
