### PR TITLE
fix Increase the default test timeout for Preselect autocomplete or multiautocomplete based test cases

### DIFF
--- a/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
@@ -49,9 +49,8 @@ Aria.classDefinition({
             "aria.utils.Type", "aria.core.Browser"],
     $constructor : function () {
         this.$RobotTestCase.constructor.call(this);
-        if (aria.core.Browser.isPhantomJS || aria.core.Browser.isIE7 || aria.core.Browser.isIE8) {
-            this.defaultTestTimeout = 120000;
-        }
+        this.defaultTestTimeout = 120000;
+
         this.resourcesHandler = this.resourcesHandler || new aria.resources.handlers.LCResourcesHandler();
         this.resourcesHandler.setSuggestions([{
                     label : "P2. TESTER B",

--- a/test/aria/widgets/form/multiautocomplete/preselectAutofill/MACPreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/multiautocomplete/preselectAutofill/MACPreselectAutofillBaseTest.js
@@ -30,6 +30,7 @@ Aria.classDefinition({
     $dependencies : ["aria.resources.handlers.LCRangeResourceHandler"],
     $constructor : function () {
         this.testTemplate = "test.aria.widgets.form.multiautocomplete.preselectAutofill.PreselectAutofillCommonTemplate";
+        this.defaultTestTimeout = 120000;
         this.resourcesHandler = new aria.resources.handlers.LCRangeResourceHandler({
             allowRangeValues : true
         });


### PR DESCRIPTION
As these tests are quite long, some browsers may failed (it happened on firefox) with timeout while the test is still rightly running.

Increasing the default time out for these tests is safe and avoid false failure.