### PR TITLE
[WAI-ARIA] Moving waiAria flag to appSettings (instead of widgetSettings)

### DIFF
--- a/src/aria/core/environment/Environment.js
+++ b/src/aria/core/environment/Environment.js
@@ -187,6 +187,16 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Return true if waiAria mode is on.
+         * @public
+         * @return {Boolean}
+         */
+        isWaiAria : function () {
+            var settings = this.checkApplicationSettings("appSettings");
+            return !! (settings && settings.waiAria);
+        },
+
+        /**
          * Turn on or off auto-escaping of HTML in statements
          * @public
          * @param {Boolean} escape

--- a/src/aria/core/environment/EnvironmentBaseCfgBeans.js
+++ b/src/aria/core/environment/EnvironmentBaseCfgBeans.js
@@ -68,6 +68,11 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:Boolean",
                     $description : "Indicates if the application is in debug state (strong validation, more error reporting).",
                     $default : Aria.debug
+                },
+                "waiAria" : {
+                    $type : "json:Boolean",
+                    $description : "If true, accessibility-related DOM attributes are enabled, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better.",
+                    $default : false
                 }
             }
 

--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -24,7 +24,7 @@ var ariaWidgetsGlobalStyle = require("./GlobalStyle.tpl.css");
 var ariaWidgetLibsBindableWidget = require("../widgetLibs/BindableWidget");
 var ariaCoreTplClassLoader = require("../core/TplClassLoader");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
-var ariaWidgetsEnvironmentWidgetSettings = require("./environment/WidgetSettings");
+var environment = require("../core/environment/Environment");
 
 /**
  * Base Widget class from which all widgets must derive
@@ -140,7 +140,7 @@ module.exports = Aria.classDefinition({
         }
 
         if (cfg.waiAria == null) {
-            cfg.waiAria = ariaWidgetsEnvironmentWidgetSettings.getWidgetSettings().waiAria;
+            cfg.waiAria = environment.isWaiAria();
         }
 
         var bindings = cfg.bind;

--- a/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
+++ b/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
@@ -77,11 +77,6 @@ module.exports = Aria.beanDefinitions({
                     },
                     $default : {}
                 },
-                "waiAria" : {
-                    $type : "json:Boolean",
-                    $description : "If true, accessibility-related DOM attributes are enabled, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better.",
-                    $default : false
-                },
                 "defaultErrorMessages" : {
                     $type : "json:Object",
                     $description : "Default values for widgets' error messages.",

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteGlobalWaiTestCase.js
@@ -25,7 +25,7 @@ module.exports = Aria.classDefinition({
 
         run : function () {
             AppEnvironment.setEnvironment({
-                widgetSettings: {
+                appSettings: {
                     waiAria: true
                 }
             }, {

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteNonWaiTestCase.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteNonWaiTestCase.js
@@ -25,7 +25,7 @@ module.exports = Aria.classDefinition({
 
         run : function () {
             AppEnvironment.setEnvironment({
-                widgetSettings: {
+                appSettings: {
                     waiAria: true
                 }
             }, {


### PR DESCRIPTION
With this PR, the `waiAria` flag is now inside `appSettings` so that it can be used outside `AriaLib` widgets (e.g. for processing indicator...).