### PR TITLE
[WAI-ARIA] aria:AutoComplete widget

### DIFF
--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -151,6 +151,7 @@ module.exports = Aria.classDefinition({
 
             var listObj = {
                 id : cfg.id,
+                waiAria : cfg.waiAria,
                 defaultTemplate : "defaultTemplate" in options ? options.defaultTemplate : cfg.listTemplate,
                 block : true,
                 sclass : cfg.listSclass || this._skinObj.listSclass,

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -180,6 +180,11 @@ module.exports = Aria.classDefinition({
         _skinnableClass : "TextInput",
 
         /**
+         * Extra attributes to put on the input/textarea element.
+         */
+        _extraInputAttributes : "",
+
+        /**
          * Prototype init method called at prototype creation time Allows to store class-level objects that are shared
          * by all instances
          * @param {Object} p the prototype object being built
@@ -338,7 +343,7 @@ module.exports = Aria.classDefinition({
                         type, '" style="', inlineStyle.join(''), 'color:', color,
                         ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth,
                         'px;"', 'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
-                        (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck,
+                        (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck, this._extraInputAttributes,
                         '>', stringUtils.escapeHTML(((this._helpTextSet) ? cfg.helptext : text) || ""),
                         '</textarea>'
 
@@ -349,7 +354,7 @@ module.exports = Aria.classDefinition({
                         type, '" style="', inlineStyle.join(''), 'color:', color, ';width:', inputWidth, 'px;"',
                         'value="', stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text),
                         '" ', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
-                        (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck,
+                        (cfg.tabIndex != null ? 'tabindex="' + this._calculateTabIndex() + '" ' : ' '), spellCheck, this._extraInputAttributes,
                         ' _ariaInput="1"/>'
                 // the _ariaInput attribute is present so that pressing
                 // ENTER on this widget raises the onSubmit event of

--- a/src/aria/widgets/form/list/CfgBeans.js
+++ b/src/aria/widgets/form/list/CfgBeans.js
@@ -99,6 +99,15 @@ module.exports = Aria.beanDefinitions({
                     $description : "strict: for strict highlighting (exact match only), always: for selecting the first item everytime, none: for no highlighting",
                     $enumValues : ["strict", "always", "none"],
                     $default : "none"
+                },
+                "waiAria" : {
+                    $type : "json:Boolean",
+                    $description : "If true, accessibility-related DOM attributes are enabled, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better."
+                },
+                "listItemDomIdPrefix" : {
+                    $type : "json:String",
+                    $description : "Prefix to prepend to the index to compute the id (to be passed to the {id .../} statement) of each list item. It is required to put ids on all list items only if waiAria is true.",
+                    $default : "myItem"
                 }
             }
         },

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -18,7 +18,6 @@ require("./ListController");
 var ariaWidgetsFormListListStyle = require("./ListStyle.tpl.css");
 var ariaWidgetsTemplateBasedWidget = require("../../TemplateBasedWidget");
 
-
 /**
  * A simple list of selectable items
  */
@@ -66,7 +65,8 @@ module.exports = Aria.classDefinition({
                         numberOfRows : cfg.numberOfRows,
                         skin : skinObj,
                         cfg : divCfg,
-                        preselect : cfg.preselect
+                        preselect : cfg.preselect,
+                        waiAria : cfg.waiAria
                     }
                 }
             }
@@ -291,6 +291,30 @@ module.exports = Aria.classDefinition({
                 this._onBoundPropertyChange(propertyName, newValue, oldValue);
             } else {
                 this.$TemplateBasedWidget.setWidgetProperty.apply(this, arguments);
+            }
+        },
+
+        /**
+         * Returns the id of the root DOM element containing the list.
+         * @return {String} id of the root DOM element containing the list.
+         */
+        getListDomId : function () {
+            return this._tplWidget.getDom().id;
+        },
+
+        /**
+         * Returns the id of the DOM element corresponding to the item in the list at the given index.
+         * This method only works if accessibility was enabled at the time the list widget was created.
+         * @param {Integer} optionIndex index of the item whose id should be returned
+         * @return {String} id of the DOM element or undefined if the list is not fully loaded yet, accessibility
+         * is disabled or the index is invalid
+         */
+        getOptionDomId : function (optionIndex) {
+            if (this._subTplCtxt) {
+                var data = this._subTplModuleCtrl.getData();
+                if (data.waiAria && optionIndex > -1 && optionIndex < data.items.length) {
+                    return this._subTplCtxt.$getId(data.listItemDomIdPrefix + optionIndex);
+                }
             }
         }
     }

--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -23,7 +23,7 @@
         {var className = _getClassForItem(item)/}
         {var entry = item.object.entry/}
 
-        <a href="javascript:void(0)" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option"{/if} href="javascript:void(0)" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}

--- a/src/aria/widgets/form/list/templates/ListTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/ListTemplate.tpl
@@ -31,6 +31,9 @@
             {on mouseup {fn: "itemClick"} /}
             {on mouseover {fn: "itemMouseOver"} /}
         {/if}
+        {if data.waiAria}
+            role="listbox"
+        {/if}
         >
         <a href="#" style="display: none;">&nbsp;</a> //IE6 does not highlight the 1 elm in list
         {foreach item inArray data.items}
@@ -41,7 +44,7 @@
 
     {macro renderItem(item, itemIdx)}
         {var a = _getClassForItem(item)/}
-        <a href="javascript:void(0)" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option"{/if} href="javascript:void(0)" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {else/}

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -48,5 +48,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.splitter.scrollbars.ScrollbarTestCase");
         this.addTests("test.aria.widgets.issue746.SkinClassFallbackTestCase");
         this.addTests("test.aria.widgets.form.text.textcontentissue.TextContentTest");
+        this.addTests("test.aria.widgets.wai.WaiTestSuite");
     }
 });

