### PR TITLE
feat Improvement for the data utility, now only validates the model once each time validateModel is called

### DIFF
--- a/src/aria/utils/StackHashMap.js
+++ b/src/aria/utils/StackHashMap.js
@@ -15,7 +15,6 @@
 var Aria = require("../Aria");
 var ariaUtilsType = require("./Type");
 
-
 (function () {
     /**
      * Counter so that each StackHashMap object has its own metadata, and they won't interfere with each other in case
@@ -190,6 +189,39 @@ var ariaUtilsType = require("./Type");
                     }
                 }
                 map[item.index] = item;
+            },
+
+            /**
+             * Checks if a key is in the StackHashMap object and returns true if it is found.
+             * @param {MultiTypes} key key which was used to add the entry in the StackHashMap object.
+             * @return {Boolean} True if there is an entry that was added with the same key.
+             */
+            isKey : function (key) {
+                var map = this._getMap(key, false);
+                if (map == null) {
+                    return false;
+                }
+                var item;
+                if (map == this._objectKeys) {
+                    item = key[this._metaDataName];
+                } else if (map != this._otherKeys) {
+                    item = map[key];
+                } else {
+                    for (var i in map) {
+                        if (map.hasOwnProperty(i)) {
+                            var elt = map[i];
+                            if (key === elt.key) {
+                                item = elt;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (item) {
+                    return true;
+                } else {
+                    return false;
+                }
             },
 
             /**

--- a/test/aria/utils/Data.js
+++ b/test/aria/utils/Data.js
@@ -69,6 +69,44 @@ Aria.classDefinition({
         },
 
         /**
+         * Tests validation of a model containing objects that have already been validated
+         */
+        test_validateAlreadyValidatedModelObjects : function () {
+            var data = {
+                param1 : {
+                    param1key : 'param1value'
+                }
+            };
+            data.param2 = data.param1;
+            var validator = new aria.utils.validators.Validator();
+            validator.count = 0;
+            validator.validate = function () {
+                this.count += 1;
+                return this._validationSucceeded();
+            };
+            aria.utils.Data.setValidator(data.param1, 'param1key', validator);
+            var messages = {};
+            aria.utils.Data.validateModel(data, messages);
+            this.assertTrue(validator.count === 1, "The validator should be called only once");
+            validator.$dispose();
+        },
+
+        /**
+         * Tests validation of a model containing recursive references
+         */
+        test_validateRecursiveModel : function () {
+            var data = {
+                param1 : 'value1'
+            };
+            data.param2 = data;
+            var validator = new aria.utils.validators.Validator();
+            aria.utils.Data.setValidator(data, 'param1', validator);
+            var messages = {};
+            aria.utils.Data.validateModel(data, messages);
+            validator.$dispose();
+        },
+
+        /**
          * Test the validateModel method
          */
         test_validateModel : function (group) {
@@ -282,7 +320,7 @@ Aria.classDefinition({
         test_createMessage : function () {
             // test default values
             var test = aria.utils.Data.createMessage("msg1");
-            this.assertTrue(test.code == null);
+            this.assertTrue(test.code === null);
             this.assertTrue(!("subMessages" in test));
             this.assertTrue(test.type == aria.utils.Data.TYPE_ERROR);
             this.assertTrue(test.localizedMessage == "msg1");
@@ -419,7 +457,7 @@ Aria.classDefinition({
             var check = (!res) ? false : true;
             this.assertFalse(check);
             aria.utils.Data.setValidatorProperties(validator, null, "onblur");
-            var res = aria.utils.Data.validateValue(data, "param1", null, null, "onblur"); // In this test a single
+            res = aria.utils.Data.validateValue(data, "param1", null, null, "onblur"); // In this test a single
             // validator has the same
             // event to validate as the
             // triggering event so

--- a/test/aria/utils/StackHashMapTest.js
+++ b/test/aria/utils/StackHashMapTest.js
@@ -24,6 +24,68 @@ Aria.classDefinition({
     $prototype : {
         /**
          * Add entries with keys of different types to a StackHashMap object (using the push method) and then check they
+         * exist in the StackHashMap using the isKey method.
+         */
+        testIsKey : function () {
+            var myMap = new aria.utils.StackHashMap();
+            var myKeyA = {};
+            var myKeyB = {};
+            var myKeyC = "string1";
+            var myKeyD = "string2";
+            var myKeyE = 3.5;
+            var myKeyF = null;
+            var myKeyG = undefined;
+            var myKeyANotFound = {};
+            var myKeyBNotFound = "stringA";
+            var myKeyCNotFound = 4;
+
+            // Check keys are not in map
+            this.assertFalse(myMap.isKey(myKeyA));
+            this.assertFalse(myMap.isKey(myKeyB));
+            this.assertFalse(myMap.isKey(myKeyC));
+            this.assertFalse(myMap.isKey(myKeyD));
+            this.assertFalse(myMap.isKey(myKeyE));
+            this.assertFalse(myMap.isKey(myKeyF));
+            this.assertFalse(myMap.isKey(myKeyG));
+            this.assertFalse(myMap.isKey(myKeyANotFound));
+            this.assertFalse(myMap.isKey(myKeyBNotFound));
+            this.assertFalse(myMap.isKey(myKeyCNotFound));
+
+            // Add keys to the map
+            myMap.push(myKeyA, {});
+            myMap.push(myKeyA, {});
+            myMap.push(myKeyB, {});
+            myMap.push(myKeyC, {});
+            myMap.push(myKeyC, {});
+            myMap.push(myKeyD, {});
+            myMap.push(myKeyE, {});
+            myMap.push(myKeyE, {});
+            myMap.push(myKeyF, {});
+            myMap.push(myKeyF, {});
+            myMap.push(myKeyG, {});
+            myMap.push(myKeyG, {});
+
+            // Check keys are in map
+            this.assertTrue(myMap.isKey(myKeyA));
+            this.assertTrue(myMap.isKey(myKeyB));
+            this.assertTrue(myMap.isKey(myKeyC));
+            this.assertTrue(myMap.isKey(myKeyD));
+            this.assertTrue(myMap.isKey(myKeyE));
+            this.assertTrue(myMap.isKey(myKeyF));
+            this.assertTrue(myMap.isKey(myKeyG));
+
+            // Check keys are not in map
+            this.assertFalse(myMap.isKey(myKeyANotFound));
+            this.assertFalse(myMap.isKey(myKeyBNotFound));
+            this.assertFalse(myMap.isKey(myKeyCNotFound));
+
+            // Clean up
+            myMap.removeAll();
+            myMap.$dispose();
+        },
+
+        /**
+         * Add entries with keys of different types to a StackHashMap object (using the push method) and then check they
          * are be retrieved correctly through the pop method.
          */
         testPushAndPop : function () {


### PR DESCRIPTION
This new feature adds a map to the data utility which stores data model objects that have been validated.  The map is used to check and enforce a model object does not get validated twice.  This resolves the following:

- recursive references within a data model object leading to infinite loops and RangeErrors
- a data model object referencing a previously validated data model object

**Illustration**:

          * (root)
        /   \
       A     B (reference to A)  
      /   
     C (reference to *)