### PR TITLE
Radio button and check box icon not centered vertically when the label has multiple lines

### DIFF
--- a/src/aria/widgets/Icon.js
+++ b/src/aria/widgets/Icon.js
@@ -159,7 +159,7 @@ module.exports = Aria.classDefinition({
          */
         _getIconStyle : function (iconInfo) {
             var cfg = this._cfg;
-            var vAlign = !iconInfo.verticalAlign ? "" : "vertical-align: " + iconInfo.verticalAlign;
+            var vAlign = !cfg.verticalAlign ? "" : "vertical-align: " + cfg.verticalAlign;
             var margins = "margin: 0 0 0 0 "; // default value
 
             if (cfg.margins != null && cfg.margins.match(/^(\d+|x) (\d+|x) (\d+|x) (\d+|x)$/)) {

--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -47,7 +47,8 @@ module.exports = Aria.classDefinition({
              * @protected
              */
             this._icon = new ariaWidgetsIcon({
-                icon : this._getIconName(this._state)
+                icon : this._getIconName(this._state),
+                verticalAlign : cfg.verticalAlign
             }, ctxt, lineNumber);
         }
 
@@ -153,25 +154,27 @@ module.exports = Aria.classDefinition({
             out.write('<span style="');
 
             if (this._skinObj.simpleHTML && cssDisplay != "block") {
-                out.write("padding-bottom: 7px;display:inline-block;");
+                out.write("padding-bottom: 7px;");
             }
 
             if (lineHeight && ariaCoreBrowser.isOldIE) {
                 out.write('line-height:' + (lineHeight - 2) + 'px;');
             }
-            var cssClass = 'class="x' + this._skinnableClass + '_' + cfg.sclass + '_' + this._state + '_label"';
-            out.write('vertical-align:middle;"><label ' + cssClass + ' style="display:' + cssDisplay);
 
             if (margin) {
-                out.write(';margin-' + margin + ':' + this._labelPadding + 'px');
+                out.write('margin-' + margin + ':' + this._labelPadding + 'px;');
             }
             if (cfg.labelWidth > -1) {
-                out.write(';width:' + cfg.labelWidth + 'px');
+                out.write('width:' + cfg.labelWidth + 'px;');
             }
+
+            out.write('text-align:' + cfg.labelAlign + ';display:' + cssDisplay + ';');
+            var cssClass = 'class="x' + this._skinnableClass + '_' + cfg.sclass + '_' + this._state + '_label"';
+            out.write('vertical-align:middle;"><label ' + cssClass + ' style="');
             if (color) {
-                out.write(';color:' + color);
+                out.write('color:' + color + ';');
             }
-            out.write(';text-align:' + cfg.labelAlign + ';">');
+            out.write('">');
             out.write(ariaUtilsString.escapeHTML(cfg.label));
 
             out.write('</label></span>');

--- a/test/aria/widgets/form/radiobutton/RadioButtonTestSuite.js
+++ b/test/aria/widgets/form/radiobutton/RadioButtonTestSuite.js
@@ -21,5 +21,6 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.form.radiobutton.checkBind.test1.RadioButtonTest");
         this.addTests("test.aria.widgets.form.radiobutton.checkBind.test2.RadioButtonTest");
+        this.addTests("test.aria.widgets.form.radiobutton.multiLine.MultiLineTestCase");
     }
 });

--- a/test/aria/widgets/form/radiobutton/multiLine/MultiLineTestCase.js
+++ b/test/aria/widgets/form/radiobutton/multiLine/MultiLineTestCase.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.radiobutton.multiLine.MultiLineTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Dom", "aria.core.Browser"],
+    $prototype : {
+        runTemplateTest : function () {
+            var container = this.getElementById("container");
+            this.tolerance = aria.core.Browser.isIE7 || aria.core.Browser.isIE8 ? 3 : 1;
+            this.checkMiddle("rbMiddle");
+            this.checkTop("rbTop");
+            this.checkBottom("rbBottom");
+            this.checkMiddle("rbDefault");
+            this.notifyTemplateTestEnd();
+        },
+
+        getRadioButtonGeometry : function (id) {
+            var radioButton = this.getWidgetInstance(id);
+            radioButton.getDom();
+            var icon = radioButton._icon.getDom();
+            var label = radioButton._label;
+            var geometry = {
+                label: aria.utils.Dom.getGeometry(label),
+                icon: aria.utils.Dom.getGeometry(icon)
+            };
+            this.assertTrue(geometry.icon.x + geometry.icon.width <= geometry.label.x, "The icon should be on the left of the label.");
+            return geometry;
+        },
+
+        checkTop: function (id) {
+            var geometry = this.getRadioButtonGeometry(id);
+            this.assertEqualsWithTolerance(geometry.icon.y, geometry.label.y, this.tolerance, "The icon should be at the top.");
+        },
+
+        checkMiddle: function (id) {
+            var geometry = this.getRadioButtonGeometry(id);
+            this.assertEqualsWithTolerance(geometry.icon.y, geometry.label.y + (geometry.label.height - geometry.icon.height) / 2, this.tolerance, "The icon should be centered.");
+        },
+
+        checkBottom: function (id) {
+            var geometry = this.getRadioButtonGeometry(id);
+            this.assertEqualsWithTolerance(geometry.icon.y, geometry.label.y + geometry.label.height - geometry.icon.height, this.tolerance, "The icon should be at the bottom.");
+        }
+    }
+});

--- a/test/aria/widgets/form/radiobutton/multiLine/MultiLineTestCaseTpl.tpl
+++ b/test/aria/widgets/form/radiobutton/multiLine/MultiLineTestCaseTpl.tpl
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.form.radiobutton.multiLine.MultiLineTestCaseTpl"
+}}
+  {macro main()}
+      <div {id "container"/} style="padding:20px;width:290px">
+        {@aria:RadioButton {
+          id : "rbTop",
+          labelWidth: 250,
+          keyValue: "vTop",
+          verticalAlign:"top",
+          label: "This is a very long option, which should probably go to the next line, but with the icon at the top! This is a very long option, which should probably go to the next line, but with the icon at the top!",
+          bind : {
+            value : {
+              inside : data,
+              to : "value"
+            }
+          }
+        }/}<br><br>
+        {@aria:RadioButton {
+          id : "rbBottom",
+          labelWidth: 250,
+          keyValue: "vBottom",
+          verticalAlign:"bottom",
+          label: "This is a very long option, which should probably go to the next line, but with the icon at the bottom! This is a very long option, which should probably go to the next line, but with the icon at the bottom!",
+          bind : {
+            value : {
+              inside : data,
+              to : "value"
+            }
+          }
+        }/}<br><br>
+        {@aria:RadioButton {
+          id : "rbMiddle",
+          labelWidth: 250,
+          keyValue: "vMiddle",
+          verticalAlign:"middle",
+          label: "This is a very long option, which should probably go to the next line, but with the icon at the middle! This is a very long option, which should probably go to the next line, but with the icon at the middle!",
+          bind : {
+            value : {
+              inside : data,
+              to : "value"
+            }
+          }
+        }/}<br><br>
+        {@aria:RadioButton {
+          id : "rbDefault",
+          labelWidth: 250,
+          keyValue: "vDefault",
+          label: "This is a very long option, which should probably go to the next line, but with the icon at the default position! This is a very long option, which should probably go to the next line, but with the icon at the default position!",
+          bind : {
+            value : {
+              inside : data,
+              to : "value"
+            }
+          }
+        }/}<br><br>
+      </div>
+  {/macro}
+{/Template}


### PR DESCRIPTION
This pull request fixes an issue with the check box and radio button when the label is large enough to wrap over multiple lines: the icon was not centered vertically.