### PR TITLE
fix easypackage failing when templates are not packaged

### DIFF
--- a/tasks/easypackage/configuration.js
+++ b/tasks/easypackage/configuration.js
@@ -41,16 +41,17 @@ module.exports = function (grunt, args) {
             }
         },
         outputDirectory : args.outputDirectory,
-        visitors : [args.includeDependencies ? {
-                    type : 'NoderDependencies',
-                    cfg : {
-                        externalDependencies : ['noder-js/**'],
-                        files : ['**/*.js']
-                    }
-                } : null, args.includeDependencies ? {
+        visitors : [
+                args.includeDependencies ? {
                     type : 'ATDependencies',
                     cfg : {
                         externalDependencies : ['aria/**'],
+                        files : atExtensions
+                    }
+                } : null, args.includeDependencies ? {
+                    type : 'NoderDependencies',
+                    cfg : {
+                        externalDependencies : ['noder-js/**', 'ariatemplates/**'],
                         files : atExtensions
                     }
                 } : null, args.includeDependencies ? {
@@ -100,7 +101,7 @@ module.exports = function (grunt, args) {
                 } : null, {
                     type : 'CopyUnpackaged',
                     cfg : {
-                        files : ['**/*.js'],
+                        files : atExtensions,
                         builder : {
                             type : 'ATMultipart',
                             cfg : {

--- a/test/node/gruntTasks.js
+++ b/test/node/gruntTasks.js
@@ -147,5 +147,27 @@ describe("easypackage grunt task", function () {
             callback();
         });
     });
+    it("should build the application correctly - third config", function (callback) {
+        testBuild(3, function () {
+            // Checks that the .tpl.css file is present and was compiled
+            var AutocompleteStyleTplCss = fs.readFileSync(testProjectPath + "target/three/app/css/AutocompleteStyle.tpl.css", 'utf8');
+            assert.ok(/abcdefg-license/.test(AutocompleteStyleTplCss), "License has not been added");
+            assert.ok(!/\{Template/.test(AutocompleteStyleTplCss), "Template compilation has not been done");
 
+            var flag;
+            try {
+                fs.readFileSync(testProjectPath + "target/three/app/css/CalendarSkin.js", 'utf8');
+                flag = false;
+            } catch (ex) {
+                flag = true;
+            }
+            assert.ok(flag, "Automatic dependency inclusion did not work");
+
+            var calendarPkg = fs.readFileSync(testProjectPath + "target/three/app/css/calendar.js", 'utf8');
+            assert.ok(/loadFileContent\("app\/css\/CalendarSkin\.js","/.test(calendarPkg), "Package app/css/calendar.js does not include CalendarSkin.js");
+            assert.ok(/loadFileContent\("app\/css\/CalendarStyle\.tpl\.css","/.test(calendarPkg), "Package app/css/calendar.js does not include CalendarStyle.tpl.css");
+            verifyImgFiles("three");
+            callback();
+        });
+    });
 });

--- a/test/nodeTestResources/testProject/gruntfiles/Gruntfile3.js
+++ b/test/nodeTestResources/testProject/gruntfiles/Gruntfile3.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var path = require('path');
+module.exports = function (grunt) {
+    grunt.registerTask('default', ['easypackage:one']);
+    grunt.loadTasks('../../../../tasks');
+    grunt.config.set('easypackage.one', {
+        options : {
+            // Compile all templates, packages just 2 files
+            outputDirectory : path.join(__dirname, "../target/three"),
+            sourceDirectories : [path.join(__dirname, '../src')],
+            sourceFiles : ['**/*'],
+            license : "/* abcdefg-license */",
+            ATAppEnvironment : {
+                defaultWidgetLibs : {
+                    "light" : "atplugins.lightWidgets.LightWidgetLib"
+                }
+            },
+            includeDependencies : true,
+            packages : [{
+                name : "app/css/calendar.js",
+                // includeDependencies is true so atpackager should automatically
+                // add CalendarSkin.js to this package
+                files : ["app/css/CalendarStyle.tpl.css"]
+            }],
+            clean : true,
+            minify : false,
+            gzipStats : true,
+            hash : false
+        }
+    });
+
+};


### PR DESCRIPTION
This pull request fixes a regression introduced by commit c3e296e18ae8f02ae7cfb0f0a10ec80b5be17a1f.
It also makes sure dependencies declared in templates are correctly detected during packaging.