### PR TITLE
fix aria:Link disabled color when skin contains multiple `sclass`

### DIFF
--- a/src/aria/utils/SynEvents.js
+++ b/src/aria/utils/SynEvents.js
@@ -1028,7 +1028,7 @@ require("./Dom");
                         if ( Aria.$window.selenium ) {
                             Aria["eval"]("with(selenium.browserbot.getCurrentWindow()){" + code + "}");
                         } else {
-                            Aria["eval"]("with(scope){" + code + "}");
+                            Aria["eval"]("with(arguments[2]){" + code + "}", null, scope);
                         }
                     }
                 }

--- a/src/aria/widgets/AriaSkinBeans.js
+++ b/src/aria/widgets/AriaSkinBeans.js
@@ -693,8 +693,7 @@ module.exports = Aria.beanDefinitions({
                     }
                 },
                 "disabledColor" : {
-                    $type : "json:String",
-                    $description : ""
+                    $type : "Color"
                 }
             }
         },

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -62,7 +62,7 @@ module.exports = Aria.classDefinition({
             var cfg = this._cfg;
             var linkClass = "xLink_" + cfg.sclass;
             if (cfg.disabled) {
-                linkClass = "xLink_disabled";
+                linkClass = "xLink_" + cfg.sclass + "_disabled xLink_disabled";
             }
             out.write(['<a', Aria.testMode ? ' id="' + this._domId + '_link"' : '', ' class="', linkClass,
                     '" href="javascript:(function(){})()"',
@@ -150,14 +150,13 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _updateState : function () {
-            var cfg = this._cfg, state = "xLink_" + cfg.sclass;
             if (this._focusElt) {
+                var cfg = this._cfg, linkClass = "xLink_" + cfg.sclass;
                 if (cfg.disabled) {
-                    state = "xLink_disabled";
+                    linkClass = "xLink_" + cfg.sclass + "_disabled xLink_disabled";
                 }
-                this._focusElt.className = state;
+                this._focusElt.className = linkClass;
             }
-
         }
     }
 });

--- a/src/aria/widgets/action/LinkStyle.tpl.css
+++ b/src/aria/widgets/action/LinkStyle.tpl.css
@@ -17,6 +17,16 @@
     $extends : "aria.widgets.WidgetStyle"
 }}
 {var skinnableClassName="Link"/}
+
+{macro main()}
+    {call startLooping()/}
+
+    a.xLink_disabled {
+        text-decoration:none;
+        cursor:default;
+    }
+{/macro}
+
 {macro writeState(info)}
 	{var pseudoclass=""/}
 	{if info.stateName != "normal"}
@@ -34,11 +44,9 @@
 {macro writeSkinClass(info)}
 	{var skinClassName=info.skinClassName/}
 	{var skinClass=info.skinClass/}
-	a.xLink_disabled{
+	a.xLink_${skinClassName}_disabled {
 		color:${skinClass.disabledColor};
-		text-decoration:none;
-		cursor:default;
 	}
-
 {/macro}
+
 {/CSSTemplate}

--- a/test/aria/widgets/action/link/disabled/LinkDisabled.js
+++ b/test/aria/widgets/action/link/disabled/LinkDisabled.js
@@ -16,34 +16,102 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.action.link.disabled.LinkDisabled",
     $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Dom", "aria.widgets.AriaSkinNormalization"],
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
     },
     $prototype : {
 
+        setUp : function () {
+            var linkSkin = aria.widgets.AriaSkin.skinObject.Link;
+            delete linkSkin["aria:skinNormalized"];
+            linkSkin.alternative = {
+                states: {
+                    normal: {
+                        color: "#6365ff"
+                    }
+                },
+                disabledColor: "#707070"
+            };
+            // makes sure the disabledColor value is different between sclass:
+            linkSkin.std.disabledColor = "#303030";
+            aria.widgets.AriaSkinNormalization.normalizeWidget("Link", linkSkin);
+        },
+
+        clickAll : function (cb) {
+            var items = [this._link1DomElt, this._link2DomElt, this._toggleDisabledElt];
+            var next = function () {
+                var item = items.shift();
+                if (item) {
+                    this.synEvent.click(item, {
+                        scope: this,
+                        fn: next
+                    });
+                } else {
+                    cb.call(this);
+                }
+            };
+            next.call(this);
+        },
+
         runTemplateTest : function () {
-            this._linkDomElt = this.getLink("link");
-            this._spanLink = this.getElementById("TestID");
-            this.assertEquals(this._linkDomElt.className, 'xLink_std', "Link should be in active state");
-            this.synEvent.click(this._spanLink, {
-                scope : this,
-                fn : this._step1
-            });
+            this._link1DomElt = this.getLink("link1");
+            this._link2DomElt = this.getLink("link2");
+            this._toggleDisabledElt = this.getElementById("toggleDisabled");
+
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber1, 0);
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber2, 0);
+
+            this.assertFalse(/xLink_disabled/.test(this._link1DomElt.className), "Link 1 should not be in disabled state");
+            this.checkRefColor(this._link1DomElt, "stdNormalColor");
+            this.assertTrue(/xLink_disabled/.test(this._link2DomElt.className), "Link 2 should be in disabled state");
+            this.checkRefColor(this._link2DomElt, "alternativeDisabledColor");
+
+            this.clickAll(this._step1);
         },
 
         _step1 : function () {
-            this.assertEquals(this._linkDomElt.className, 'xLink_disabled', "Link should be in disabled state");
-            this.synEvent.click(this._spanLink, {
-                scope : this,
-                fn : this._step2
-            });
+            // only clicks on the previously enabled element are taken into account:
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber1, 1);
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber2, 0);
+
+            this.assertTrue(/xLink_disabled/.test(this._link1DomElt.className), "Link 1 should be in disabled state");
+            this.checkRefColor(this._link1DomElt, "stdDisabledColor");
+            this.assertFalse(/xLink_disabled/.test(this._link2DomElt.className), "Link 2 should be in disabled state");
+            this.checkRefColor(this._link2DomElt, "alternativeNormalColor");
+
+            this.clickAll(this._step2);
         },
 
         _step2 : function () {
-            this.assertEquals(this._linkDomElt.className, 'xLink_std', "Link should be in active state");
-            this._linkDomElt = null;
-            this._spanLink = null;
+            // only clicks on the previously enabled element are taken into account:
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber1, 1);
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber2, 1);
+
+            this.assertFalse(/xLink_disabled/.test(this._link1DomElt.className), "Link 1 should not be in disabled state");
+            this.checkRefColor(this._link1DomElt, "stdNormalColor");
+            this.assertTrue(/xLink_disabled/.test(this._link2DomElt.className), "Link 2 should be in disabled state");
+            this.checkRefColor(this._link2DomElt, "alternativeDisabledColor");
+
+            this.clickAll(this._step3);
+        },
+
+        _step3 : function () {
+            // only clicks on the enabled element are taken into account:
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber1, 2);
+            this.assertEquals(this.templateCtxt._tpl.data.clicksNumber2, 1);
+
+            this._link1DomElt = null;
+            this._link2DomElt = null;
+            this._toggleDisabledElt = null;
             this.notifyTemplateTestEnd();
