### PR TITLE
Revert "fix #1314 disable robot for Firefox 3.6"

### DIFF
--- a/src/aria/jsunit/RobotTestCase.js
+++ b/src/aria/jsunit/RobotTestCase.js
@@ -50,14 +50,10 @@ module.exports = Aria.classDefinition({
          */
         run : function () {
             var robot = ariaJsunitRobot;
-
             if (!this.skipTest && !robot.isUsable()) {
                 this._startTest();
-                var isOldFirefox = (aria.core.Browser.isFirefox && aria.core.Browser.majorVersion < 4);
-                if (!isOldFirefox) {
-                    this._currentTestName = 'RobotTestCase:run';
-                    this.raiseFailure('The robot is not usable');
-                }
+                this._currentTestName = 'RobotTestCase:run';
+                this.raiseFailure('The robot is not usable');
                 this._endTest();
             } else {
                 this.$TemplateTestCase.run.call(this);


### PR DESCRIPTION
This reverts commit e55822502a93ba95fdcf3b07f885d543c99692c0.

Let's re-enable robot tests in Firefox 3.6 as [robot-server](https://github.com/attester/robot-server) is compatible with Firefox 3.6.