--- a/test/aria/widgets/wai/WaiTestSuite.js
+++ b/test/aria/widgets/wai/WaiTestSuite.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.WaiTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.widgets.wai.autoComplete.WaiAutoCompleteTestSuite");
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var domUtils = require("ariatemplates/utils/Dom");
+var fnUtils = require("ariatemplates/utils/Function");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteBaseTest",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            template : this.myTemplate
+        });
+    },
+    $prototype : {
+        // The following 2 properties should be defined in the child classes:
+        myAutoCompleteId: null,
+        myAutoCompleteAccessible: false,
+
+        // The following 3 properties can be overridden in child classes:
+        myTemplate: "test.aria.widgets.wai.autoComplete.AutoCompleteTpl",
+        myAutoCompleteInitialTyping: "p",
+        myAutoCompleteFinalText: "Poitiers",
+
+        getChildrenWithAttribute : function (element, attribute) {
+            if (element.querySelectorAll) {
+                return element.querySelectorAll("[" + attribute + "]");
+            }
+            // IE7 support!
+            var res = [];
+            var loop = function (element) {
+                var children = element.childNodes;
+                for (var i = 0, l = children.length; i < l; i++) {
+                    var child = children[i];
+                    if (child.hasAttribute(attribute)) {
+                        res.push(child);
+                    } else {
+                        loop(child);
+                    }
+                }
+            };
+            loop(element);
+            return res;
+        },
+
+        checkAccessibilityEnabled : function (widget) {
+            var inputElt = widget.getTextInputField();
+
+            var role = inputElt.getAttribute("role");
+            this.assertEquals(role, "combobox", "wrong input role value (%1)");
+
+            var ariaAutocomplete = inputElt.getAttribute("aria-autocomplete");
+            this.assertEquals(ariaAutocomplete, "list", "wrong input aria-autocomplete value (%1)");
+
+            var ariaExpanded = inputElt.getAttribute("aria-expanded");
+            this.assertTrue(ariaExpanded === "true" || ariaExpanded === "false", "wrong input aria-expanded value");
+            var ariaExpandedBool = (ariaExpanded === "true");
+            this.assertEquals(ariaExpandedBool, !! widget._dropdownPopup, "aria-expanded (%1) does not match the state of widget._dropdownPopup (%2)");
+            var listWidget = widget.controller.getListWidget();
+            this.assertEquals(ariaExpandedBool, !! listWidget, "aria-expanded (%1) does not match the state of widget.controller.getListWidget() (%2)");
+
+            var ariaOwns = inputElt.getAttribute("aria-owns");
+            var ariaOwnsElt;
+            this.assertEquals(!! ariaOwns, ariaExpandedBool, "aria-owns should be present (%1) if and only if aria-expanded is true (%2)");
+            var listBoxElt;
+            var optionsElt = [];
+            if (ariaOwns) {
+                ariaOwnsElt = this.testDocument.getElementById(ariaOwns);
+                this.assertTrue(ariaOwnsElt != null, "the id specified in aria-owns was not found in the document");
+
+                var childrenWithRole = this.getChildrenWithAttribute(ariaOwnsElt, "role");
+                for (var i = 0, l = childrenWithRole.length; i < l; i++) {
+                    var curChild = childrenWithRole[i];
+                    var curRole = curChild.getAttribute("role");
+                    this.assertTrue(curRole === "listbox" || curRole === "option");
+                    if (curRole == "listbox") {
+                        this.assertFalsy(listBoxElt, "several items have the listbox role");
+                        listBoxElt = curChild;
+                    } else if (curRole == "option") {
+                        optionsElt.push(curChild);
+                    }
+                }
+                this.assertEquals(listWidget._cfg.items.length, optionsElt.length, "the number of items in listWidget._cfg.items (%1) is not the same as the number of DOM element with role=option (%2)");
+                this.assertTruthy(listBoxElt, "no item has the listbox role");
+                for (var i = 0, l = optionsElt.length; i < l; i++) {
+                    var curOption = optionsElt[i];
+                    this.assertTrue(domUtils.isAncestor(curOption, listBoxElt), "option not inside the listbox element: " + curOption.id);
+                }
+            }
+
+            var ariaActiveDescendant = inputElt.getAttribute("aria-activedescendant");
+            var ariaActiveDescendantElt;
+            if (ariaActiveDescendant) {
+                this.assertTrue(ariaExpandedBool, "aria-activedescendant is defined but aria-expanded is false");
+                ariaActiveDescendantElt = this.testDocument.getElementById(ariaActiveDescendant);
+                this.assertTruthy(ariaActiveDescendantElt, "the id specified in aria-activedescendant was not found in the document");
+                this.assertEquals(ariaActiveDescendantElt.getAttribute("role"), "option", "the aria-activedescendant element does not have the option role");
+                this.assertTruthy(ariaOwnsElt, "aria-activedescendant is defined but aria-owns is not defined or not found");
+                this.assertTrue(domUtils.isAncestor(ariaActiveDescendantElt, ariaOwnsElt), "the aria-activedescendant element is not inside the aria-owns element");
+                this.assertTrue(domUtils.isAncestor(ariaActiveDescendantElt, listBoxElt), "the aria-activedescendant element is not inside the listbox element");
+                var selectedIdx = listWidget._cfg.selectedIndex;
+                this.assertTrue(selectedIdx > -1, "unexpected value of listWidget._cfg.selectedIdx: " + selectedIdx);
+                var labelFromDom = (ariaActiveDescendantElt.textContent || ariaActiveDescendantElt.innerText).replace(/^\s*(.*?)\s*$/,"$1");
+                var labelFromWidget = listWidget._cfg.items[selectedIdx].label;
+                this.assertEquals(labelFromDom, labelFromWidget);
+            }
+        },
+
+        waiAttributes : ["role", "aria-expanded", "aria-autocomplete", "aria-activedescendant", "aria-owns"],
+
+        checkNoAccessibilityAttribute : function (element) {
+            var waiAttributes = this.waiAttributes;
+            for (var i = 0, l = waiAttributes.length ; i < l; i++) {
+                var curAttribute = waiAttributes[i];
+                var items = this.getChildrenWithAttribute(element, curAttribute);
+                this.assertEquals(items.length, 0, "Found %1 element(s) with the " + curAttribute + " attribute");
+            }
+        },
+
+        checkAccessibilityDisabled : function (widget) {
+            // there should be no element with the role, aria-owns, aria-expanded, aria-activedescendant or aria-autocomplete attribute
+            this.checkNoAccessibilityAttribute(widget.getDom());
+            var listWidget = widget.controller.getListWidget();
+            if (listWidget) {
+                // check there is no role in the list widget
+                this.checkNoAccessibilityAttribute(listWidget._tplWidget.getDom());
+            }
+        },
+
+        initialSetup : function() {
+            this.myAutoCompleteWidget = this.getWidgetInstance(this.myAutoCompleteId);
+            var checkFn = this.myAutoCompleteAccessible ? this.checkAccessibilityEnabled : this.checkAccessibilityDisabled;
+            this.myAutoCompleteCheckFn = fnUtils.bind(checkFn, this, this.myAutoCompleteWidget);
+        },
+
+        runTemplateTest : function () {
+            this.initialSetup();
+            this.myAutoCompleteCheckFn();
+            this.executeScenario(this.myAutoCompleteWidget, this.myAutoCompleteCheckFn);
+        },
+
+        executeScenario : function (widget, checkFn) {
+            var input = widget.getTextInputField();
+            var self = this;
+
+            var step1 = function () {
+                self.synEvent.click(input, step2);
+            };
+
+            var step2 = function () {
+                checkFn();
+                self.synEvent.type(input, self.myAutoCompleteInitialTyping, step3);
+            };
+
+            var step3 = function () {
+                self.waitFor({
+                    condition: function () {
+                        checkFn();
+                        var listWidget = widget.controller.getListWidget();
+                        return listWidget && listWidget._subTplCtxt;
+                    },
+                    callback: step4
+                });
+            };
+
+            var step4 = function () {
+                self.synEvent.type(input, "[down][down]", step5);
+            };
+
+            var step5 = function () {
+                self.waitFor({
+                    condition: function () {
+                        checkFn();
+                        return !! widget.controller.getDataModel().selectedIdx == 1;
+                    },
+                    callback: step6
+                });
+            };
+
+            var step6 = function () {
+                self.synEvent.type(input, "[enter]", step7);
+            };
+
+            var step7 = function () {
+                self.waitFor({
+                    condition: function () {
+                        checkFn();
+                        return ! widget._dropdownPopup;
+                    },
+                    callback: step8
+                });
+            };
+
+            var step8 = function () {
+                self.assertEquals(input.value, self.myAutoCompleteFinalText);
+                self.notifyTemplateTestEnd();
+            };
+
+            step1();
+        }
+
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalNonWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalNonWaiTestCase.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteGlobalNonWaiTestCase",
+    $extends : require("./AutoCompleteBaseTest"),
+    $prototype: {
+        myAutoCompleteId: "city1",
+        myAutoCompleteAccessible: false
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalWaiTestCase.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteGlobalWaiTestCase",
+    $extends : require("./AutoCompleteBaseTest"),
+    $prototype: {
+        myAutoCompleteId: "city1",
+        myAutoCompleteAccessible: true,
+
+        run : function () {
+            AppEnvironment.setEnvironment({
+                widgetSettings: {
+                    waiAria: true
+                }
+            }, {
+                scope: this,
+                fn: this.$AutoCompleteBaseTest.run
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteNonWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteNonWaiTestCase.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteNonWaiTestCase",
+    $extends : require("./AutoCompleteBaseTest"),
+    $prototype: {
+        myAutoCompleteId: "city3",
+        myAutoCompleteAccessible: false,
+
+        run : function () {
+            AppEnvironment.setEnvironment({
+                widgetSettings: {
+                    waiAria: true
+                }
+            }, {
+                scope: this,
+                fn: this.$AutoCompleteBaseTest.run
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteTpl.tpl
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteTpl.tpl
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteTpl",
+    $hasScript : true
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        <div style="margin:10px;">
+            Using default accessibility value: <br>
+            {@aria:AutoComplete {
+                id : "city1",
+                label : "City 1",
+                labelWidth: 100,
+                autoFill : false,
+                resourcesHandler : this.acHandler
+            }/} <br><br>
+            With accessibility enabled: <br>
+            {@aria:AutoComplete {
+                id : "city2",
+                waiAria : true,
+                label : "City 2",
+                labelWidth: 100,
+                autoFill : false,
+                resourcesHandler : this.acHandler
+            }/} <br><br>
+            With accessibility disabled: <br>
+            {@aria:AutoComplete {
+                id : "city3",
+                waiAria : false,
+                label : "City 3",
+                labelWidth: 100,
+                autoFill : false,
+                resourcesHandler : this.acHandler
+            }/} <br>
+        </div>
+
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteTplScript.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteTplScript.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var LCResourcesHandler = require("ariatemplates/resources/handlers/LCResourcesHandler");
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteTplScript",
+    $constructor : function () {
+        this.acHandler = new LCResourcesHandler();
+        this.acHandler.setSuggestions([{
+                    label : 'Paris',
+                    code : 'Paris'
+                }, {
+                    label : 'Pau',
+                    code : 'Pau'
+                }, {
+                    label : 'Pessac',
+                    code : 'Pessac'
+                }, {
+                    label : 'Perpignan',
+                    code : 'Perpignan'
+                }, {
+                    label : 'Pierrelatte',
+                    code : 'Pierrelatte'
+                }, {
+                    label : 'Plaisir',
+                    code : 'Plaisir'
+                }, {
+                    label : 'Poitiers',
+                    code : 'Poitiers'
+                }, {
+                    label : 'Pontoise',
+                    code : 'Pontoise'
+                }]);
+    },
+    $destructor : function () {
+        this.acHandler.$dispose();
+        this.acHandler = null;
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteWaiTestCase.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteWaiTestCase",
+    $extends : require("./AutoCompleteBaseTest"),
+    $prototype: {
+        myAutoCompleteId: "city2",
+        myAutoCompleteAccessible: true
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/WaiAutoCompleteTestSuite.js
+++ b/test/aria/widgets/wai/autoComplete/WaiAutoCompleteTestSuite.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.WaiAutoCompleteTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteWaiTestCase");
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteGlobalNonWaiTestCase");
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteGlobalWaiTestCase");
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteNonWaiTestCase");
+    }
+});


### PR DESCRIPTION
This PR adds the DOM attributes required for the aria:AutoComplete widget to comply with the WAI-ARIA specifications (when the `waiAria` flag is enabled).

It is built on top of #1490 
