### PR TITLE
aria.utils.Dom.calculatePosition extra pixels in IE 7

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -661,13 +661,15 @@ module.exports = Aria.classDefinition({
 
             if (obj.getBoundingClientRect && !stopAbsolute) {
                 // IE getBoundingClientRect have extra pixels.
-                var shift = browser.isIE7 ? 2 : 0;
+                // cf https://github.com/jquery/jquery/blob/master/src/offset.js#L101-106
+                var shiftLeft = browser.isIE7 ? document.documentElement.clientLeft : 0;
+                var shiftTop = browser.isIE7 ? document.documentElement.clientTop : 0;
                 // IE throws an error if the element is not in DOM
                 try {
                     var rect = obj.getBoundingClientRect();
                     scrollNotIncluded = false;
-                    offsetLeft = rect.left - shift;
-                    offsetTop = rect.top - shift;
+                    offsetLeft = rect.left - shiftLeft;
+                    offsetTop = rect.top - shiftTop;
 
                 } catch (er) {
                     offsetLeft = 0;


### PR DESCRIPTION
This commit improves the detection of the extra pixels returned by `getBoundingClientRect` in IE 7.

cf http://chunghe.blogspot.fr/2008/03/15-use-getboundingclientrect-if.html
and https://github.com/jquery/jquery/blob/master/src/offset.js#L101-106