### PR TITLE
fix #1468 Prefix URLs in CSS templates feature not working

### DIFF
--- a/src/aria/templates/CSSCtxt.js
+++ b/src/aria/templates/CSSCtxt.js
@@ -231,7 +231,7 @@ module.exports = Aria.classDefinition({
          * @return {String}
          */
         _parseImgUrl : function (url) {
-            return "url (\"" + url + "\")";
+            return "url(\"" + url + "\")";
         },
 
         /**

--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -902,7 +902,8 @@ module.exports = Aria.classDefinition({
         /**
          * Retrieve the computed style for a given CSS property on a given DOM element.
          * @param {HTMLElement} element The DOM element on which to retrieve a CSS property
-         * @param {String} property The CSS property to retrieve
+         * @param {String} property The CSS property to retrieve. For maximum portability, it should be in camel case
+         * (for instance <code>backgroundImage</code>)
          */
         getStyle : function (element, property) {
             var browser = ariaCoreBrowser;

--- a/test/aria/templates/css/imgprefix/ImgPrefixTemplateTestCase.js
+++ b/test/aria/templates/css/imgprefix/ImgPrefixTemplateTestCase.js
@@ -25,7 +25,8 @@ Aria.classDefinition({
             template : "test.aria.templates.css.imgprefix.SimpleTemplate"
         });
 
-        this.imgPaths = ["images/bg.jpg", "images/bg.jpg", "images/bg.jpg", "images)/bg.jpg", "images/?bg.jpg", "images'/bg.'jpg", "images\"/bg.\"jpg"];
+        this.imgPaths = ["images/bg.jpg", "images/bg.jpg", "images/bg.jpg", "images)/bg.jpg", "images/?bg.jpg",
+                "images'/bg.'jpg", "images\"/bg.\"jpg"];
 
         // set the app environment
         aria.core.AppEnvironment.setEnvironment({
@@ -54,7 +55,10 @@ Aria.classDefinition({
             // reset app environment
             aria.core.AppEnvironment.setEnvironment({
                 "imgUrlMapping" : null
-            }, { fn : this._afterAppEnvResetting, scope : this}, true);
+            }, {
+                fn : this._afterAppEnvResetting,
+                scope : this
+            }, true);
         },
 
         _afterAppEnvResetting : function () {
@@ -75,12 +79,42 @@ Aria.classDefinition({
                 var tmp = this._cleanUrls(urls[i]);
                 this.assertTrue(tmp === this.imgPaths[i], "The framework is adding a prefix for image urls inside CSS templates, it shouldn't.");
             }
+            this._testImageIsActuallyLoadedAfterPrefixing();
+        },
+
+        _testImageIsActuallyLoadedAfterPrefixing : function () {
+            aria.core.AppEnvironment.setEnvironment({
+                "imgUrlMapping" : function (url) {
+                    return aria.core.DownloadMgr.resolveURL("aria/css/atskin/imgs/" + url);
+                }
+            }, {
+                fn : this._loadThirdTpl,
+                scope : this
+            }, true);
+        },
+
+        _loadThirdTpl : function () {
+            this._replaceTestTemplate({
+                template : "test.aria.templates.css.imgprefix.TemplateWithRealImage"
+            }, this._afterThirdTemplateLoaded);
+        },
+
+        _afterThirdTemplateLoaded : function () {
+            var container = Aria.$window.document.getElementById("container-real-image");
+            var style = aria.utils.Dom.getStyle(container, "backgroundImage");
+
+            // if the image did not load, it will be "none"
+            this.assertNotEquals(style, "none", "The prefixed image did not really load!");
+            this.assertTrue(style.indexOf('aria/css/atskin/imgs/errortooltip.png') > -1);
+
             this.end();
         },
 
         _cleanUrls : function (url) {
             url = url.charAt(url.length - 1) === ")" ? url.substring(0, url.length - 1) : url;
-            url = url.charAt(url.length - 1) === "\"" || url.charAt(url.length - 1) === "\'" ? url.substring(0, url.length - 1) : url;
+            url = url.charAt(url.length - 1) === "\"" || url.charAt(url.length - 1) === "\'"
+                    ? url.substring(0, url.length - 1)
+                    : url;
             return url;
         }
     }

--- a/test/aria/templates/css/imgprefix/TemplateWithRealImage.tpl
+++ b/test/aria/templates/css/imgprefix/TemplateWithRealImage.tpl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.templates.css.imgprefix.TemplateWithRealImage",
+    $css : ["test.aria.templates.css.imgprefix.TemplateWithRealImageCss"]
+}}
+
+{macro main ()}
+    <div class="container-real-image" id="container-real-image">
+        <p>Container With Real Image</p>
+    </div>
+
+{/macro}
+
+{/Template}

--- a/test/aria/templates/css/imgprefix/TemplateWithRealImageCss.tpl.css
+++ b/test/aria/templates/css/imgprefix/TemplateWithRealImageCss.tpl.css
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+    $classpath : "test.aria.templates.css.imgprefix.TemplateWithRealImageCss"
+}}
+
+{macro main ()}
+    * {
+      margin: 0;
+      padding: 0;
+    }
+
+    .container-real-image {
+        background-image: url('errortooltip.png');
+    }
+
+{/macro}
+
+{/CSSTemplate}


### PR DESCRIPTION
Feature implemented in #972 did not work due to invalid CSS
generated: a space between `url` keyword and the parentheses
made the whole CSS rule invalid and hence not applied

----------

As amazing as it might be, it seems that this feature in fact never really worked, or somehow the browsers changed how they interpret `url ('...')` strings in CSS which is quite hard to believe (but never say never)

Consider:
http://output.jsbin.com/meqafekasa/

It has the following HTML:
```
 <div style="width:150px; height: 30px; background-color:green ; background-image: url('http://www.amadeus.com/web/static/82b6bd11/img/amadeus.png')"> </div>
  
 <div style="width:150px; height: 30px; background-color: red;   background-image: url ('http://www.amadeus.com/web/static/82b6bd11/img/amadeus.png')"> </div>
```

The first one does not have space between `url` and left parenthesis, the second one has a space. Tested across Chrome, Firefox and IE9, first is always working and the second never.