### PR TITLE
Fixing Drag class dispose process

### DIFF
--- a/src/aria/jsunit/RobotJavaSelenium.js
+++ b/src/aria/jsunit/RobotJavaSelenium.js
@@ -44,7 +44,10 @@ module.exports = Aria.classDefinition({
          */
         this.offsetY = 0;
 
-        if (Aria.$frameworkWindow.top.attester) {
+        if (Aria.$frameworkWindow.top.attester && Aria.$frameworkWindow.top.location !== Aria.$frameworkWindow.location) {
+            // Aria.$frameworkWindow.top.location === Aria.$frameworkWindow.location means we are not running
+            // in the attester iframe, so there is no need to apply the extra offset.
+            // Otherwise, we are running in an iframe. Let's apply the offset:
             this.offsetY = 32; // height of the header in attester
         }
 

--- a/src/aria/utils/Mouse.js
+++ b/src/aria/utils/Mouse.js
@@ -256,6 +256,15 @@ var ariaCoreBrowser = require("../core/Browser");
              */
             stopListen : function (gesture, id) {
                 if (this._idList[gesture]) {
+                    var element = this._idList[gesture][id];
+                    if (gesture == "drag" && element && element == this._activeDrag) {
+                        // the element being dragged has been disposed,
+                        // terminate the drag:
+                        this._dragStartPosition = null;
+                        disconnectMouseEvents(this);
+                        this._candidateForDrag = null;
+                        this._activeDrag = null;
+                    }
                     delete this._idList[gesture][id];
                 }
             },

--- a/src/aria/utils/dragdrop/Drag.js
+++ b/src/aria/utils/dragdrop/Drag.js
@@ -224,11 +224,15 @@ var document = Aria.$frameworkWindow.document;
             if (this.proxy && this.proxy.overlay) {
                 this.proxy.$dispose();
             }
+            if (this.overlay) {
+                this.overlay.$dispose();
+                this.overlay = null;
+            }
             this.element = null;
             this.handle = null;
             this.cursor = null;
             this.proxy = null;
-            ariaUtilsMouse.stopListen("drag", this);
+            ariaUtilsMouse.stopListen("drag", this.listenerId);
         },
         $prototype : {
 
@@ -462,9 +466,10 @@ var document = Aria.$frameworkWindow.document;
                 var element = this.getElement();
                 // This is to handle if there is a scroll
                 element.onselectstart = Aria.returnTrue;
-                if (this.dragOverIFrame) {
+                if (this.overlay) {
                     // remove overlay here
                     this.overlay.$dispose();
+                    this.overlay = null;
                 }
                 if (this.proxy && this.proxy.overlay) {
                     element.style.top = (this._elementInitialPosition.top + this._movableGeometry.y - this._movableInitialGeometry.y)

--- a/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollTestCase.js
@@ -84,7 +84,19 @@ Aria.classDefinition({
             this.assertEquals(parentGeometry.x, overlayGeometry.x, "The overlay xpos is not the same as the dialog one. Expected %1, got %2.");
             this.assertEquals(parentGeometry.y, overlayGeometry.y - 10, "The overlay ypos is not 10px (resize) more than the dialog one. Expected %1, got %2.");
 
-            this.end();
+            var activeDragInstance = aria.utils.Mouse._activeDrag;
+            var activeDragId = activeDragInstance.listenerId;
+            this.assertEquals(aria.utils.Mouse._idList.drag[activeDragId], activeDragInstance);
+
+            this._disposeTestTemplate();
+
+            this.assertNull(aria.utils.Mouse._activeDrag, "There is still an active drag after the template is disposed.");
+            this.assertFalsy(aria.utils.Mouse._idList.drag[activeDragId], "Drag instance was not unregistered.");
+
+            this.synEvent.execute([["mouseRelease", this._robot.BUTTON1_MASK]], {
+                fn : this.end,
+                scope : this
+            });
         },
 
         _getHandle : function (dialogId, index) {


### PR DESCRIPTION
This commit fixes the following error:
```
Unable to get property 'replace' of undefined or null reference
```
which happened when running the following test: `test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase`