### PR TITLE
Repositions the popup of the multiselect when clicking on an option

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -910,13 +910,13 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Repositions the popup based on the dom reference, if the dom reference is no longer visible then closes the
-         * popup and blurs the dom reference.
-         * @param {Object} event scroll event that triggered the handler.
+         * Updates the position of the popup based on the dom reference. If the dom reference is no longer visible,
+         * then the popup is made temporarily invisible (until updatePosition is called again with a visible dom
+         * reference).
          */
-        _isScrolling : function () {
+        updatePosition : function () {
             var domReference = this.reference;
-            if (domReference) {
+            if (domReference && this.isOpen) {
 
                 var geometry = ariaUtilsDom.getGeometry(domReference);
                 var referenceIsInViewport = geometry && (ariaUtilsDom.isInViewport({

--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -287,20 +287,27 @@ var ariaUtilsDelegate = require("../utils/Delegate");
             },
 
             /**
+             * Updates the position of all opened popups.
+             */
+            updatePositions : function () {
+                for (var i = this.openedPopups.length - 1; i >= 0; i--) {
+                    var popup = this.openedPopups[i];
+                    popup.updatePosition();
+                }
+            },
+
+            /**
              * handles the scroll for the popup
              * @param {Object} Event that triggered the scroll.
              */
             _onScroll : function (event) {
-                for (var i = this.openedPopups.length - 1; i >= 0; i--) {
-                    var popup = this.openedPopups[i];
-                    if (event.type === "mousewheel") {
-                        ariaCoreTimer.addCallback({
-                            fn : popup._isScrolling,
-                            scope : popup
-                        });
-                    } else if (event.type === "scroll") {
-                        popup._isScrolling();
-                    }
+                if (event.type === "mousewheel") {
+                    ariaCoreTimer.addCallback({
+                        fn : this.updatePositions,
+                        scope : this
+                    });
+                } else if (event.type === "scroll") {
+                    this.updatePositions();
                 }
             },
 

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -187,6 +187,10 @@ module.exports = Aria.classDefinition({
                     } else if (repositionDropDown && this._dropdownPopup) {
                         this._closeDropdown();
                         this._openDropdown();
+                        // Note: an alternative here would be to call this._dropdownPopup.updatePosition()
+                        // instead of closing and re-opening the popup. This would avoid loosing
+                        // the current scrolling position in some cases, but, it could perhaps introduce
+                        // some regressions in other cases.
                     }
                 }
             }

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -114,6 +114,9 @@ module.exports = Aria.classDefinition({
                 stopValueProp : !this._instantBind
             };
             this._reactToControllerReport(report, arg);
+            if (this._instantBind && this._dropdownPopup) {
+                this._dropdownPopup.updatePosition();
+            }
         },
 
         /**

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -35,6 +35,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.multiselect.upArrowKey.test1.MultiSelect",
                 "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect",
                 "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim",
-                "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase"];
+                "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase",
+                "test.aria.widgets.form.multiselect.popupReposition.MultiSelect"];
     }
 });

--- a/test/aria/widgets/form/multiselect/popupReposition/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/popupReposition/MultiSelect.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.popupReposition.MultiSelect",
+    $dependencies : ["aria.utils.Dom"],
+    $extends : "aria.jsunit.MultiSelectTemplateTestCase",
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test.
+         */
+        runTemplateTest : function () {
+            this.toggleMultiSelectOn("ms1", this._step1);
+        },
+
+        _step1 : function () {
+            this.initialPosition = this.checkPopupAligned();
+            this.toggleMultiSelectOption("ms1", 100, this._step2);
+        },
+
+        _step2 : function () {
+            var position = this.checkPopupAligned();
+            this.assertJsonEquals(this.initialPosition, position);
+            this.toggleMultiSelectOption("ms1", 101, this._step3);
+        },
+
+        _step3 : function () {
+            var emptyPosition = this.emptyPosition = this.checkPopupAligned();
+            var initialPosition = this.initialPosition;
+
+            this.assertEquals(initialPosition.popup.width, emptyPosition.popup.width);
+            this.assertEquals(initialPosition.popup.height, emptyPosition.popup.height);
+            this.assertEquals(initialPosition.field.width, emptyPosition.field.width);
+            this.assertEquals(initialPosition.field.height, emptyPosition.field.height);
+
+            this.assertEquals(initialPosition.popup.y, emptyPosition.popup.y);
+            this.assertEquals(initialPosition.field.y, emptyPosition.field.y);
+
+            this.assertTrue(initialPosition.popup.x <= emptyPosition.popup.x);
+            this.assertTrue(initialPosition.field.x <= emptyPosition.field.x);
+
+            this.toggleMultiSelectOption("ms1", 101, this._step4);
+        },
+
+        _step4 : function () {
+            var position = this.checkPopupAligned();
+            this.assertJsonEquals(this.initialPosition, position);
+            this.toggleMultiSelectOption("ms1", 101, this._step5);
+        },
+
+        _step5 : function () {
+            var position = this.checkPopupAligned();
+            this.assertJsonEquals(this.emptyPosition, position);
+            this.checkPopupAligned();
+            this.end();
+        },
+
+        checkPopupAligned : function () {
+            var ms = this.getWidgetInstance("ms1");
+            var popup = ms._dropdownPopup.domElement;
+            var field = ms._frame._frame._domElt;
+            var popupGeometry = aria.utils.Dom.getGeometry(popup);
+            var fieldGeometry = aria.utils.Dom.getGeometry(field);
+            this.assertEquals(popupGeometry.x, fieldGeometry.x);
+            return {
+                popup: popupGeometry,
+                field: fieldGeometry
+            };
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/popupReposition/MultiSelectStyle.tpl.css
+++ b/test/aria/widgets/form/multiselect/popupReposition/MultiSelectStyle.tpl.css
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath : "test.aria.widgets.form.multiselect.popupReposition.MultiSelectStyle"
+}}
+
+    {macro main()}
+        .myOuterContainer {
+            overflow: auto;
+            width: 500px;
+            height: 300px;
+            margin: 10px;
+            border: 1px solid black;
+            text-align: center;
+        }
+
+        .myInnerContainer {
+            display: inline-block;
+            background-color: white;
+            padding: 10px;
+            width: 300px;
+            text-align: left;
+        }
+    {/macro}
+{/CSSTemplate}

--- a/test/aria/widgets/form/multiselect/popupReposition/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/popupReposition/MultiSelectTpl.tpl
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.multiselect.popupReposition.MultiSelectTpl",
+    $css : ["test.aria.widgets.form.multiselect.popupReposition.MultiSelectStyle"],
+    $hasScript : true
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+        <div class="myOuterContainer">
+            <div class="myInnerContainer">
+                {@aria:MultiSelect {
+                    label : "My Multi-select:",
+                    id : "ms1",
+                    items : filter.options,
+                    instantBind: true,
+                    bind : {
+                        value : {
+                            to : "value",
+                            inside : filter
+                        }
+                    }
+                }/}
+                {section {
+                    bindRefreshTo : [{inside : filter, to : "value"}],
+                    macro : "list"
+                }/}
+            </div>
+        </div>
+  {/macro}
+
+  {macro list()}
+      <table>
+          <tbody>
+              {foreach item in getFilteredList()}
+                  <tr><td>${item.name}</td><td>${item.type}</td></tr>
+              {/foreach}
+          </tbody>
+      </table>
+  {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/multiselect/popupReposition/MultiSelectTplScript.js
+++ b/test/aria/widgets/form/multiselect/popupReposition/MultiSelectTplScript.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.multiselect.popupReposition.MultiSelectTplScript',
+    $dependencies : ['aria.utils.Array'],
+    $constructor : function () {
+        var types = [];
+        var list = [];
+        for (var i = 0; i < 100; i++) {
+            types.push({
+                label: "Type dat" + i,
+                value: "Type dat" + i
+            });
+            list.push({
+                name: "File " + (2*i),
+                type: "Text"
+            });
+            list.push({
+                name: "File " + (2*i+1),
+                type: "Image"
+            });
+        }
+        types.push({label: "Text", value: "Text"});
+        types.push({label: "Image", value: "Image"});
+        this.filter = {
+            value: ["Text", "Image"],
+            options: types
+        };
+        this.list = list;
+    },
+    $prototype : {
+        getFilteredList : function () {
+            var list = this.list;
+            var filter = this.filter.value;
+            var res = [];
+            for (var i = 0, l = list.length; i < l; i++) {
+                var curItem = list[i];
+                if (aria.utils.Array.indexOf(filter, curItem.type) > -1) {
+                    res.push(curItem);
+                }
+            }
+            return res;
+        }
+    }
+});


### PR DESCRIPTION
Clicking on a multiselect option often triggers a refresh, which may lead to the multiselect being visually moved. This commit makes sure that, in that case, the popup moves along with the multiselect.