### PR TITLE
Adding a cutYear option to the date parsing functions

### DIFF
--- a/src/aria/utils/Beans.js
+++ b/src/aria/utils/Beans.js
@@ -39,6 +39,18 @@ module.exports = Aria.beanDefinitions({
                 "inputPattern" : {
                     $type : "environmentBase:inputFormatTypes",
                     $description : "Date pattern used to match user input to convert it in a Javascript valid date."
+                },
+                "isDateBeforeMonth" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the date is written before or after the month."
+                },
+                "isMonthYear" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the date contains only the month and year, without day."
+                },
+                "cutYear" : {
+                    $type : "json:Integer",
+                    $description : "2-digits number above which a 2-digits year 'xx' is interpreted as '19xx' instead of '20xx'."
                 }
             }
         }

--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -1151,6 +1151,13 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
          * @return {Date}
          */
         interpretDateAndMonth : function (dateStr, options) {
+            /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1488) */
+            if (options != null && typeof options != "object") {
+                options = {
+                    isDateBeforeMonth: options
+                };
+            }
+            /* BACKWARD-COMPATIBILITY-END (GitHub #1488) */
             var dateBeforeMonth = (options && ("isDateBeforeMonth" in options))
                   ? options.isDateBeforeMonth
                   : this._environment.getDateFormats().dateBeforeMonth;
@@ -1219,6 +1226,13 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
          * @return {Date}
          */
         interpretMonthAndYear : function (dateStr, options) {
+            /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1488) */
+            if (options != null && typeof options != "object") {
+                options = {
+                    yearBeforeMonth: options
+                };
+            }
+            /* BACKWARD-COMPATIBILITY-END (GitHub #1488) */
             var yearBeforeMonth = options && options.yearBeforeMonth;
             var dateArray = this._parseDateString(dateStr), interpretdDate, interpretdMonth, arrayLen, interpretdYear;
             // The Array size should always be 2 if not return nothing

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -759,6 +759,43 @@ Aria.classDefinition({
         testUTCFormat : function () {
             var dt = new Date(Date.UTC(2014, 2, 30, 2, 15, 0, 0)); // 30/03/2014 02:15:00 UTC
             this.assertEquals(aria.utils.Date.format(dt, 'HH:mm', true), "02:15", "30/03/2014 02:15:00 UTC should be formated to %2, got %1");
+        },
+
+        /**
+         * Tests the cutYear option.
+         */
+        testCutYearOption : function () {
+            var ariaDateUtil = aria.utils.Date;
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretMonthAndYear("0345", {cutYear: 90}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretMonthAndYear("0345", {cutYear: 46}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretMonthAndYear("0345", {cutYear: 45}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretMonthAndYear("0345", {cutYear: 44}),"dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretMonthAndYear("0345", {cutYear: 10}),"dd/MM/yyyy"), "01/03/1945");
+
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("0345", {isMonthYear: true, cutYear: 90}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("0345", {isMonthYear: true, cutYear: 46}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("0345", {isMonthYear: true, cutYear: 45}),"dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("0345", {isMonthYear: true, cutYear: 44}),"dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("0345", {isMonthYear: true, cutYear: 10}),"dd/MM/yyyy"), "01/03/1945");
+
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretDateAndMonth("010345", {cutYear: 90}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretDateAndMonth("010345", {cutYear: 46}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretDateAndMonth("010345", {cutYear: 45}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretDateAndMonth("010345", {cutYear: 44}), "dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretDateAndMonth("010345", {cutYear: 10}), "dd/MM/yyyy"), "01/03/1945");
+
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("010345", {cutYear: 90}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("010345", {cutYear: 46}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("010345", {cutYear: 45}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("010345", {cutYear: 44}), "dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("010345", {cutYear: 10}), "dd/MM/yyyy"), "01/03/1945");
+
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 90, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 46, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 45, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 44, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 10, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/1945");
+
         }
     }
 });

--- a/test/aria/utils/DateInterpret.js
+++ b/test/aria/utils/DateInterpret.js
@@ -61,7 +61,9 @@ Aria.classDefinition({
 
         },
         interpretAndAssertMonthYear : function (dateStr, month, year, yearBeforeMonth) {
-            var date = aria.utils.Date.interpretMonthAndYear(dateStr, yearBeforeMonth);
+            var date = aria.utils.Date.interpretMonthAndYear(dateStr, {
+                yearBeforeMonth: yearBeforeMonth
+            });
             this.assertTrue(date.getFullYear() === year);
             this.assertTrue(date.getMonth() + 1 === month);
         },

--- a/test/aria/utils/DateInterpret.js
+++ b/test/aria/utils/DateInterpret.js
@@ -66,6 +66,12 @@ Aria.classDefinition({
             });
             this.assertTrue(date.getFullYear() === year);
             this.assertTrue(date.getMonth() + 1 === month);
+
+            /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1488) */
+            date = aria.utils.Date.interpretMonthAndYear(dateStr, yearBeforeMonth);
+            this.assertTrue(date.getFullYear() === year);
+            this.assertTrue(date.getMonth() + 1 === month);
+            /* BACKWARD-COMPATIBILITY-END (GitHub #1488) */
         },
         testDateinterpreter : function () {
             // should interpret as 05 Dec


### PR DESCRIPTION
This PR adds a `cutYear` option to the date parsing functions, which allows to configure the 2-digits number above which a 2-digits year 'xx' is considered '19xx' instead of '20xx'.