+        },
+
+        checkRefColor : function (domElt, refColorId) {
+            var refColorElt = this.getElementById(refColorId);
+            var expectedColor = aria.utils.Dom.getStyle(refColorElt, "color");
+            var foundColor = aria.utils.Dom.getStyle(domElt, "color");
+            this.assertEquals(foundColor, expectedColor);
         }
     }
 });

--- a/test/aria/widgets/action/link/disabled/LinkDisabledTpl.tpl
+++ b/test/aria/widgets/action/link/disabled/LinkDisabledTpl.tpl
@@ -17,20 +17,57 @@
 	$classpath: "test.aria.widgets.action.link.disabled.LinkDisabledTpl",
 	$hasScript: true
 }}
-	{var data = {linkDisabled : false}/}
+	{var data = {link1Disabled : false, link2Disabled : true, clicksNumber1: 0, clicksNumber2: 0}/}
 	{macro main()}
 		{@aria:Link {
-			label: "Some Link",
-			id: "link",
-			disabled:false,
+			label: "Some Link 1",
+			id: "link1",
 			bind :{
 				disabled : {
-				inside :data,
-				to : "linkDisabled"
+					inside :data,
+					to : "link1Disabled"
+				}
+			},
+			onclick: onClickLink1
+		}/}<br>
+
+		{@aria:Link {
+			label: "Some Link 2",
+			id: "link2",
+			sclass: "alternative",
+			bind :{
+				disabled : {
+					inside :data,
+					to : "link2Disabled"
+				}
+			},
+			onclick: onClickLink2
+		}/}<br>
+
+		<span {id "toggleDisabled"/} {on click "onToggleDisabledClick"/} >Toggle disabled</span><br>
+		<span>Number of clicks:
+		{@aria:Text {
+			bind: {
+				text: {
+					to: "clicksNumber1",
+					inside: data
+				}
+			}
+		}/},
+		{@aria:Text {
+			bind: {
+				text: {
+					to: "clicksNumber2",
+					inside: data
 				}
 			}
 		}/}
-
-	<span {id "TestID"/} {on click "onClickCallback"/} >click me</span>
+		</span><br>
+		{var skinStd = aria.widgets.AriaSkinInterface.getSkinObject("Link", "std") /}
+		<span {id "stdNormalColor"/} style="color:${skinStd.states.normal.color};">normal</span><br>
+		<span {id "stdDisabledColor"/} style="color:${skinStd.disabledColor};">disabled</span><br>
+		{var skinAlternative = aria.widgets.AriaSkinInterface.getSkinObject("Link", "alternative") /}
+		<span {id "alternativeNormalColor"/} style="color:${skinAlternative.states.normal.color};">normal</span><br>
+		<span {id "alternativeDisabledColor"/} style="color:${skinAlternative.disabledColor};">disabled</span><br>
 	{/macro}
 {/Template}

--- a/test/aria/widgets/action/link/disabled/LinkDisabledTplScript.js
+++ b/test/aria/widgets/action/link/disabled/LinkDisabledTplScript.js
@@ -17,9 +17,17 @@ Aria.tplScriptDefinition({
     $classpath : "test.aria.widgets.action.link.disabled.LinkDisabledTplScript",
     $prototype : {
 
-        onClickCallback : function (evt) {
-            var toggleState = !this.data.linkDisabled;
-            this.$json.setValue(this.data, "linkDisabled", toggleState);
+        onToggleDisabledClick : function (evt) {
+            this.$json.setValue(this.data, "link1Disabled", !this.data.link1Disabled);
+            this.$json.setValue(this.data, "link2Disabled", !this.data.link2Disabled);
+        },
+
+        onClickLink1 : function () {
+            this.$json.setValue(this.data, "clicksNumber1", this.data.clicksNumber1 + 1);
+        },
+
+        onClickLink2 : function () {
+            this.$json.setValue(this.data, "clicksNumber2", this.data.clicksNumber2 + 1);
         }
     }
 });


### PR DESCRIPTION
This commit fixes the following issue: when different `sclass` with different colors for the disabled state are defined for the aria:Link widget, all disabled links were using the same color for the disabled state, regardless of the `sclass` property.