### PR TITLE
feat atLoader injector script to load AT packages

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -34,8 +34,9 @@ module.exports = function (grunt) {
     var notAtExtensions = atExtensions.map(function (value) {
         return '!' + value;
     });
+    var atLoaderFileName = 'aria/atLoader-' + packagingSettings.pkg.version + '.js';
     var hashFiles = atExtensions.concat(['aria/core/transport/iframeSource*', 'aria/utils/FrameATLoaderHTML*',
-            '**/*.swf', '**/*.jnlp', '!aria/css/**', '!<%= atbuildOptions.outputBootstrapFile %>']).concat(packagingSettings.prod.hashIncludeFiles);
+            '**/*.swf', '**/*.jnlp', '!aria/css/**', '!' + atLoaderFileName, '!<%= atbuildOptions.outputBootstrapFile %>']).concat(packagingSettings.prod.hashIncludeFiles);
 
     grunt.config.set('atpackager.prod', {
         options : {
@@ -137,6 +138,15 @@ module.exports = function (grunt) {
                         }
                     }, grunt.config.get('atbuildOptions.checkPackaged') ? 'CheckPackaged' : null],
             packages : [{
+                name: atLoaderFileName,
+                files: ['aria/atLoader.js'],
+                builder: {
+                                type : 'Concat',
+                                cfg : {
+                                    header : packagingSettings.licenseMin
+                                }
+                            }
+            },{
                         name : '<%= atbuildOptions.outputBootstrapFile %>',
                         builder : {
                             type : 'NoderBootstrapPackage',

--- a/src/aria/atLoader.js
+++ b/src/aria/atLoader.js
@@ -1,0 +1,58 @@
+/* global Aria */
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+
+    /**
+     * atLoader.js
+     * this script is used to synchronously load Aria Templates classes that are not included
+     * in the AT package.
+     * It is sufficient to insert the array of classes as the innerHTML of the tag 
+     * used to load this script.
+     * All the classes' dependencies have to be added to this array.
+     * No comments or other sintax is allowed in it except for the array itself.
+     *
+     * i.e:
+     *     <script type="text/javascript" src="../../src/aria/atLoader.js">
+     *           ["aria/utils/Number.js", "aria/utils/environment/Number.js"]
+     *     </script>
+     */
+
+    var document = Aria.$window.document;
+
+    var getLastScript = function () {
+        // When not in the "loading" mode, it is not reliable to use the last script to find the configuration
+        // IE is using the "interactive" mode instead of "loading".
+        if (document.readyState == "loading" || document.readyState == "interactive") {
+            var scripts = document.getElementsByTagName('script');
+            return scripts[scripts.length - 1];
+        }
+    };
+
+    var script = document.currentScript || getLastScript();
+
+    var dependencies = Aria['eval']('return ' + aria.utils.String.trim(script.innerHTML));
+    var map = {};
+
+    for (var i = 0, l = dependencies.length; i < l; i++) {
+        var dep = aria.core.DownloadMgr.resolveURL(dependencies[i]);
+        if (map[dep] !== true) {
+            document.write('<script type=\"text/javascript\" src=\"' + dep + '\"></script>');
+            map[dep] = true;
+        }
+    }
+
+})();

--- a/src/aria/utils/FrameATLoader.js
+++ b/src/aria/utils/FrameATLoader.js
@@ -297,6 +297,17 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Returns the address of the framework JS file.
+         * @return {String}
+         */
+        getFrameworkHref: function () {
+            if (this.frameworkHref == null) {
+                this.frameworkHref = this._findScriptPattern(this.frameworkHrefPattern);
+            }
+            return this.frameworkHref;
+        },
+
+        /**
          * Set the following property if they are not defined already: bootRootFolderPath, frameworkHref, frameworkJS
          * @param {aria.core.CfgBeans:Callback} cb callback called when the properties are set.
          */
@@ -309,12 +320,10 @@ module.exports = Aria.classDefinition({
                 this.$callback(cb);
                 return;
             }
+            this.getFrameworkHref();
             if (this.frameworkHref == null) {
-                this.frameworkHref = this._findScriptPattern(this.frameworkHrefPattern);
-                if (this.frameworkHref == null) {
-                    this.$callback(cb, true);
-                    return;
-                }
+                this.$callback(cb, true);
+                return;
             }
             this.$onOnce({
                 bootstrapLoaded : cb

--- a/test/MainTestSuite.js
+++ b/test/MainTestSuite.js
@@ -23,6 +23,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.AriaTest");
+        this.addTests("test.aria.atLoader.AtLoaderTest");
         this.addTests("test.aria.core.CoreTestSuite");
         this.addTests("test.aria.dom.DomTestSuite");
         this.addTests("test.aria.embed.EmbedTestSuite");

--- a/test/aria/atLoader/AtLoaderTest.js
+++ b/test/aria/atLoader/AtLoaderTest.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.atLoader.AtLoaderTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.FrameATLoader", "aria.core.DownloadMgr"],
+    $prototype : {
+        testAsyncCheckAtLoader : function () {
+            var window = Aria.$window;
+            var document = window.document;
+
+            window.frameworkHref = aria.utils.FrameATLoader.getFrameworkHref();
+            window.atLoaderHref = window.frameworkHref.replace(/\/([^\/]+)-([^\/-]+\.js)$/, "/atLoader-$2");
+            window.atLoaderScript = aria.core.DownloadMgr.resolveURL("test/aria/atLoader/atLoader.js");
+            this.iFrame = document.createElement("iframe");
+            this.iFrame.src = aria.core.DownloadMgr.resolveURL("test/aria/atLoader/atLoader.html");
+            this.iFrame.style.cssText = "position: absolute; left: 10px; top: 100px; width: 500px; height: 500px;";
+            document.body.appendChild(this.iFrame);
+            this.waitFor({
+                condition : function () {
+                    return this.iFrame.contentWindow.document.getElementById("result");
+                },
+                callback : function () {
+                    var result = this.iFrame.contentWindow.document.getElementById("result").innerHTML;
+                    this.assertEquals('test PASSED', result, '%1 is not the expected result: %2');
+                    this.notifyTestEnd("testAsyncCheckAtLoader");
+                }
+            });
+        },
+        tearDown : function () {
+            if (this.iFrame) {
+                Aria.$window.document.body.removeChild(this.iFrame);
+            }
+            this.iFrame = null;
+        }
+    }
+});

--- a/test/aria/atLoader/atLoader.html
+++ b/test/aria/atLoader/atLoader.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Test - AtLoader</title>
+    <style>
+        .success {
+          background-color: green;
+        }
+        .error {
+          background-color: red;
+        }
+    </style>
+    <script>
+        document.write('<base href="' + window.parent.location.href + '">');
+        document.write('<script type="text/javascript" src="' + window.parent.frameworkHref + '"></scri'+'pt>');
+        // Load aria.utils.Number with its dependencies:
+        document.write('<script type="text/javascript" src="' + window.parent.atLoaderHref + '">["aria/utils/Number.js", "aria/utils/environment/Number.js"]</scri'+'pt>');
+    </script>
+  </head>
+  <body>
+    <h1>TEST AtLoader</h1>
+    <h2>Injecting classes: ["aria/utils/Number.js", "aria/utils/environment/Number.js"]</h2>
+    <script>
+        document.write('<script type="text/javascript" src="' + window.parent.atLoaderScript + '"></scri'+'pt>');
+    </script>
+  </body>
+</html>

--- a/test/aria/atLoader/atLoader.js
+++ b/test/aria/atLoader/atLoader.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+
+    var err = [],
+        document = Aria.$window.document;
+
+    function checkEqual(arg1, arg2, value1, value2) {
+        if (value1 !== value2) {
+            var msg = arg1 + ' is ' + value1 + ' while ' + arg2 + ' is ' + value2;
+            err.push(msg);
+            console.error(msg);
+        }
+    }
+
+    function showResult() {
+        var res, className;
+        if (err.length > 0) {
+            err.unshift('test FAILED');
+            res = err.join('<br>');
+            className = 'error';
+        } else {
+            res = 'test PASSED';
+            className = 'success';
+        }
+        document.write('<h2 id="result" class="' + className + '">' + res + '</h2>');
+    }
+
+    function testInjection() {
+        var num = "55",
+            convertedNum;
+
+        Aria.load({
+            classes : ['aria.utils.Number']
+        });
+
+        try {
+            convertedNum = aria.utils.Number.toNumber(num);
+        } catch (e) {
+            console.error(e.message);
+            err.push(e.message);
+        }
+
+        checkEqual('convertedNum', 'num', convertedNum, 55);
+    }
+
+    testInjection();
+    showResult();
+
+})();


### PR DESCRIPTION
atLoader is used to synchronously load Aria Templates classes that are not included
in the AT package.
It is sufficient to insert the array of classes as the innerHTML of the tag
used to load this script.
All the classes' dependencies have to be added to this array.
No comments or other sintax is allowed in it except for the array itself.