### PR TITLE
Allowing JS plugins to be inserted client-side through the ?plugin= syntax

### DIFF
--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+    var window = this;
+
+    function fixedEncodeURI(str) {
+        return encodeURI(str).replace(/%5B/g, '[').replace(/%5D/g, ']');
+    }
+
+    window.location.search.replace(/(?:\?|\&)plugin=([^&]*)/g, function (match, plugin) {
+        var url = decodeURIComponent(plugin);
+        window.document.write('<script src="' + fixedEncodeURI(url) + '"></script>');
+        return "";
+    });
+})();

--- a/test/test.htm
+++ b/test/test.htm
@@ -78,6 +78,7 @@
         Aria.rootFolderPath = "../";
         aria.core.DownloadMgr.updateRootMap({"aria": {"*" : ariaRootPath}});
     </script>
+    <script type="text/javascript" src="plugins.js"></script>
     <style>
         #_TestInfoOutput_ {
             position: absolute;


### PR DESCRIPTION
This commit adds the "plugin" URL parameter which allows to add any JavaScript file in the test page.