### PR TITLE
Fixing regression with templates depending on server resources

### DIFF
--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -449,7 +449,7 @@ module.exports = Aria.classDefinition({
             if (typeof res == "string") {
                 var logicalPath = Aria.getLogicalPath(res);
                 var serverRes = /([^\/]*)\/Res$/.exec(logicalPath);
-                return 'require("ariatemplates/$resources").' + (serverRes ? "module(" + serverRes[1] + "," : "file(")
+                return 'require("ariatemplates/$resources").' + (serverRes ? "module(" + out.stringify(serverRes[1]) + "," : "file(")
                         + out.stringify(logicalPath) + ")";
             }
             if (typeof res == "object") {

--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -109,6 +109,9 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.layoutResize.ResizeTestCase");
         this.addTests("test.aria.templates.templateSyntaxError.TemplateSyntaxErrorTestCase");
 
+        this.addTests("test.aria.templates.resources.TemplateWithResourcesTestCase");
+        this.addTests("test.aria.templates.resources.TemplateWithResourcesDevTestCase");
+
         this.addTests("test.aria.templates.robotCalibrationTest.RobotCalibrationTest");
 
     }

--- a/test/aria/templates/resources/Res.js
+++ b/test/aria/templates/resources/Res.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.resourcesDefinition({
+    $classpath : "test.aria.templates.resources.Res",
+    $resources : {
+        myResource : "IT IS WORKING!"
+    }
+});

--- a/test/aria/templates/resources/TemplateWithResources.tpl
+++ b/test/aria/templates/resources/TemplateWithResources.tpl
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : 'test.aria.templates.resources.TemplateWithResources',
+    $res : {
+        res : 'test.aria.templates.resources.Res'
+    }
+}}
+
+    {macro main()}
+        ${res.myResource}
+    {/macro}
+
+{/Template}

--- a/test/aria/templates/resources/TemplateWithResourcesDevTestCase.js
+++ b/test/aria/templates/resources/TemplateWithResourcesDevTestCase.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.templates.resources.TemplateWithResourcesDevTestCase",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.templates.resources.TemplateWithResources"
+        });
+    },
+    $prototype : {
+        run : function () {
+            AppEnvironment.setEnvironment({
+                appSettings : {
+                    devMode : true
+                }
+            }, {
+                fn : this.$TemplateTestCase.run,
+                scope : this
+            });
+        },
+
+        runTemplateTest : function () {
+            var content = (this.testDiv.textContent || this.testDiv.innerText).replace(/^\s*(.*?)\s*$/, "$1");
+            this.assertEquals(content, "IT IS WORKING!");
+            this.notifyTemplateTestEnd();
+        }
+    }
+});

--- a/test/aria/templates/resources/TemplateWithResourcesTestCase.js
+++ b/test/aria/templates/resources/TemplateWithResourcesTestCase.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var IOFiltersMgr = require("ariatemplates/core/IOFiltersMgr");
+var IOFilter = require("ariatemplates/core/IOFilter");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.templates.resources.TemplateWithResourcesTestCase",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.templates.resources.TemplateWithResources"
+        });
+    },
+    $prototype : {
+        run : function () {
+            var self = this;
+            self.redirectedResources = 0;
+            this.myFilter = new IOFilter();
+            this.myFilter.onRequest = function (req) {
+                var url = req.url.replace(/(\?|&)timestamp=[0-9]+$/, "");
+                if (url == "/myResourcesServer?language=en_US&moduleName=resources") {
+                    self.redirectedResources++;
+                    this.redirectToFile(req, "test/aria/templates/resources/Res.js");
+                }
+            };
+            IOFiltersMgr.addFilter(this.myFilter);
+            AppEnvironment.setEnvironment({
+                urlService : {
+                    "implementation": "aria.modules.urlService.PatternURLCreationImpl",
+                    "args": [
+                        "${moduleName}/${actionName}",
+                        "/myResourcesServer?language=${locale}&moduleName=${moduleName}"
+                    ]
+                }
+            }, {
+                fn : this.$TemplateTestCase.run,
+                scope : this
+            });
+        },
+
+        runTemplateTest : function () {
+            var content = (this.testDiv.textContent || this.testDiv.innerText).replace(/^\s*(.*?)\s*$/, "$1");
+            this.assertEquals(content, "IT IS WORKING!");
+            this.assertEquals(this.redirectedResources, 1);
+            IOFiltersMgr.removeFilter(this.myFilter);
+            this.myFilter.$dispose();
+            this.myFilter = null;
+            this.notifyTemplateTestEnd();
+        }
+    }
+});


### PR DESCRIPTION
This commit fixes a regression introduced in Aria Templates v1.7.6 (dc9c3ba89fdaaf5a67fc2707f916d1f599b4a56d) :
templates which have a server resources dependency (i.e. whose classpath ends with `.Res`) failed to be loaded.

For example, if the template contained something like this:
```
 {Template {
   $classpath : "x.y.MyTemplate",
   $res : {
     myRes : "x.y.myResourceName.Res"
   }
 } ...
```
That template could not be loaded, with the following error message:
```
 [aria.core.MultiLoader] Load failed
 ReferenceError: myResourceName is not defined
```