### PR TITLE
Allowing dialogs to be inside a container

### DIFF
--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -134,6 +134,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "animation:AnimationName",
                     $description : "When the popup is being opened, the animation is applied",
                     $sample : "slide left"
+                },
+                "popupContainer" : {
+                    $type : "json:ObjectRef",
+                    $description : "[Optional] Object implementing the IPopupContainer interface, which defines in which container the popup will be added. By default, the aria.popups.container.Viewport singleton is used and the popup is a direct child of document.body."
                 }
             }
         },

--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -345,7 +345,8 @@ var ariaUtilsDelegate = require("../utils/Delegate");
                             // the element is in the modal popup, it is fine to focus it
                             break;
                         }
-                        if (popup.modalMaskDomElement) {
+                        if (popup.modalMaskDomElement && utilsDom.isAncestor(target, popup.popupContainer.getContainerElt())) {
+                            // the element is inside the container for which there is a modal mask
                             ariaTemplatesNavigationManager.focusFirst(popup.domElement);
                             break;
                         }

--- a/src/aria/popups/container/DomElement.js
+++ b/src/aria/popups/container/DomElement.js
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("ariatemplates/Aria");
+var DomUtils = require("../../utils/Dom");
+
+/**
+ * Implementation of the IPopupContainer interface to use any HTMLElement as a popup
+ * container.
+ */
+module.exports = Aria.classDefinition({
+    $classpath : "aria.popups.container.DomElement",
+    $implements : [require("./IPopupContainer")],
+    $constructor : function (container) {
+        this.container = container;
+    },
+    $destructor : function () {
+        this.container = null;
+    },
+    $statics : {
+        BASE_NOT_IMPLEMENTED: "The 'base' parameter for the %1 method is not implemented."
+    },
+    $prototype : {
+        /**
+         * Returns the DOM element of the container, to which the popup DOM element
+         * and its mask will be appended.
+         * @return {HTMLElement}
+         */
+        getContainerElt : function () {
+            return this.container;
+        },
+
+        /**
+         * Returns the DOM element of the container (as returned by getContainerElt).
+         * @return {String|HTMLElement}
+         */
+        getContainerRef : function () {
+            return this.container;
+        },
+
+        /**
+         * Returns an object containing the scroll position of the container.
+         * @return {Object} Object with 'scrollLeft' and 'scrollTop' properties.
+         */
+        getContainerScroll : function () {
+            var container = this.container;
+            return {
+                scrollLeft: container.scrollLeft,
+                scrollTop: container.scrollTop
+            };
+        },
+
+        /**
+         * Returns the overflow style of the container.
+         * @return {String}
+         */
+        getContainerOverflow : function () {
+            return this.container.style.overflow;
+        },
+
+        /**
+         * Changes the overflow style of the container.
+         * Returns the previous value.
+         * @param {String} new overflow value
+         * @return {String} old overflow value
+         */
+        changeContainerOverflow : function (newValue) {
+            var containerStyle = this.container.style;
+            var res = containerStyle.overflow;
+            containerStyle.overflow = newValue;
+            return res;
+        },
+
+        /**
+         * Returns the position of the given domElt, in the coordinates of the container.
+         * @param {HTMLElement} domElt element whose position will be returned
+         * @return {aria.utils.DomBeans:Position}
+         */
+        calculatePosition : function (domElt) {
+            var position = DomUtils.calculatePosition(domElt);
+            var container = this.container;
+            var containerPosition = DomUtils.calculatePosition(container);
+            return {
+                left : position.left - containerPosition.left - container.clientLeft,
+                top: position.top - containerPosition.top - container.clientTop
+            };
+        },
+
+        /**
+         * Returns the size of the container's content (if this is larger than the value returned
+         * by getClientSize, scrollbars are needed to view the full content).
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getScrollSize : function () {
+            var container = this.container;
+            return {
+                width: container.scrollWidth,
+                height: container.scrollHeight
+            };
+        },
+
+        /**
+         * Returns the size of the container's client area.
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getClientSize : function () {
+            var container = this.container;
+            return {
+                width: container.clientWidth,
+                height: container.clientHeight
+            };
+        },
+
+        /**
+         * Returns the position and size of the container's client area, in the
+         * container's coordinates.
+         */
+        _getGeometry : function () {
+            var container = this.container;
+            return {
+                x: container.scrollLeft,
+                y: container.scrollTop,
+                width: container.clientWidth,
+                height: container.clientHeight
+            };
+        },
+
+        /**
+         * Check if a given position + size couple can fit in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base This parameter should not be defined (not implemented)
+         * @return {Boolean} True if the given position+size couple can fit in the current viewport
+         */
+        isInside : function (position, size, base) {
+            if (base) {
+                this.$logError(this.BASE_NOT_IMPLEMENTED, ["isInside"]);
+            }
+            return DomUtils.isInside({
+                x: position.left,
+                y: position.top,
+                width: size.width,
+                height: size.height
+            }, this._getGeometry());
+        },
+
+        /**
+         * Given a position + size couple, returns a corrected position that should fit in the container.
+         * If the size is bigger than the container it returns a position such that the top left corner
+         * of the element is in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base This parameter should not be defined (not implemented)
+         * @return {aria.utils.DomBeans:Position}
+         */
+        fitInside : function (position, size, base) {
+            if (base) {
+                this.$logError(this.BASE_NOT_IMPLEMENTED, ["fitInside"]);
+            }
+            return DomUtils.fitInside({
+                x: position.left,
+                y: position.top,
+                width: size.width,
+                height: size.height
+            },  this._getGeometry());
+        },
+
+        /**
+         * Center the given size in the container.
+         * @param {aria.utils.DomBeans:Size} size size of the element to center in the container
+         * @param {Object} base This parameter should not be defined (not implemented)
+         * @return {aria.utils.DomBeans:Position} position of the element when centered in the container
+         */
+        centerInside : function (size, base) {
+            if (base) {
+                this.$logError(this.BASE_NOT_IMPLEMENTED, ["centerInside"]);
+            }
+            var container = this.container;
+            return {
+                left : Math.floor(container.scrollLeft + (container.clientWidth - size.width) / 2),
+                top : Math.floor(container.scrollTop + (container.clientHeight - size.height) / 2)
+            };
+        }
+
+    }
+});

--- a/src/aria/popups/container/IPopupContainer.js
+++ b/src/aria/popups/container/IPopupContainer.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("ariatemplates/Aria");
+
+/**
+ * Interface used by the Popup class and the @aria:Dialog widget to interact with
+ * the popup container.
+ */
+module.exports = Aria.interfaceDefinition({
+    $classpath : "aria.popups.container.IPopupContainer",
+    $interface : {
+        /**
+         * Returns the DOM element of the container, to which the popup DOM element
+         * and its mask will be appended.
+         * @return {HTMLElement}
+         */
+        getContainerElt : function () {},
+
+        /**
+         * Returns aria.utils.Dom.VIEWPORT if the container is the viewport,
+         * otherwise the DOM element of the container (as returned by getContainerElt).
+         * @return {String|HTMLElement}
+         */
+        getContainerRef : function () {},
+
+        /**
+         * Returns an object containing the scroll position of the container.
+         * @return {Object} Object with 'scrollLeft' and 'scrollTop' properties.
+         */
+        getContainerScroll : function () {},
+
+        /**
+         * Returns the overflow style of the container.
+         * @return {String}
+         */
+        getContainerOverflow : function () {},
+
+        /**
+         * Changes the overflow style of the container.
+         * Returns the previous value.
+         * @param {String} new overflow value
+         * @return {String} old overflow value
+         */
+        changeContainerOverflow : function (newValue) {},
+
+        /**
+         * Returns the position of the given domElt, in the coordinates of the container.
+         * @param {HTMLElement} domElt element whose position will be returned
+         * @return {aria.utils.DomBeans:Position}
+         */
+        calculatePosition : function (domElt) {},
+
+        /**
+         * Returns the size of the container's content (if this is larger than the value returned
+         * by getClientSize, scrollbars are needed to view the full content).
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getScrollSize : function () {},
+
+        /**
+         * Returns the size of the container's client area.
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getClientSize : function () {},
+
+        /**
+         * Check if a given position + size couple can fit in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {Boolean} True if the given position+size couple can fit in the current viewport
+         */
+        isInside : function (position, size, base) {},
+
+        /**
+         * Given a position + size couple, returns a corrected position that should fit in the container.
+         * If the size is bigger than the container it returns a position such that the top left corner
+         * of the element is in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {aria.utils.DomBeans:Position}
+         */
+        fitInside : function (position, size, base) {},
+
+        /**
+         * Center the given size in the container.
+         * @param {aria.utils.DomBeans:Size} size size of the element to center in the container
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {aria.utils.DomBeans:Position} position of the element when centered in the container
+         */
+        centerInside : function (size, base) {}
+    }
+});

--- a/src/aria/popups/container/Manager.js
+++ b/src/aria/popups/container/Manager.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("../../Aria");
+var DomUtils = require("../../utils/Dom");
+var TypeUtils = require("../../utils/Type");
+var Viewport = require("./Viewport");
+var DomElement = require("./DomElement");
+
+/**
+ * This class allows to create and release popup containers.
+ */
+module.exports = Aria.classDefinition({
+    $classpath : "aria.popups.container.Manager",
+    $singleton : true,
+    $statics : {
+        ID_NOT_FOUND : "Missing element with id '%1' in DOM."
+    },
+    $prototype : {
+        /**
+         * Creates (if needed) and returns a popup container object corresponding to the given DOM element.
+         * The return value is an object which implements the aria.popups.container.IPopupContainer interface.
+         * When the returned object is no longer useful, it has to be released with the releasePopupContainer
+         * method.
+         * @param {String|HTMLElement} idOrElt Id of an element or
+         * @return {Object}
+         */
+        createPopupContainer : function (idOrElt) {
+            var domElt = idOrElt;
+            if (TypeUtils.isString(idOrElt)) {
+                domElt = DomUtils.getElementById(idOrElt);
+                if (!domElt) {
+                    this.$logError(this.ID_NOT_FOUND, [idOrElt]);
+                }
+            }
+            var body = Aria.$window.document.body;
+            domElt = domElt || body;
+            return (domElt == body ? Viewport : new DomElement(domElt));
+        },
+
+        /**
+         * This method should be called with the value returned by createPopupContainer when it is no longer
+         * useful, to properly dispose it.
+         * @param {Object} instance Value returned by createPopupContainer.
+         */
+        releasePopupContainer : function (instance) {
+            if (instance instanceof DomElement) {
+                instance.$dispose();
+            }
+        }
+    }
+ });

--- a/src/aria/popups/container/Viewport.js
+++ b/src/aria/popups/container/Viewport.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("../../Aria");
+var DomUtils = require("../../utils/Dom");
+var Browser = require("../../core/Browser");
+
+/**
+ * Implementation of the IPopupContainer interface to use the viewport (document.body)
+ * as a popup container.
+ */
+module.exports = Aria.classDefinition({
+    $classpath : "aria.popups.container.Viewport",
+    $singleton : true,
+    $implements : [require("./IPopupContainer")],
+    $prototype : {
+        /**
+         * Returns the DOM element of the container, to which the popup DOM element
+         * and its mask will be appended.
+         * @return {HTMLElement}
+         */
+        getContainerElt : function () {
+            return Aria.$window.document.body;
+        },
+
+        /**
+         * Returns aria.utils.Dom.VIEWPORT.
+         * @return {String}
+         */
+        getContainerRef : function () {
+            return DomUtils.VIEWPORT;
+        },
+
+        /**
+         * Returns an object containing the scroll position of the container.
+         * @return {Object} Object with 'scrollLeft' and 'scrollTop' properties.
+         */
+        getContainerScroll : function () {
+            return DomUtils._getDocumentScroll();
+        },
+
+        /**
+         * Returns the overflow style of the container.
+         * @return {String}
+         */
+        getContainerOverflow : function () {
+            return DomUtils.getDocumentScrollElement().style.overflow;
+        },
+
+        /**
+         * Changes the overflow style of the container.
+         * Returns the previous value.
+         * @param {String} new overflow value
+         * @return {String} old overflow value
+         */
+        changeContainerOverflow : function (newValue) {
+            // PTR 04893174 was rolled back for release 1.1-13 because it introduces a regression on Airrail.
+            // PTR 04893174: do not set scrollElement = document.body on Firefox, as it resets all scrolling
+            // position when changing the overflow style
+            // PTR 05210073: the changes reverted for PTR 04893174 were put back in place and the code changes
+            // in order to fix the regression were implemented
+
+            var scrollElement = DomUtils.getDocumentScrollElement();
+            var res = scrollElement.style.overflow;
+            if (Browser.isFirefox) {
+                var docScroll = DomUtils._getDocumentScroll();
+                scrollElement.style.overflow = newValue;
+                scrollElement.scrollTop = docScroll.scrollTop;
+                scrollElement.scrollLeft = docScroll.scrollLeft;
+            } else {
+                scrollElement.style.overflow = newValue;
+            }
+            return res;
+        },
+
+        /**
+         * Returns the position of the given domElt, in the coordinates of the container.
+         * @param {HTMLElement} domElt element whose position will be returned
+         * @return {aria.utils.DomBeans:Position}
+         */
+        calculatePosition : function (domElt) {
+            var position = DomUtils.calculatePosition(domElt);
+            return {
+                left: position.left,
+                top: position.top
+            };
+        },
+
+        /**
+         * Returns the size of the container's content (if this is larger than the value returned
+         * by getClientSize, scrollbars are needed to view the full content).
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getScrollSize : function () {
+            var viewport = DomUtils._getViewportSize();
+            var scrollElement = DomUtils.getDocumentScrollElement();
+            // ensure that all viewport is used
+            return {
+                width: Math.max(viewport.width, scrollElement.scrollWidth),
+                height: Math.max(viewport.height, scrollElement.scrollHeight)
+            };
+        },
+
+        /**
+         * Returns the size of the container's client area.
+         * @return {aria.utils.DomBeans:Size}
+         */
+        getClientSize : function () {
+            return DomUtils._getViewportSize();
+        },
+
+        /**
+         * Check if a given position + size couple can fit in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {Boolean} True if the given position+size couple can fit in the current viewport
+         */
+        isInside : function (position, size, base) {
+            return DomUtils.isInViewport(position, size, base);
+        },
+
+        /**
+         * Given a position + size couple, returns a corrected position that should fit in the container.
+         * If the size is bigger than the container it returns a position such that the top left corner
+         * of the element is in the container.
+         * @param {aria.utils.DomBeans:Position} position
+         * @param {aria.utils.DomBeans:Size} size
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {aria.utils.DomBeans:Position}
+         */
+        fitInside : function (position, size, base) {
+            return DomUtils.fitInViewport(position, size, base);
+        },
+
+        /**
+         * Center the given size in the container.
+         * @param {aria.utils.DomBeans:Size} size size of the element to center in the container
+         * @param {Object} base The base element used to account for scrolling offsets
+         * @return {aria.utils.DomBeans:Position} position of the element when centered in the container
+         */
+        centerInside : function (size, base) {
+            return DomUtils.centerInViewport(size, base);
+        }
+    }
+});

--- a/src/aria/templates/Layout.js
+++ b/src/aria/templates/Layout.js
@@ -201,6 +201,16 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
             },
             // viewportSize: {width: ..., height: ...},
 
