### PR TITLE
[WAI-ARIA] Adding the waiAria flag for widgets in the AriaLib

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -97,6 +97,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:Integer",
                     $description : "The tab index of the widget. If null it's not taken into account, if 0 or above the widget will be focusable thorugh tab, if negative it won't be focusable.",
                     $default : null
+                },
+                "waiAria" : {
+                    $type : "json:Boolean",
+                    $description : "If true, and if the widget supports it, accessibility-related DOM attributes are enabled on this widget, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better."
                 }
             }
         },

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -24,6 +24,7 @@ var ariaWidgetsGlobalStyle = require("./GlobalStyle.tpl.css");
 var ariaWidgetLibsBindableWidget = require("../widgetLibs/BindableWidget");
 var ariaCoreTplClassLoader = require("../core/TplClassLoader");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
+var ariaWidgetsEnvironmentWidgetSettings = require("./environment/WidgetSettings");
 
 /**
  * Base Widget class from which all widgets must derive
@@ -136,6 +137,10 @@ module.exports = Aria.classDefinition({
             if (!ariaWidgetsAriaSkinInterface.checkSkinClassExists(this._skinnableClass, cfg.sclass)) {
                 cfg.sclass = 'std';
             }
+        }
+
+        if (cfg.waiAria == null) {
+            cfg.waiAria = ariaWidgetsEnvironmentWidgetSettings.getWidgetSettings().waiAria;
         }
 
         var bindings = cfg.bind;

--- a/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
+++ b/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
@@ -77,6 +77,11 @@ module.exports = Aria.beanDefinitions({
                     },
                     $default : {}
                 },
+                "waiAria" : {
+                    $type : "json:Boolean",
+                    $description : "If true, accessibility-related DOM attributes are enabled, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better.",
+                    $default : false
+                },
                 "defaultErrorMessages" : {
                     $type : "json:Object",
                     $description : "Default values for widgets' error messages.",


### PR DESCRIPTION
The `waiAria` flag allows to enable or disable accessibility either globally or at each widget level.