### PR TITLE
feat #1452 Classic Test Runner: explicitly declare wlibs

### DIFF
--- a/src/aria/tester/runner/view/config/Config.tpl
+++ b/src/aria/tester/runner/view/config/Config.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.config.Config',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {value:200},
     $height : {min:125},

--- a/src/aria/tester/runner/view/filter/Filter.tpl
+++ b/src/aria/tester/runner/view/filter/Filter.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.filter.Filter',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {min:178},
     $height : {value:25},

--- a/src/aria/tester/runner/view/header/Header.tpl
+++ b/src/aria/tester/runner/view/header/Header.tpl
@@ -16,10 +16,11 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.header.Header',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {"min":178},
     $height : {value:50},
-     $css:['aria.tester.runner.view.header.HeaderCSS']
+    $css:['aria.tester.runner.view.header.HeaderCSS']
 }}
     {macro main()}
         <div id="header">

--- a/src/aria/tester/runner/view/links/Links.tpl
+++ b/src/aria/tester/runner/view/links/Links.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.links.Links',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {value:200},
     $height : {min:125},

--- a/src/aria/tester/runner/view/logo/Logo.tpl
+++ b/src/aria/tester/runner/view/logo/Logo.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.logo.Logo',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:false,
     $width : {value:200},
     $height : {value:90},

--- a/src/aria/tester/runner/view/main/Main.tpl
+++ b/src/aria/tester/runner/view/main/Main.tpl
@@ -16,7 +16,8 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.main.Main',
-     $css:['aria.tester.runner.view.main.MainCSS'],
+    $css:['aria.tester.runner.view.main.MainCSS'],
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {"min":180},
     $height : {"min":342}

--- a/src/aria/tester/runner/view/mini/Mini.tpl
+++ b/src/aria/tester/runner/view/mini/Mini.tpl
@@ -16,7 +16,8 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.mini.Mini',
-     $css:['aria.tester.runner.view.mini.MiniCSS'],
+    $css:['aria.tester.runner.view.mini.MiniCSS'],
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {"min":180},
     $height : {"min":342}

--- a/src/aria/tester/runner/view/monitor/Monitor.tpl
+++ b/src/aria/tester/runner/view/monitor/Monitor.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.monitor.Monitor',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:false,
     $width : {min:180},
     $height : {min:282},

--- a/src/aria/tester/runner/view/nav/Nav.tpl
+++ b/src/aria/tester/runner/view/nav/Nav.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.nav.Nav',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:false,
     $width : {value:200},
     $height : {min:342},

--- a/src/aria/tester/runner/view/normal/Normal.tpl
+++ b/src/aria/tester/runner/view/normal/Normal.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.normal.Normal',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {"min":390},
     $height : {"min":342}

--- a/src/aria/tester/runner/view/popup/Popup.tpl
+++ b/src/aria/tester/runner/view/popup/Popup.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.popup.Popup',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $css:['aria.tester.runner.view.popup.PopupCSS']
 }}

--- a/src/aria/tester/runner/view/popup/generic/Generic.tpl
+++ b/src/aria/tester/runner/view/popup/generic/Generic.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.popup.generic.Generic',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true
 }}
     {macro main()}

--- a/src/aria/tester/runner/view/popup/options/Options.tpl
+++ b/src/aria/tester/runner/view/popup/options/Options.tpl
@@ -18,6 +18,7 @@
     $classpath:'aria.tester.runner.view.popup.options.Options',
     $extends:'aria.tester.runner.view.popup.generic.Generic',
     $css : ['aria.tester.runner.view.popup.options.OptionsCSS'],
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true
 }}
     {macro displayPopupTitle()}

--- a/src/aria/tester/runner/view/popup/report/Report.tpl
+++ b/src/aria/tester/runner/view/popup/report/Report.tpl
@@ -18,6 +18,7 @@
     $classpath:'aria.tester.runner.view.popup.report.Report',
     $extends:'aria.tester.runner.view.popup.generic.Generic',
     $css : ['aria.tester.runner.view.popup.report.ReportCSS'],
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true
 }}
     {macro displayPopupTitle()}

--- a/src/aria/tester/runner/view/popup/warning/Warning.tpl
+++ b/src/aria/tester/runner/view/popup/warning/Warning.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.popup.warning.Warning',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $extends:'aria.tester.runner.view.popup.generic.Generic',
     $hasScript:true,
     $css : ['aria.tester.runner.view.popup.warning.WarningCSS']

--- a/src/aria/tester/runner/view/report/Report.tpl
+++ b/src/aria/tester/runner/view/report/Report.tpl
@@ -16,6 +16,7 @@
 // TODOC
 {Template {
     $classpath:'aria.tester.runner.view.report.Report',
+    $wlibs : {"aria" : "aria.widgets.AriaLib"},
     $hasScript:true,
     $width : {"min":178},
     $height : {"min":203},


### PR DESCRIPTION
Explicitly declare dependencies so that an application using the runner does not need to depend on AriaLib in order to run the tester

See https://github.com/attester/attester/pull/124

I tested the fix on our application;
When calling  in our TestBootstrap.js `aria.core.AppEnvironment.updateEnvironment({   defaultWidgetLibs: { ...`  without AriaLib it fails with TEMPLATE ERROR when loading Classic Test Runner. With this commit, the test runner loads fine even without AriaLib added on our side.