### PR TITLE
Adding WAI-ARIA to loading indicator

### DIFF
--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -67,7 +67,9 @@ module.exports = Aria.classDefinition({
             var overlay = this.$Overlay._createOverlay.call(this, params);
 
             if (this.__text) {
-                overlay.innerHTML = "<span class='xLDI-text'>" + this.__text + "</span>";
+                overlay.innerHTML = this._waiAria ?
+                    "<span class='xLDI-text' aria-live='polite'>" + this.__text + "</span>" :
+                    "<span class='xLDI-text'>" + this.__text + "</span>";
             }
 
             return overlay;

--- a/src/aria/utils/overlay/Overlay.js
+++ b/src/aria/utils/overlay/Overlay.js
@@ -14,6 +14,7 @@
  */
 var Aria = require("../../Aria");
 var ariaUtilsDom = require("../Dom");
+var environment = require("../../core/environment/Environment");
 
 /**
  * This class creates an overlay and keeps it positioned above a given HTML element
@@ -22,6 +23,19 @@ var ariaUtilsDom = require("../Dom");
 module.exports = Aria.classDefinition({
     $classpath : 'aria.utils.overlay.Overlay',
     $constructor : function (element, params) {
+        /**
+         * Element on which the overlay is applied
+         * @type HTMLElement
+         */
+        this.element = element;
+
+        /**
+         * Environment variable related to WAI-ARIA activation
+         @ @protected
+         * @type Boolean
+         */
+        this._waiAria = environment.isWaiAria();
+
         var overlay = this._createOverlay(params);
 
         /**
@@ -29,12 +43,6 @@ module.exports = Aria.classDefinition({
          * @type HTMLElement
          */
         this.overlay = overlay;
-
-        /**
-         * Element on which the overlay is applied
-         * @type HTMLElement
-         */
-        this.element = element;
 
         this._appendToDOM(overlay);
         this._setInPosition(element, overlay);

--- a/test/aria/utils/overlay/OverlayTestSuite.js
+++ b/test/aria/utils/overlay/OverlayTestSuite.js
@@ -28,5 +28,7 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.overlay.loadingIndicator.ieScrollIssue.IEScrollIssueTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.ieScrollIssue2.IEScrollIssue2EltTest");
         this.addTests("test.aria.utils.overlay.loadingIndicator.ieScrollIssue2.IEScrollIssue2SectionTest");
+
+        this.addTests("test.aria.utils.overlay.loadingIndicator.wai.WaiAriaTest");
     }
 });

--- a/test/aria/utils/overlay/loadingIndicator/IndicatorHelper.js
+++ b/test/aria/utils/overlay/loadingIndicator/IndicatorHelper.js
@@ -84,6 +84,19 @@ Aria.classDefinition({
          */
         getOverlay : function (element) {
             return aria.utils.DomOverlay.__getOverlay(element);
+        },
+
+        /**
+         * Return the label node from the overlay associated to that element
+         * @param {HTMLElement} element
+         * @return {HTMLElement} span label node
+         */
+        getLabelElement : function(element) {
+            var overlay = this.getOverlay(element);
+            if (!overlay) {
+                return false;
+            }
+            return overlay.overlay.overlay.firstChild;
         }
     }
 });

--- a/test/aria/utils/overlay/loadingIndicator/wai/WaiAriaTest.js
+++ b/test/aria/utils/overlay/loadingIndicator/wai/WaiAriaTest.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+var liHelper = require("test/aria/utils/overlay/loadingIndicator/IndicatorHelper");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.utils.overlay.loadingIndicator.wai.WaiAriaTest",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor: function() {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            processing: false
+        };
+        this.setTestEnv({
+            template : "test.aria.utils.overlay.loadingIndicator.wai.WaiAriaTestTpl",
+            data : this.data
+        });
+    },
+    $prototype : {
+        run : function () {
+            AppEnvironment.setEnvironment({
+                appSettings: {
+                    waiAria: true
+                }
+            }, {
+                scope: this,
+                fn: this.$TemplateTestCase.run
+            });
+        },
+
+        runTemplateTest : function () {
+            var sectionDom, labelDom, liveAttr;
+            try {
+                sectionDom = this.getElementById("waiSection");
+
+                aria.utils.Json.setValue(this.data, "processing", true);
+
+                labelDom = liHelper.getLabelElement(sectionDom);
+                liveAttr = labelDom.getAttribute("aria-live");
+
+                this.assertNotNull(liveAttr, "aria-live attribute should exist");
+                this.assertEquals(liveAttr, "polite", "aria-live attribute should be set to 'polite'");
+
+                this.notifyTemplateTestEnd();
+            } catch (e) {
+                this.handleAsyncTestError(e);
+            }
+        }
+    }
+});

--- a/test/aria/utils/overlay/loadingIndicator/wai/WaiAriaTestTpl.tpl
+++ b/test/aria/utils/overlay/loadingIndicator/wai/WaiAriaTestTpl.tpl
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath: "test.aria.utils.overlay.loadingIndicator.wai.WaiAriaTestTpl"
+}}
+    {macro main()}
+        {section {
+           id: "waiSection",
+           type: "div",
+           attributes: {
+              style: "width:500px;height:400px"
+           },
+           macro: "waiAria",
+           bindProcessingTo: {
+              to: "processing",
+              inside: data
+           },
+           processingLabel: "Hello I am jaws reading this message"
+        }/}
+    {/macro}
+
+    {macro waiAria()}
+      This is a simple macro.
+    {/macro}
+{/Template}


### PR DESCRIPTION
This change introduces the generation of an `aria-live="polite"` attribute on the span that contains informative text on loading overlays.