+            /**
+             * Raises the viewportResized event with the current viewport size.
+             */
+            refreshLayout : function () {
+                layout.$raiseEvent({
+                    name : "viewportResized",
+                    viewportNewSize : layout.viewportSize
+                });
+            },
+
             $on : function () {
                 this.$JsObject.$on.apply(this, arguments);
                 __checkListeners();

--- a/src/aria/utils/dragdrop/Drag.js
+++ b/src/aria/utils/dragdrop/Drag.js
@@ -498,7 +498,7 @@ var document = Aria.$frameworkWindow.document;
 
                 }
                 if (constrainTo) {
-                    this._boundary = ariaUtilsDom.getGeometry(constrainTo);
+                    this._boundary = ariaUtilsDom.getClientGeometry(constrainTo);
                     return;
                 }
                 this._boundary = null;

--- a/src/aria/utils/resize/Resize.js
+++ b/src/aria/utils/resize/Resize.js
@@ -45,7 +45,7 @@ module.exports = Aria.classDefinition({
             cursor : params.cursor,
             proxy : proxy,
             axis : params.axis,
-            constrainTo : ariaUtilsDom.VIEWPORT
+            constrainTo : params.constrainTo || ariaUtilsDom.VIEWPORT
         });
 
     },

--- a/src/aria/utils/resize/Resize.js
+++ b/src/aria/utils/resize/Resize.js
@@ -63,6 +63,10 @@ module.exports = Aria.classDefinition({
         start : function (coord) {
             this.posX = coord.x;
             this.posY = coord.y;
+            this._mouseInitialPosition = {
+                left : coord.x,
+                top : coord.y
+            };
             var element = this.getElement(true), movable, document = Aria.$window.document;
             // This will prevent text selection on IE on the element
             element.onselectstart = Aria.returnFalse;
@@ -93,10 +97,12 @@ module.exports = Aria.classDefinition({
 
             var movable = this.getMovable();
             if (movable && movable.style) {
+                var mouseInitPos = this._mouseInitialPosition;
+                var movableInitPos = this._movableInitialGeometry;
 
-                var offsetX = this._vertical ? 0 : evt.clientX - this.posX;
-                var offsetY = this._horizontal ? 0 : evt.clientY - this.posY;
-                var geometry = ariaUtilsJson.copy(this._movableGeometry), dw, dh;
+                var offsetX = this._vertical ? 0 : evt.clientX - mouseInitPos.left;
+                var offsetY = this._horizontal ? 0 : evt.clientY - mouseInitPos.top;
+                var geometry = ariaUtilsJson.copy(movableInitPos), dw, dh;
 
                 geometry = this._resizeWitHandlers(geometry, this.cursor, offsetX, offsetY);
 
@@ -123,6 +129,9 @@ module.exports = Aria.classDefinition({
                 movable.style.left = (geometry.x - this._baseMovableOffset.left) + "px";
                 movable.style.height = (geometry.height - this._baseMovableOffset.height) + "px";
                 movable.style.width = (geometry.width - this._baseMovableOffset.width) + "px";
+
+                this.posY = mouseInitPos.top + geometry.y - movableInitPos.y;
+                this.posX = mouseInitPos.left + geometry.x - movableInitPos.x;
                 this._movableGeometry = geometry;
                 this.$raiseEvent("resize");
             }
@@ -169,15 +178,12 @@ module.exports = Aria.classDefinition({
                     geometry.y += offsetY;
                     geometry.height -= offsetY;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posY += geometry.y - this._movableGeometry.y;
                     break;
                 case "ne-resize" :
                     geometry.y += offsetY;
                     geometry.height -= offsetY;
                     geometry.width += offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posX += offsetX;
-                    this.posY += geometry.y - this._movableGeometry.y;
                     break;
                 case "nw-resize" :
                     geometry.x += offsetX;
@@ -185,57 +191,72 @@ module.exports = Aria.classDefinition({
                     geometry.height -= offsetY;
                     geometry.width -= offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posX += geometry.x - this._movableGeometry.x;
-                    this.posY += geometry.y - this._movableGeometry.y;
                     break;
                 case "s-resize" :
                     geometry.height += offsetY;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posY += offsetY;
                     break;
                 case "se-resize" :
                     geometry.height += offsetY;
                     geometry.width += offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posY += offsetY;
-                    this.posX += offsetX;
                     break;
                 case "sw-resize" :
                     geometry.x += offsetX;
                     geometry.height += offsetY;
                     geometry.width -= offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posY += offsetY;
-                    this.posX += geometry.x - this._movableGeometry.x;
                     break;
                 case "e-resize" :
                     geometry.width += offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posX += offsetX;
                     break;
                 case "w-resize" :
                     geometry.x += offsetX;
                     geometry.width -= offsetX;
                     geometry = this._fitResizeBoundary(geometry);
-                    this.posX += geometry.x - this._movableGeometry.x;
                     break;
             }
             return geometry;
         },
         /**
-         * fits the top and left position of the element within viewport
+         * Fits the resized element within viewport
          * @param {aria.utils.DomBeans:Geometry} geometry
-         * @return {aria.utils.DomBeans:Position} top and left values of the fitted geometry
+         * @return {aria.utils.DomBeans:Geometry} fitted geometry
          */
 
         _fitResizeBoundary : function (geometry) {
-            var domUtil = ariaUtilsDom;
-            var pos = (this._boundary) ? domUtil.fitInside(geometry, this._boundary) : {
-                top : geometry.y,
-                left : geometry.x
-            };
-            geometry.x = pos.left;
-            geometry.y = pos.top;
+            var boundary = this._boundary;
+            if (boundary) {
+                var boundaryGeometry = boundary;
+                if (boundary == ariaUtilsDom.VIEWPORT) {
+                    var viewportSize = ariaUtilsDom._getViewportSize();
+                    boundaryGeometry = {
+                        x: 0,
+                        y: 0,
+                        width: viewportSize.width,
+                        height: viewportSize.height
+                    };
+                }
+                var deltaLeft = geometry.x - boundaryGeometry.x;
+                var deltaTop = geometry.y - boundaryGeometry.y;
+                var deltaRight = boundaryGeometry.x + boundaryGeometry.width - geometry.x - geometry.width;
+                var deltaBottom = boundaryGeometry.y + boundaryGeometry.height - geometry.y - geometry.height;
+                if (deltaLeft < 0) {
+                    geometry.x -= deltaLeft;
+                    geometry.width += deltaLeft;
+                }
+                if (deltaTop < 0) {
+                    geometry.y -= deltaTop;
+                    geometry.height += deltaTop;
+                }
+                if (deltaRight < 0) {
+                    geometry.width += deltaRight;
+                }
+                if (deltaBottom < 0) {
+                    geometry.height += deltaBottom;
+                }
+            }
             return geometry;
         },
         /**
@@ -244,13 +265,10 @@ module.exports = Aria.classDefinition({
          * @param {HTMLElement} element
          */
         _setElementStyle : function (element) {
+            var position = ariaUtilsDom.getOffset(element);
+            position.width = element.offsetWidth;
+            position.height = element.offsetHeight;
             var style = element.style;
-            var position = {
-                left : element.offsetLeft,
-                top : element.offsetTop,
-                height : element.offsetHeight,
-                width : element.offsetWidth
-            };
             this._elementInitialPosition = position;
             style.position = "absolute";
             style.left = position.left + "px";

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1986,6 +1986,17 @@ module.exports = Aria.beanDefinitions({
                 "resizeend" : {
                     $type : "common:Callback",
                     $description : "Callback called after the dialog resizing ends."
+                },
+                "container" : {
+                    $type : "json:MultiTypes",
+                    $description : "Element which will contain the dialog. It can be specified either by its id or by an HTMLElement object. If not specified, the dialog will be in document.body.",
+                    $contentTypes : [{
+                        $type : "json:String",
+                        $description : "Id of the DOM element which will contain the dialog."
+                    }, {
+                        $type : "json:ObjectRef",
+                        $description : "{HTMLElement} The DOM element which will contain the dialog."
+                    }]
                 }
             }
         },

--- a/test/aria/utils/dragdrop/DragDropCSS.tpl.css
+++ b/test/aria/utils/dragdrop/DragDropCSS.tpl.css
@@ -22,7 +22,7 @@
       float: left;
       width: 200px;
       height: 300px;
-      border: 1px solid #cdcdcd;
+      background-color: #eef;
     }
 
     .constrained-draggable-class {

--- a/test/aria/widgets/container/ContainerTestSuite.js
+++ b/test/aria/widgets/container/ContainerTestSuite.js
@@ -29,7 +29,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.tooltip.TooltipTestCase");
         this.addTests("test.aria.widgets.container.dialog.DialogTestSuite");
         this.addTests("test.aria.widgets.container.bindableSize.BindableSizeTestSuite");
-        this.addTests("test.aria.widgets.container.dialog.movable.issue367.MovableDialogTestCase");
         this.addTests("test.aria.widgets.container.checkContent.DivTest");
         this.addTests("test.aria.widgets.container.tabpanel.TabPanelTest");
     }

--- a/test/aria/widgets/container/dialog/DialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/DialogTestSuite.js
@@ -41,5 +41,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.dialog.missingMacro.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.wrongCfg.ValidationTest");
         this.addTests("test.aria.widgets.container.dialog.configContainer.DialogTestCase");
+        this.addTests("test.aria.widgets.container.dialog.container.DialogContainerTestSuite");
     }
 });

--- a/test/aria/widgets/container/dialog/MovableDialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/MovableDialogTestSuite.js
@@ -24,6 +24,7 @@ Aria.classDefinition({
                 "test.aria.widgets.container.dialog.bindPosition.DialogOnResizeTestCase",
                 "test.aria.widgets.container.dialog.bindPosition.PopupMoveToTestCase",
                 "test.aria.widgets.container.dialog.bindPosition.DialogInViewportTestCase",
+                "test.aria.widgets.container.dialog.movable.issue367.MovableDialogTestCase",
                 "test.aria.widgets.container.dialog.movable.test1.MovableDialogTestCase",
                 "test.aria.widgets.container.dialog.movable.test2.MovableDialogTestCaseTwo",
                 "test.aria.widgets.container.dialog.movable.test3.MovableDialogTestCaseThree",

--- a/test/aria/widgets/container/dialog/container/BaseDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/BaseDialogContainerTestCase.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Browser = require("ariatemplates/core/Browser");
+var TypeUtils = require("ariatemplates/utils/Type");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $extends : require("ariatemplates/jsunit/RobotTestCase"),
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {};
+        this.setTestEnv({
+            iframe: true,
+            template : "test.aria.widgets.container.dialog.container.DialogContainer",
+            css: "left:0px;top:0px;border:0px;width:1200px;height:700px;",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.testWindow.scrollTo(0, 1492);
+            this.getElementById("home").scrollTop = 1503;
+            this.start();
+        },
+
+        start: function () {},
+
+        resizeViewport : function (width, height, cb) {
+            var iframeStyle = this.testIframe.style;
+            iframeStyle.width = Math.floor(width) + "px";
+            iframeStyle.height = Math.floor(height) + "px";
+            setTimeout(cb, 100);
+        },
+
+        waitForFocus : function (id, callback) {
+            var self = this;
+            return function () {
+                self.waitForDomEltFocus(self.getElementById(id), callback);
+            };
+        },
+
+        waitForIdVisible : function (id, callback) {
+            var self = this;
+            return function () {
+                self.waitFor({
+                    condition: function () {
+                        var elt = self.getElementById(id);
+                        var geometry = self.testWindow.aria.utils.Dom.getGeometry(elt);
+                        return !! geometry;
+                    },
+                    callback: callback
+                });
+            };
+        },
+
+        getDialogGeometry : function (id) {
+            var dialogWidget = this.getWidgetInstance(id);
+            var domElt = dialogWidget.getDom();
+            return this.getGeometry(domElt);
+        },
+
+        getDialogMaskGeometry : function (id) {
+            var dialogWidget = this.getWidgetInstance(id);
+            var domElt = dialogWidget._popup.modalMaskDomElement;
+            return this.getGeometry(domElt);
+        },
+
+        getGeometry : function (domElt) {
+            if (TypeUtils.isString(domElt)) {
+                domElt = this.getElementById(domElt);
+            }
+            return this.testWindow.aria.utils.Dom.getGeometry(domElt);
+        },
+
+        getClientGeometry : function (domElt) {
+            if (TypeUtils.isString(domElt)) {
+                domElt = this.getElementById(domElt);
+            }
+            return this.testWindow.aria.utils.Dom.getClientGeometry(domElt);
+        },
+
+        assertCentered : function (geometry1, geometry2) {
+            var posX = geometry1.x + (geometry1.width - geometry2.width) / 2;
+            var posY = geometry1.y + (geometry1.height - geometry2.height) / 2;
+            this.assertPixelEquals(posX, geometry2.x);
+            this.assertPixelEquals(posY, geometry2.y);
+        },
+
+        assertSameGeometry : function (geometry1, geometry2) {
+            this.assertPixelEquals(geometry1.x, geometry2.x);
+            this.assertPixelEquals(geometry1.y, geometry2.y);
+            this.assertPixelEquals(geometry1.width, geometry2.width);
+            this.assertPixelEquals(geometry1.height, geometry2.height);
+        },
+
+        getDialogTitleBar : function (id) {
+            var dialogWidget = this.getWidgetInstance(id);
+            return dialogWidget._titleBarDomElt;
+        },
+
+        getDialogMaximizeButton : function (id) {
+            var titleBar = this.getDialogTitleBar(id);
+            var child = titleBar.lastChild;
+            while (child && ! (/maximize/.test(child.className))) {
+                child = child.previousSibling;
+            }
+            return child;
+        },
+
+        moveDialog : function (id, newPositionOffset, callback) {
+            var dialogTitleBar = this.getDialogTitleBar(id);
+            var dialogTitleBarGeometry = this.getGeometry(dialogTitleBar);
+            var dialogTitleCenter = {
+                x : dialogTitleBarGeometry.x + dialogTitleBarGeometry.width / 2,
+                y : dialogTitleBarGeometry.y + dialogTitleBarGeometry.height / 2
+            };
+            var destination = {
+                x : dialogTitleCenter.x + newPositionOffset.x,
+                y : dialogTitleCenter.y + newPositionOffset.y
+            };
+            this.synEvent.drag({
+                to: destination
+            }, dialogTitleCenter, callback);
+        },
+
+        assertDisplayMatchesDataModel : function (containerGeometry, dialogName) {
+            var dialogGeometry = this.getDialogGeometry(dialogName + "Dialog");
+            if (this.data[dialogName + "Maximized"]) {
+                this.assertSameGeometry(containerGeometry, dialogGeometry);
+            } else {
+                this.assertPixelEquals(dialogGeometry.x - containerGeometry.x, this.data[dialogName + "X"]);
+                this.assertPixelEquals(dialogGeometry.y - containerGeometry.y, this.data[dialogName + "Y"]);
+                if (this.data[dialogName + "Width"] !== -1) {
+                    this.assertPixelEquals(dialogGeometry.width, this.data[dialogName + "Width"]);
+                }
+                if (this.data[dialogName + "Height"] !== -1) {
+                    this.assertPixelEquals(dialogGeometry.height, this.data[dialogName + "Height"]);
+                }
+                if (this.data[dialogName + "Center"]) {
+                    this.assertCentered(containerGeometry, dialogGeometry);
+                }
+            }
+
+            // checks that the dialog stays inside the container:
+            this.assertTrue(dialogGeometry.x >= containerGeometry.x);
+            this.assertTrue(dialogGeometry.y >= containerGeometry.y);
+            this.assertTrue(dialogGeometry.x + dialogGeometry.width <= containerGeometry.x + containerGeometry.width);
+            this.assertTrue(dialogGeometry.y + dialogGeometry.height <= containerGeometry.y + containerGeometry.height);
+            return dialogGeometry;
+        },
+
+        assertPixelEquals : Browser.isOldIE ? function (x, y) {
+            this.assertEqualsWithTolerance(x, y, 1);
+        } : function (x, y) {
+            this.assertEquals(Math.floor(x), Math.floor(y));
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/DialogContainer.tpl
+++ b/test/aria/widgets/container/dialog/container/DialogContainer.tpl
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.container.DialogContainer",
+   $css : ["test.aria.widgets.container.dialog.container.DialogContainerStyle"],
+   $hasScript : true
+}}
+
+    {macro main ()}
+        <div style="height:10000px;padding-top:100px;padding-left:50px;padding-right:200px;">
+            <div style="height:1400px;">
+            </div>
+            <div>
+                {call dialogButton("generalDialogModal", null, true)/}
+                {call dialogButton("generalDialogNonModal", null, false)/}<br>
+                <input {id "bodyInput1" /}> <input {id "bodyInput2" /}>
+            </div>
+            <div>
+                {@aria:Tab {
+                    tabId: "home",
+                    id: "homeTab",
+                    bind: {
+                        selectedTab: {
+                            to: "activeTab",
+                            inside: data
+                        }
+                    }
+                }}Home{/@aria:Tab}
+                {@aria:Tab {
+                    tabId: "info",
+                    id: "infoTab",
+                    bind: {
+                        selectedTab: {
+                            to: "activeTab",
+                            inside: data
+                        }
+                    }
+                }}Info{/@aria:Tab}
+                {@aria:Tab {
+                    tabId: "details",
+                    id: "detailsTab",
+                    bind: {
+                        selectedTab: {
+                            to: "activeTab",
+                            inside: data
+                        }
+                    }
+                }}Details{/@aria:Tab}
+            </div>
+            <div style="border:1px solid black;">
+                <div class="tabContent active" {id "home"/} tabindex="-1">
+                    <p><b>Home tab</b></p>
+                    <div style="background-color:green;height:1500px;width:32px;"></div>
+                    <input {id "homeInput1"/}> <br>
+                    <input {id "homeInput2"/}> <br>
+                    {call dialogButton("homeDialogModal", "home", true)/}
+                    {call dialogButton("homeDialogNonModal", "home", false)/}<br>
+                    <div style="background-color:green;height:1500px;width:32px;"></div>
+                </div>
+                <div class="tabContent" {id "info"/}>
+                    <p><b>Info tab</b></p>
+                    {call dialogButton("infoDialogModal", "info", true)/}
+                    {call dialogButton("infoDialogNonModal", "info", false)/}<br>
+                    <input {id "infoInput1"/}> <br>
+                    <input {id "infoInput2"/}> <br>
+                </div>
+                <div class="tabContent" {id "details"/} style="height:1500px;">
+                  {call dialogButton("detailsDialogModal", "details", true)/}
+                  {call dialogButton("detailsDialogNonModal", "details", false)/}<br>
+                  <input {id "detailsInput1"/}> <br>
+                  <input {id "detailsInput2"/}> <br>
+                </div>
+            </div>
+        </div>
+    {/macro}
+
+    {macro dialogButton(name, containerId, modal)}
+        {@aria:Button {
+            label: "Toggle "+name,
+            id: name + "ToggleButton",
+            onclick: {
+                fn: toggleDialog,
+                args: name
+            }
+        }/}
+        {@aria:Dialog {
+            macro: {
+                name: "dialogContent",
+                args: [name]
+            },
+            id: name + "Dialog",
+            movable: true,
+            resizable: true,
+            maximizable: true,
+            modal: modal,
+            container: containerId ? $getId(containerId) : null,
+            bind: {
+                center: {
+                    to: name+"Center",
+                    inside: data
+                },
+                xpos: {
+                    to: name+"X",
+                    inside: data
+                },
+                ypos: {
+                    to: name+"Y",
+                    inside: data
+                },
+                width: {
+                    to: name+"Width",
+                    inside: data
+                },
+                height: {
+                    to: name+"Height",
+                    inside: data
+                },
+                maximized: {
+                    to: name+"Maximized",
+                    inside: data
+                },
+                visible: {
+                    to: name+"Visible",
+                    inside: data
+                }
+            }
+        }/}
+    {/macro}
+
+    {macro dialogContent(name)}
+        This is dialog ${name}. <br>
+        <input {id name + "Input1"/}> <br>
+        <input {id name + "Input2"/}> <br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/container/DialogContainerScript.js
+++ b/test/aria/widgets/container/dialog/container/DialogContainerScript.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.DialogContainerScript",
+    $dependencies : ["aria.templates.Layout"],
+    $destructor : function() {
+        if (this.changeTab) {
+            this.$json.removeListener(this.data, "activeTab", this.changeTab);
+            this.changeTab = null;
+        }
+    },
+    $prototype : {
+        $dataReady: function() {
+            this.$json.setValue(this.data, "activeTab", "home");
+            if (!this.changeTab) {
+                this.changeTab = {
+                    fn: this.changeTabListener,
+                    scope: this
+                };
+                this.$json.addListener(this.data, "activeTab", this.changeTab);
+            }
+        },
+
+        changeTabListener : function (info) {
+            var oldDomElt = this.$getElementById(info.oldValue);
+            var newDomElt = this.$getElementById(info.newValue);
+            oldDomElt.classList.remove("active");
+            newDomElt.classList.add("active");
+            // The following method makes sure the position of all dialogs
+            // inside the current tab is updated (even if there was a resize
+            // of the viewport while the tab was hidden)
+            aria.templates.Layout.refreshLayout();
+        },
+
+        toggleDialog: function(event, name) {
+            var propName = name + "Visible";
+            this.$json.setValue(this.data, propName, !this.data[propName]);
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/DialogContainerStyle.tpl.css
+++ b/test/aria/widgets/container/dialog/container/DialogContainerStyle.tpl.css
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+   $classpath : "test.aria.widgets.container.dialog.container.DialogContainerStyle"
+}}
+
+    {macro main ()}
+
+      .tabContent {
+          display: none;
+          overflow: auto;
+          padding: 10px;
+          height: 500px;
+          border: 15px solid blue;
+          border-left-width: 7px;
+          border-top-width: 11px;
+          border-right-width: 3px;
+          position: relative;
+      }
+
+      .tabContent.active {
+          display: block;
+      }
+
+    {/macro}
+
+{/CSSTemplate}

--- a/test/aria/widgets/container/dialog/container/DialogContainerTestSuite.js
+++ b/test/aria/widgets/container/dialog/container/DialogContainerTestSuite.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.DialogContainerTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this._tests = [
+            "test.aria.widgets.container.dialog.container.FocusDialogContainerTestCase",
+            "test.aria.widgets.container.dialog.container.MoveDialogContainerTestCase",
+            "test.aria.widgets.container.dialog.container.MaximizeDialogContainerTestCase",
+            "test.aria.widgets.container.dialog.container.ResizeDialogContainerTestCase",
+            "test.aria.widgets.container.dialog.container.HideResizeDialogContainerTestCase"
+        ];
+    }
+});

--- a/test/aria/widgets/container/dialog/container/FocusDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/FocusDialogContainerTestCase.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.FocusDialogContainerTestCase",
+    $extends : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $prototype : {
+
+        start: function () {
+            var self = this;
+
+            function step0() {
+                self.synEvent.click(self.getElementById("homeDialogModalToggleButton"), self.waitForIdVisible("homeDialogModalInput1", step1));
+            }
+
+            function step1() {
+                self.synEvent.click(self.getElementById("bodyInput1"), self.waitForFocus("bodyInput1", step2));
+            }
+
+            function step2() {
+                self.synEvent.type(null, "\t", self.waitForFocus("bodyInput2", step3));
+                // pressing tab from bodyInput2 skips the content of the home tab and directly goes to the dialog
+            }
+
+            function step3() {
+                self.synEvent.type(null, "\t", self.waitForFocus("homeDialogModalInput1", step4));
+            }
+
+            function step4() {
+                self.synEvent.type(null, "\t", self.waitForFocus("homeDialogModalInput2", step5));
+            }
+
+            function step5 () {
+                self.synEvent.click(self.getElementById("infoTab"), self.waitForIdVisible("infoInput1", step6));
+            }
+
+            function step6 () {
+                self.synEvent.click(self.getElementById("bodyInput2"), self.waitForFocus("bodyInput2", step7));
+            }
+
+            function step7() {
+                self.synEvent.type(null, "\t[ENTER]", self.waitForFocus("infoDialogModalInput1", step8));
+            }
+
+            function step8() {
+                self.synEvent.click(self.getElementById("bodyInput2"), self.waitForFocus("bodyInput2", step9));
+            }
+
+            function step9() {
+                self.synEvent.type(null, "\t", self.waitForFocus("infoDialogModalInput1", step10));
+            }
+
+            function step10() {
+                self.synEvent.click(self.getElementById("homeTab"), self.waitForIdVisible("homeDialogModalInput1", step11));
+            }
+
+            function step11() {
+                self.synEvent.click(self.getElementById("bodyInput2"), self.waitForFocus("bodyInput2", step12));
+            }
+
+            function step12() {
+                self.synEvent.type(null, "\t", self.waitForFocus("homeDialogModalInput1", step13));
+            }
+
+            function step13() {
+                self.synEvent.execute([["type", null, "[ESCAPE]"], ["click", self.getElementById("bodyInput2")]], self.waitForFocus("bodyInput2", step14));
+            }
+
+            function step14() {
+                // after the dialog is closed, it is possible to focus homeInput1
+                self.synEvent.type(null, "\t", self.waitForFocus("homeInput1", step15));
+            }
+
+            function step15() {
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/HideResizeDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/HideResizeDialogContainerTestCase.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.HideResizeDialogContainerTestCase",
+    $extends : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $prototype : {
+
+        start: function () {
+            var self = this;
+
+            function step0() {
+                self.synEvent.click(self.getElementById("homeDialogModalToggleButton"), self.waitForIdVisible("homeDialogModalInput1", step1));
+            }
+
+            function step1() {
+                var containerGeometry = self.getClientGeometry("home");
+                var dialogMaskGeometry = self.getDialogMaskGeometry("homeDialogModalDialog");
+                self.assertSameGeometry(containerGeometry, dialogMaskGeometry);
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.synEvent.click(self.getElementById("infoTab"), self.waitForIdVisible("infoInput1", step2));
+            }
+
+            function step2() {
+                self.resizeViewport(1300, 550, step3);
+            }
+
+            function step3() {
+                self.synEvent.click(self.getElementById("homeTab"), self.waitForIdVisible("homeDialogModalInput1", step4));
+            }
+
+            function step4() {
+                var containerGeometry = self.getClientGeometry("home");
+                var dialogMaskGeometry = self.getDialogMaskGeometry("homeDialogModalDialog");
+                self.assertSameGeometry(containerGeometry, dialogMaskGeometry);
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/MaximizeDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/MaximizeDialogContainerTestCase.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.MaximizeDialogContainerTestCase",
+    $extends : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $prototype : {
+
+        start: function () {
+            var self = this;
+
+            function step0() {
+                self.synEvent.click(self.getElementById("homeDialogNonModalToggleButton"), self.waitForIdVisible("homeDialogNonModalInput1", step1));
+            }
+
+            function step1() {
+                var containerGeometry = self.getClientGeometry("home");
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogNonModal");
+                self.assertFalsy(self.data.homeDialogNonModalMaximized);
+                self.synEvent.click(self.getDialogMaximizeButton("homeDialogNonModalDialog"), step2);
+            }
+
+            function step2() {
+                self.assertTrue(self.data.homeDialogNonModalMaximized);
+                var containerGeometry = self.getClientGeometry("home");
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogNonModal");
+                self.synEvent.click(self.getDialogMaximizeButton("homeDialogNonModalDialog"), step3);
+            }
+
+            function step3() {
+                self.assertFalsy(self.data.homeDialogNonModalMaximized);
+                var containerGeometry = self.getClientGeometry("home");
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogNonModal");
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/MoveDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/MoveDialogContainerTestCase.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.MoveDialogContainerTestCase",
+    $extends : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $prototype : {
+        start: function () {
+            var self = this;
+            var containerGeometry;
+
+            function step0() {
+                self.synEvent.click(self.getElementById("homeDialogModalToggleButton"), self.waitForIdVisible("homeDialogModalInput1", step1));
+            }
+
+            function step1() {
+                // containerGeometry must be set only once the dialog is displayed (because the scrollbar disappears when the modal dialog appears)
+                containerGeometry = self.getClientGeometry("home");
+                var dialogMaskGeometry = self.getDialogMaskGeometry("homeDialogModalDialog");
+                self.assertSameGeometry(containerGeometry, dialogMaskGeometry);
+                self.assertTrue(self.data.homeDialogModalCenter);
+                self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.moveDialog("homeDialogModalDialog", {x: - self.data.homeDialogModalX - 50, y: - self.data.homeDialogModalY - 50}, step2);
+            }
+
+            function step2() {
+                self.assertFalse(self.data.homeDialogModalCenter);
+                var dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertPixelEquals(dialogGeometry.x, containerGeometry.x);
+                self.assertPixelEquals(dialogGeometry.y, containerGeometry.y);
+                self.moveDialog("homeDialogModalDialog", {
+                    x: containerGeometry.width - dialogGeometry.width + 50,
+                    y: containerGeometry.height - dialogGeometry.height + 50
+                }, step3);
+            }
+
+            function step3() {
+                var dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertFalse(self.data.homeDialogModalCenter);
+                self.assertPixelEquals(dialogGeometry.x + dialogGeometry.width, containerGeometry.x + containerGeometry.width);
+                self.assertPixelEquals(dialogGeometry.y + dialogGeometry.height, containerGeometry.y + containerGeometry.height);
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/container/ResizeDialogContainerTestCase.js
+++ b/test/aria/widgets/container/dialog/container/ResizeDialogContainerTestCase.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.container.ResizeDialogContainerTestCase",
+    $extends : "test.aria.widgets.container.dialog.container.BaseDialogContainerTestCase",
+    $prototype : {
+        start: function () {
+            var self = this;
+            var jsonUtils = self.templateCtxt._tpl.$json;
+            var containerGeometry;
+
+            function step0() {
+                jsonUtils.setValue(self.data, "homeDialogModalCenter", false);
+                jsonUtils.setValue(self.data, "homeDialogModalX", 49);
+                jsonUtils.setValue(self.data, "homeDialogModalY", 70);
+                jsonUtils.setValue(self.data, "homeDialogModalWidth", 300);
+                jsonUtils.setValue(self.data, "homeDialogModalHeight", 200);
+                self.synEvent.click(self.getElementById("homeDialogModalToggleButton"), self.waitForIdVisible("homeDialogModalInput1", step1));
+            }
+
+            function step1() {
+                // containerGeometry must be set only once the dialog is displayed (because the scrollbar disappears when the modal dialog appears)
+                containerGeometry = self.getClientGeometry("home");
+                var dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertPixelEquals(dialogGeometry.x - containerGeometry.x, 49);
+                self.assertPixelEquals(dialogGeometry.y - containerGeometry.y, 70);
+                self.assertPixelEquals(dialogGeometry.width, 300);
+                self.assertPixelEquals(dialogGeometry.height, 200);
+                var startPos = {
+                    x: dialogGeometry.x,
+                    y: dialogGeometry.y
+                };
+                var endPos = {
+                    x: containerGeometry.x - 50,
+                    y: containerGeometry.y - 50
+                };
+                self.synEvent.drag({
+                    to: endPos
+                }, startPos, step3);
+            }
+
+            function step3() {
+                var dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertPixelEquals(dialogGeometry.x, containerGeometry.x);
+                self.assertPixelEquals(dialogGeometry.y, containerGeometry.y);
+                self.assertPixelEquals(dialogGeometry.width, 349);
+                self.assertPixelEquals(dialogGeometry.height, 270);
+
+                jsonUtils.setValue(self.data, "homeDialogModalX", containerGeometry.width - 400);
+                jsonUtils.setValue(self.data, "homeDialogModalY", containerGeometry.height - 300);
+                dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertPixelEquals(dialogGeometry.x, containerGeometry.x + containerGeometry.width - 400);
+                self.assertPixelEquals(dialogGeometry.y, containerGeometry.y + containerGeometry.height - 300);
+                var startPos = {
+                    x: dialogGeometry.x + dialogGeometry.width - 10,
+                    y: dialogGeometry.y + dialogGeometry.height - 10
+                };
+                var endPos = {
+                    x: containerGeometry.x + containerGeometry.width + 50,
+                    y: containerGeometry.y + containerGeometry.height + 50
+                };
+                self.synEvent.drag({
+                    to: endPos
+                }, startPos, step4);
+            }
+
+            function step4() {
+                var dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertPixelEquals(dialogGeometry.x, containerGeometry.x + containerGeometry.width - 400);
+                self.assertPixelEquals(dialogGeometry.y, containerGeometry.y + containerGeometry.height - 300);
+                self.assertPixelEquals(dialogGeometry.width, 400);
+                self.assertPixelEquals(dialogGeometry.height, 300);
+
+                jsonUtils.setValue(self.data, "homeDialogModalCenter", true);
+                dialogGeometry = self.assertDisplayMatchesDataModel(containerGeometry, "homeDialogModal");
+                self.assertTrue(self.data.homeDialogModalCenter);
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/attester-nophantom.yml
+++ b/test/attester-nophantom.yml
@@ -22,6 +22,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
     - test.aria.utils.DomScrollIntoView
+    - test.aria.widgets.container.dialog.container.DialogContainerTestSuite
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
   # This test works in Firefox and Chrome locally but not on Travis... It is removed in .travis.yml
     - test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive

--- a/test/attester-packaged.yml
+++ b/test/attester-packaged.yml
@@ -24,6 +24,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
     - test.aria.utils.DomScrollIntoView
+    - test.aria.widgets.container.dialog.container.DialogContainerTestSuite
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
     - test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive
    #Excluded from this file but added in attester.yml (tests for the unpackaged version):


### PR DESCRIPTION
This PR adds a new `container` property for the `@aria:Dialog` widget.
If this property is defined, the dialog is inserted as a child of the corresponding DOM element (which must have the `position:relative` or `position: absolute` style), and the dialog can only be moved or resized inside this element. If the dialog is modal, the modal mask is only above the container, and focusing elements outside the container is still possible.
This PR also contains a commit which fixes issues in the Resize/Drag utilities.