### PR TITLE
Adding doc about the yearBeforeMonth option (for aria.utils.Date functions)

### DIFF
--- a/src/aria/utils/Beans.js
+++ b/src/aria/utils/Beans.js
@@ -51,6 +51,10 @@ module.exports = Aria.beanDefinitions({
                 "cutYear" : {
                     $type : "json:Integer",
                     $description : "2-digits number above which a 2-digits year 'xx' is interpreted as '19xx' instead of '20xx'."
+                },
+                "yearBeforeMonth" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the year is written before or after the month."
                 }
             }
         }


### PR DESCRIPTION
The `yearBeforeMonth` option was not documented. This PR adds documentation in the bean.