### PR TITLE
Empty multiselect focus issue

### DIFF
--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -152,6 +152,7 @@ module.exports = Aria.classDefinition({
             if (!this._hasFocus) {
                 this.focus();
             }
+            this._keepFocus = false;
 
             var report = this.controller.toggleDropdown(this.getTextInputField().value, this._dropdownPopup != null);
             this._reactToControllerReport(report, {

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this._tests = ["test.aria.widgets.form.multiselect.checkFeatures.MultiSelect",
+                "test.aria.widgets.form.multiselect.emptyMultiSelect.MultiSelect",
                 "test.aria.widgets.form.multiselect.deleteFieldValue.test1.MultiSelect",
                 "test.aria.widgets.form.multiselect.deleteFieldValue.test2.MultiSelect",
                 "test.aria.widgets.form.multiselect.downArrowKey.MultiSelect",

--- a/test/aria/widgets/form/multiselect/emptyMultiSelect/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/emptyMultiSelect/MultiSelect.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.emptyMultiSelect.MultiSelect",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype : {
+        /**
+         * This method is always the first entry point to a template test.
+         */
+        runTemplateTest : function () {
+            var myMultiSelect = this.myMultiSelect = this.getWidgetInstance("myMultiSelect");
+            myMultiSelect.getDom();
+            var dropDownIcon = myMultiSelect._frame._icons.dropdown.domElts[0];
+            this.synEvent.click(dropDownIcon, {
+                fn : this._step1,
+                scope : this
+            });
+        },
+
+        _step1 : function () {
+            this.waitFor({
+                condition : function () {
+                    return this.myMultiSelect._state == "normalFocused";
+                },
+                callback : this._step2
+            });
+        },
+
+        _step2 : function () {
+            var myMultiSelect = this.myMultiSelect;
+            this.assertEquals(myMultiSelect._state, "normalFocused");
+            this.assertEquals(myMultiSelect._frame._stateName, "normalFocused");
+            this.assertTrue(/Focused/i.test(myMultiSelect._frame._frame._domElt.className));
+            this.assertTrue(aria.utils.Dom.isAncestor(Aria.$window.document.activeElement, myMultiSelect._domElt));
+            var myInput = this.myInput = this.getElementById("myInput");
+            this.synEvent.click(myInput, {
+                fn : this._step3,
+                scope : this
+            });
+        },
+
+        _step3 : function () {
+            this.waitFor({
+                condition : function () {
+                    return this.myMultiSelect._state == "normal";
+                },
+                callback : this._step4
+            });
+        },
+
+        _step4 : function () {
+            var myMultiSelect = this.myMultiSelect;
+            this.assertEquals(myMultiSelect._state, "normal");
+            this.assertEquals(myMultiSelect._frame._stateName, "normal");
+            this.assertFalse(/Focused/i.test(myMultiSelect._frame._frame._domElt.className));
+            this.assertTrue(Aria.$window.document.activeElement == this.myInput);
+            this.myInput = null;
+            this.myMultiSelect = null;
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/emptyMultiSelect/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/emptyMultiSelect/MultiSelectTpl.tpl
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.multiselect.emptyMultiSelect.MultiSelectTpl"
+}}
+
+    {macro main()}
+        <h1>This test needs focus</h1>
+            {@aria:MultiSelect {
+                label : "My Multi-select:",
+                id : "myMultiSelect",
+                items : []
+            }/} <input {id "myInput"/}>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This pull request fixes the following issue: when a `@aria:MultiSelect` widget is empty (i.e. when its `items` property is an empty array) and when clicking on the dropdown icon to open the popup, the widget gets the focused style and keeps it forever (even when the focus is somewhere else).