### PR TITLE
Browser detection improvements: adding isEdge, fixing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "grunt-verifylowercase": "0.2.0",
     "jade": "1.1.5",
     "mocha": "1.17.0",
-    "ua-parser-js": "0.7.3"
+    "ua-parser-js": "git+https://github.com/ariatemplates/ua-parser-js#latest"
   }
 }

--- a/src/aria/core/Browser.js
+++ b/src/aria/core/Browser.js
@@ -177,6 +177,13 @@ module.exports = Aria.classDefinition({
          */
         this.isFirefox = false;
 
+        /**
+         * <em>true</em> if the browser is any version of Microsoft Edge.
+         * Some reference: https://msdn.microsoft.com/en-us/library/hh869301%28v=vs.85%29.aspx#edge
+         * @type Boolean
+         */
+        this.isEdge = false;
+
         /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1397) */
         /**
          * <b>Deprecated, use <em>aria.core.Browser.isFirefox instead</em>.</b>
@@ -941,18 +948,18 @@ module.exports = Aria.classDefinition({
                     case "safari":
                         if (output.isSymbian) {
                             this._setFlag(output, "S60");
-                        } else if (/(phantomjs)/ig.test(output.ua)) {
-                            this._setFlag(output, "PhantomJS");
-                            name = "PhantomJS";
                         } else {
                             this._setFlag(output, "Safari");
                         }
+                        break;
+                    case "androidbrowser":
+                        this._setFlag(output, "AndroidBrowser");
                         break;
                     default:
                         maybeOtherBrowser = true;
                 }
 
-                if (ariaUtilsArray.contains(["Firefox", "Chrome", "IE", "Opera", "IEMobile"], name)) {
+                if (ariaUtilsArray.contains(["Firefox", "Chrome", "IE", "Opera", "IEMobile", "Edge", "PhantomJS"], name)) {
                     this._setFlag(output, name);
                     maybeOtherBrowser = false;
                 }
@@ -1015,14 +1022,6 @@ module.exports = Aria.classDefinition({
                 // make sure output.version is consistent with detected
                 // major version
                 version = "" + detectedMajorVersion + ".0";
-            }
-
-            if (version == null) {
-                if (output.isPhantomJS) {
-                    if (/phantomjs[\/\s]((?:\d+\.?)+)/ig.test(output.ua)) {
-                        version = RegExp.$1;
-                    }
-                }
             }
 
             // ----------------------------------------------- major version (2)
@@ -1233,6 +1232,7 @@ module.exports = Aria.classDefinition({
             this.isIE11 = false;
             this.isOldIE = false;
             this.isModernIE = false;
+            this.isEdge = false;
             this.isFirefox = false;
             /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1397) */
             this._isFF = false;

--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1221,7 +1221,7 @@ module.exports = Aria.classDefinition({
             if (document == null) {
                 document = Aria.$window.document;
             }
-            return ((!(ariaCoreBrowser.isSafari || ariaCoreBrowser.isChrome) && (document.compatMode == "CSS1Compat"))
+            return ((!(ariaCoreBrowser.isSafari || ariaCoreBrowser.isChrome || ariaCoreBrowser.isEdge) && (document.compatMode == "CSS1Compat"))
                     ? document.documentElement
                     : document.body);
         },

--- a/test/aria/core/useragent/UseCases.js
+++ b/test/aria/core/useragent/UseCases.js
@@ -366,7 +366,7 @@ Aria.classDefinition({
     values: {
         browser: {
             properties: {
-                name : "Mobile Safari",
+                name : "Android Browser",
                 version : "4.0",
                 osName : "Android",
                 osVersion : "4.0.3"
@@ -395,7 +395,7 @@ Aria.classDefinition({
     values: {
         browser: {
             properties: {
-                name : "Mobile Safari",
+                name : "Android Browser",
                 version : "4.0",
                 osName : "Android",
                 osVersion : "2.2"


### PR DESCRIPTION
This commit adds the new isEdge flag to allow Microsoft Edge to be detected. For this purpose, the version of `ua-parser-js` was updated, which also fixes an invalid name for the Android Browser on some devices, and simplifies the code regarding PhantomJS detection.

Note that this pull request does not include any fix to improve the compatibility of Aria Templates with Microsoft Edge (which will be added in a later PR, if required)