### PR TITLE
Adding /src/aria/core/useragent/ua-parser.js to npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 /src/aria/bootstrap.js
 /src/aria/bootstrap-node.js
 /src/aria/noderError/
+/src/aria/core/useragent/ua-parser.js

--- a/src/aria/core/useragent/.gitignore
+++ b/src/aria/core/useragent/.gitignore
@@ -1,1 +1,0 @@
-ua-parser.js


### PR DESCRIPTION
As `/src/aria/core/useragent/ua-parser.js` was ignored through a `.gitignore` file which had no corresponding `.npmignore` file, the `.gitignore` file was used as the default `.npmignore`, leading to /src/aria/core/useragent/ua-parser.js not being included in the npm package (which makes the yeoman generator `yo ariatemplates` fail, cf http://ariatemplates.com/forum/showthread.php?tid=267).