### PR TITLE
Fixing several movable dialog tests in IE 7 and IE 8

### DIFF
--- a/src/aria/utils/overlay/Overlay.js
+++ b/src/aria/utils/overlay/Overlay.js
@@ -15,7 +15,6 @@
 var Aria = require("../../Aria");
 var ariaUtilsDom = require("../Dom");
 
-
 /**
  * This class creates an overlay and keeps it positioned above a given HTML element
  * @class aria.utils.overlay.Overlay
@@ -105,8 +104,8 @@ module.exports = Aria.classDefinition({
             var overlayStyle = overlay.style;
             var positions = ["Top", "Right", "Bottom", "Left"], singleBorder, border = {};
             for (var i = 0, posCount = positions.length; i < posCount; i++) {
-                singleBorder = dom.getStyle(overlay, "border" + positions[i] + "Width").split("px")[0];
-                border[positions[i].toLowerCase()] = singleBorder ? +singleBorder : 0;
+                singleBorder = + dom.getStyle(overlay, "border" + positions[i] + "Width").split("px")[0];
+                border[positions[i].toLowerCase()] = isNaN(singleBorder) ? 0 : singleBorder;
             }
             var geometry = ariaUtilsDom.getGeometry(element);
             if (geometry) {


### PR DESCRIPTION
In IE 7 and 8, `aria.utils.Dom.getStyle(domElt, "borderTopWidth")` can return something like `"medium"`, which was unexpected by the `aria.utils.overlay.Overlay._setInPosition` method, which would then fail with an "Invalid argument" exception (when setting "NaNpx" for the `width` or `height` property of the overlay style).

After 604f33b756e5796dfd43ef5b8f1e8051047309bd, now that an Overlay is created by default for movable dialogs, this problem made several movable dialog tests fail in IE 7 and IE 8, such as:

test.aria.widgets.container.dialog.movable.test1.MovableDialogTestCase
test.aria.widgets.container.dialog.movable.test2.MovableDialogTestCaseTwo
test.aria.widgets.container.dialog.movable.test3.MovableDialogTestCaseThree
test.aria.widgets.container.dialog.movable.test4.MovableDialogTestCaseFour
test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive
test.aria.widgets.container.dialog.movable.issue367.MovableDialogTestCase

This commit fixes the issue about the unexpected value, which fixes the above tests.