### PR TITLE
fix aria.utils.Dom.scrollIntoView issue on Chrome

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1147,6 +1147,12 @@ module.exports = Aria.classDefinition({
 
                 if (element) {
                     var hasScrollbar = (!element.clientHeight) ? false : element.scrollHeight > element.clientHeight;
+
+                    // On Chrome, documentScroll == document.body due to https://code.google.com/p/chromium/issues/detail?id=157855
+                    // But if the body has no margin: document.body.scrollHeight == document.body.clientHeight
+                    // and hasScrollbar can be false even if there is a scrollbar. That's why the following line was added:
+                    hasScrollbar = hasScrollbar || (element == documentScroll && documentScroll == document.body);
+
                     if (!hasScrollbar) {
                         if (element == documentScroll) {
                             element = null;

--- a/test/aria/utils/DomScrollIntoView.js
+++ b/test/aria/utils/DomScrollIntoView.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.utils.DomScrollIntoView",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype: {
+        testScrollIntoViewChromeBug : function () {
+            var document = Aria.$window.document;
+            var bodyStyle = document.body.style.cssText;
+            var containerElement;
+            try {
+                // Makes sure the document is initially not scrolled:
+                Aria.$window.scroll(0, 0);
+                // sets the margin on the body as 0 which makes document.body.scrollHeight == document.body.clientHeight
+                document.body.style.cssText = "margin:0;";
+                var containerElement = document.createElement("div");
+                document.body.appendChild(containerElement);
+                containerElement.style.cssText = "position:relative;height:3000px;";
+                var childElement = document.createElement("div");
+                containerElement.appendChild(childElement);
+                childElement.style.cssText = "position:absolute;width:10px;height:10px;left:10px;top:1500px;background-color:blue;z-index:1000;";
+                var elementInitialGeometry = aria.utils.Dom.getGeometry(childElement);
+                this.assertTrue(elementInitialGeometry.y >= 1500, "The pre-condition is not satisfied");
+                aria.utils.Dom.scrollIntoView(childElement, true);
+                var elementFinalGeometry = aria.utils.Dom.getGeometry(childElement);
+                this.assertEqualsWithTolerance(elementFinalGeometry.y, 0, 2, "scrollIntoView did not work."); // 2 px of tolerance for IE7
+            } finally {
+                if (containerElement) {
+                    document.body.removeChild(containerElement);
+                }
+                document.body.style.cssText = bodyStyle;
+            }
+        }
+    }
+});

--- a/test/aria/utils/UtilsTestSuite.js
+++ b/test/aria/utils/UtilsTestSuite.js
@@ -42,6 +42,7 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.DateCompare");
         this.addTests("test.aria.utils.Delegate");
         this.addTests("test.aria.utils.Dom");
+        this.addTests("test.aria.utils.DomScrollIntoView");
         this.addTests("test.aria.utils.Ellipsis");
         this.addTests("test.aria.utils.Event");
         this.addTests("test.aria.utils.FireDomEvent");

--- a/test/attester-nophantom.yml
+++ b/test/attester-nophantom.yml
@@ -21,6 +21,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test4.DialogOnResizeScrollTestCase
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
+    - test.aria.utils.DomScrollIntoView
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
   # This test works in Firefox and Chrome locally but not on Travis... It is removed in .travis.yml
     - test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive

--- a/test/attester-packaged.yml
+++ b/test/attester-packaged.yml
@@ -23,6 +23,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test4.DialogOnResizeScrollTestCase
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
+    - test.aria.utils.DomScrollIntoView
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
     - test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive
    #Excluded from this file but added in attester.yml (tests for the unpackaged version):


### PR DESCRIPTION
aria.utils.Dom.scrollIntoView failed to scroll the document on Chrome when the body had no margin.