### PR TITLE
cutYear option not used in interpretFullDateRef (cf #1488)

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -945,7 +945,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
 
             // special case 3 10DEC11/+5 -> 10DEC2011 + 5 days
             if (this._interpret_specialCase3.test(entry)) {
-                return this.interpretFullDateRef(entry);
+                return this.interpretFullDateRef(entry, dateOptions);
             }
             // if length is less than 3 its not date string
             if (entrylen < 3) {
@@ -1104,9 +1104,10 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
         /**
          * To interpret the date 01Jan2012/+5
          * @param {String} dateStr string that needs to be parsed
+         * @param {aria.utils.Beans:options} options options for the date interpreter - optional
          * @return {Date}
          */
-        interpretFullDateRef : function (dateStr) {
+        interpretFullDateRef : function (dateStr, options) {
             var execResult = this._interpret_specialCase3.exec(dateStr), jsdate;
             var newEntry = execResult[1];
             var shift = parseInt(execResult[3], 10);
@@ -1114,7 +1115,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             if (Math.abs(shift) > 365) {
                 return null;
             }
-            jsdate = this.interpretDateAndMonth(newEntry);
+            jsdate = this.interpretDateAndMonth(newEntry, options);
             if (jsdate) {
                 jsdate.setDate(jsdate.getDate() + shift);
             }

--- a/test/aria/utils/Date.js
+++ b/test/aria/utils/Date.js
@@ -796,6 +796,17 @@ Aria.classDefinition({
             this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 44, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/1945");
             this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("01#0345", {cutYear: 10, inputPattern: "dd#MMyy"}), "dd/MM/yyyy"), "01/03/1945");
 
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("02MAR45/-1", {cutYear: 90}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("02MAR45/-1", {cutYear: 46}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("02MAR45/-1", {cutYear: 45}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("02MAR45/-1", {cutYear: 44}), "dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpret("02MAR45/-1", {cutYear: 10}), "dd/MM/yyyy"), "01/03/1945");
+
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretFullDateRef("02MAR45/-1", {cutYear: 90}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretFullDateRef("02MAR45/-1", {cutYear: 46}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretFullDateRef("02MAR45/-1", {cutYear: 45}), "dd/MM/yyyy"), "01/03/2045");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretFullDateRef("02MAR45/-1", {cutYear: 44}), "dd/MM/yyyy"), "01/03/1945");
+            this.assertEquals(ariaDateUtil.format(ariaDateUtil.interpretFullDateRef("02MAR45/-1", {cutYear: 10}), "dd/MM/yyyy"), "01/03/1945");
         }
     }
 });


### PR DESCRIPTION
This PR adds support for the `cutYear` option in the case of `interpretFullDateRef` (missing case in #1488).