### PR TITLE
fix aria.utils.Date.format didn't work well for the day of the week, when used with the last parameter to true

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -1395,6 +1395,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             newDate.getMinutes = newDate.getUTCMinutes;
             newDate.getSeconds = newDate.getUTCSeconds;
             newDate.getMilliseconds = newDate.getUTCMilliseconds;
+            newDate.getDay = newDate.getUTCDay;
             return newDate;
         },
 

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -292,6 +292,9 @@ Aria.classDefinition({
             formattedValue = ariaDateUtil.format(new Date(2010, 3, 1, 0, 0, 0), "d MMM y");
             this.assertTrue(formattedValue === "1 Apr 10", "Wrong output: " + formattedValue);
 
+            formattedValue = ariaDateUtil.format(new Date("2015/05/26 23:15:00 GMT+0000"), "EEE d MMM", true);
+            this.assertTrue(formattedValue === "Tue 26 May", "Wrong output: " + formattedValue);
+
             aria.core.environment.Environment.setLanguage("fr_FR", {
                 fn : this.appEnvChanged,
                 scope : this


### PR DESCRIPTION
aria.utils.Date.format(new Date("2015/05/26 23:15:00 GMT+0000"),"EEE d MMM",true) returned `Wed 26 May` instead of `Tue 26 May`