### PR TITLE
Fixed the setup of the deprecation for aria.utils.Device (and replicated for aria.core.Browser).

### DIFF
--- a/src/aria/core/Browser.js
+++ b/src/aria/core/Browser.js
@@ -590,42 +590,42 @@ module.exports = Aria.classDefinition({
          * Puts in place, if possible, properties descriptors in order to be able to log warnings for all possible accesses to the deprecated properties.
          */
         __deprecateProperties : function() {
-            if (this.supportsPropertyDescriptors()) {
-                ariaUtilsArray.forEach(this._deprecatedProperties, function(property) {
-                    // ------------------------------------------- destructuring
+            var supportsPropertyDescriptors = this.supportsPropertyDescriptors();
 
-                    var name = property.name;
-                    var type = property.type;
-                    var underlying = property.underlying;
-                    var loggingMessage = property.loggingMessage;
-                    var loggingMessageArguments = property.loggingMessageArguments;
+            ariaUtilsArray.forEach(this._deprecatedProperties, function(property) {
+                // ----------------------------------------------- destructuring
 
-                    // ---------------------------------------------- processing
+                var name = property.name;
+                var type = property.type;
+                var underlying = property.underlying;
+                var loggingMessage = property.loggingMessage;
+                var loggingMessageArguments = property.loggingMessageArguments;
 
-                    var self = this;
+                // -------------------------------------------------- processing
 
-                    if (type == "attribute") {
-                        var prefixedName = "_" + name;
-                        this[prefixedName] = this[name];
+                var self = this;
 
-                        Object.defineProperty(this, name, {
-                            get : function () {
-                                self.$logWarn(loggingMessage, loggingMessageArguments);
-                                return self[prefixedName];
-                            },
-                            set : function (value) {
-                                self.$logWarn(loggingMessage, loggingMessageArguments);
-                                self[prefixedName] = value;
-                            }
-                        });
-                    } else {
-                        this[name] = function() {
+                if (type == "attribute" && supportsPropertyDescriptors) {
+                    var prefixedName = "_" + name;
+                    this[prefixedName] = this[name];
+
+                    Object.defineProperty(this, name, {
+                        get : function () {
                             self.$logWarn(loggingMessage, loggingMessageArguments);
-                            return underlying.apply(self, arguments);
-                        };
-                    }
-                }, this);
-            }
+                            return self[prefixedName];
+                        },
+                        set : function (value) {
+                            self.$logWarn(loggingMessage, loggingMessageArguments);
+                            self[prefixedName] = value;
+                        }
+                    });
+                } else if (type == "method") {
+                    this[name] = function() {
+                        self.$logWarn(loggingMessage, loggingMessageArguments);
+                        return underlying.apply(self, arguments);
+                    };
+                }
+            }, this);
         },
 
         /**

--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -918,7 +918,7 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Reiusse a pending request. A request might need to be reissued because the transport was not ready (it's the
+         * Reissue a pending request. A request might need to be reissued because the transport was not ready (it's the
          * case of XDR).
          * @param {String} reqId ID of the pending request.
          */

--- a/test/aria/core/BrowserTest.js
+++ b/test/aria/core/BrowserTest.js
@@ -154,9 +154,7 @@ Aria.classDefinition({
             // -----------------------------------------------------------------
 
             Browser.init();
-            if (!Browser.supportsPropertyDescriptors()) {
-                return;
-            }
+            var supportsPropertyDescriptors = Browser.supportsPropertyDescriptors();
 
             // -----------------------------------------------------------------
 
@@ -169,15 +167,20 @@ Aria.classDefinition({
 
                 // -------------------------------------------------------------
 
-                if (type == "attribute") {
+                var called = false;
+                if (type == "attribute" && supportsPropertyDescriptors) {
                     var dummy = Browser[name];
-                } else {
+                    called = true;
+                } else if (type == "method") {
                     Browser[name]();
+                    called = true;
                 }
 
                 // -------------------------------------------------------------
 
-                this.assertErrorInLogs(loggingMessage, 1);
+                if (called) {
+                    this.assertErrorInLogs(loggingMessage, 1);
+                }
             }, this);
         }
         /* BACKWARD-COMPATIBILITY-END (GitHub #1397) */

--- a/test/aria/utils/DeviceTest.js
+++ b/test/aria/utils/DeviceTest.js
@@ -175,9 +175,7 @@ Aria.classDefinition({
             // -----------------------------------------------------------------
 
             Device.init();
-            if (!aria.core.Browser.supportsPropertyDescriptors()) {
-                return;
-            }
+            var supportsPropertyDescriptors = aria.core.Browser.supportsPropertyDescriptors();
 
             // -----------------------------------------------------------------
 
@@ -190,15 +188,20 @@ Aria.classDefinition({
 
                 // -------------------------------------------------------------
 
-                if (type == "attribute") {
+                var called = false;
+                if (type == "attribute" && supportsPropertyDescriptors) {
                     var dummy = Device[name];
-                } else {
+                    called = true;
+                } else if (type == "method") {
                     Device[name]();
+                    called = true;
                 }
 
                 // -------------------------------------------------------------
 
-                this.assertErrorInLogs(loggingMessage, 1);
+                if (called) {
+                    this.assertErrorInLogs(loggingMessage, 1);
+                }
             }, this);
         }
         /* BACKWARD-COMPATIBILITY-END (GitHub #1397) */


### PR DESCRIPTION
Deprecated methods which log a warning and then call the new implementation don't depend on the ability of the platform to provide property descriptors. I fixed the code according to that statement.

I also did an unrelated typo fix.