### PR TITLE
Avoid useless recursion in aria.utils.Json.inject if objects are identical

### DIFF
--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -18,7 +18,6 @@ var ariaUtilsType = require("./Type");
 var ariaUtilsArray = require("./Array");
 var ariaUtilsObject = require("./Object");
 
-
 (function () {
 
     // shortcut to array & type utils
@@ -816,6 +815,10 @@ var ariaUtilsObject = require("./Object");
 
                 if (!allArray && !allObject) {
                     return false;
+                }
+
+                if (src === target) {
+                    return true;
                 }
 
                 if (allArray) {

--- a/test/aria/utils/JsonTest.js
+++ b/test/aria/utils/JsonTest.js
@@ -408,6 +408,21 @@ Aria.classDefinition({
             aria.utils.Json.inject(aria.utils.Json.copy(source), withMergeResult, true);
             this.assertJsonEquals(withMerge, withMergeResult);
 
+            // test identical objects recursion
+            var a = {
+                b : "c"
+            };
+            a.d = a;
+            var objOne = {
+                a : a
+            };
+            var objTwo = {
+                a : a
+            };
+
+            // Just test that the "Maximum call stack size exceeded" error is not raised
+            aria.utils.Json.inject(objOne, objTwo, true);
+
         },
 
         /**
@@ -1424,14 +1439,17 @@ Aria.classDefinition({
         },
 
         testKeysSimple : function () {
-            this.assertJsonEquals(['mykey'], aria.utils.Json.keys({ mykey: 'value' }));
+            this.assertJsonEquals(['mykey'], aria.utils.Json.keys({
+                mykey : 'value'
+            }));
         },
 
         testKeysWithListeners : function () {
-            var listened = { mykey: 'value' };
+            var listened = {
+                mykey : 'value'
+            };
             aria.utils.Json.addListener(listened, 'mykey', {
-                fn: function () {
-                }
+                fn : function () {}
             });
             this.assertJsonEquals(['mykey'], aria.utils.Json.keys(listened));
         }


### PR DESCRIPTION
If you inject an object into another setting the merge flag to true, if the objects are identical and contain cyclic references, then the maximum call stack size is exceeded.