### PR TITLE
Empty label issue with aria:SelectBox widget

### DIFF
--- a/src/aria/widgets/controllers/SelectBoxController.js
+++ b/src/aria/widgets/controllers/SelectBoxController.js
@@ -184,12 +184,7 @@ module.exports = Aria.classDefinition({
             var lowerCaseDispValue = displayedText.toLowerCase();
             var dispValueLength = displayedText.length;
 
-            // an empty field is usually not considered as an error
-            if (!displayedText) {
-                dm.value = null;
-                dm.text = '';
-                report.ok = true;
-            } else if (displayedText == dm.text) {
+            if (displayedText == dm.text) {
                 // if the displayed value is the same as before, don't loop over the whole list
                 report.ok = true;
             } else {
@@ -208,6 +203,12 @@ module.exports = Aria.classDefinition({
                             report.matchCorrectValueStart = true;
                         }
                     }
+                }
+                if (!report.ok && !displayedText) {
+                    // an empty field is usually not considered as an error
+                    dm.value = null;
+                    dm.text = '';
+                    report.ok = true;
                 }
             }
             if (report.ok) {

--- a/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
+++ b/test/aria/widgets/form/selectbox/SelectboxTestSuite.js
@@ -21,6 +21,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.selectbox.SelectboxTestCase");
         this.addTests("test.aria.widgets.form.selectbox.checkValue.MainTemplateTestCase");
         this.addTests("test.aria.widgets.form.selectbox.checkTypeLetters.SelectBoxTypeAllLetters");
+        this.addTests("test.aria.widgets.form.selectbox.emptyOption.EmptyOptionTestCase");
         this.addTests("test.aria.widgets.form.selectbox.preselect.PreselectTestCase");
         this.addTests("test.aria.widgets.form.selectbox.optionhighlight.SelectboxOptionHighlightTestCase");
     }

--- a/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCase.js
+++ b/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCase.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.selectbox.emptyOption.EmptyOptionTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $prototype : {
+        runTemplateTest : function () {
+            this._step1();
+        },
+
+        _step1 : function () {
+            this.assertEquals(this.templateCtxt._tpl.onChangeCalled, 0);
+            this.assertEquals(this.templateCtxt._tpl.data.value, "empty");
+            this.synEvent.click(this.getExpandButton("happySelectBox"), {
+                fn : this._step2,
+                scope : this
+            });
+        },
+
+        _step2 : function () {
+            this.waitFor({
+                callback: this._step3,
+                condition: function () {
+                    var popupElt = this.getWidgetDropDownPopup("happySelectBox");
+                    return popupElt && popupElt.getElementsByTagName("a").length > 0;
+                }
+            });
+        },
+
+        _step3 : function () {
+            // clicking on the expand button should not change the value in the data model
+            this.assertEquals(this.templateCtxt._tpl.onChangeCalled, 0);
+            this.assertEquals(this.templateCtxt._tpl.data.value, "empty");
+
+            var popupElt = this.getWidgetDropDownPopup("happySelectBox");
+            var yesElt = popupElt.getElementsByTagName("a")[2];
+            // check that yesElt corresponds to the expected element:
+            this.assertTrue(/Yes/.test(yesElt.innerHTML));
+
+            this.synEvent.click(yesElt, {
+                fn : this._step4,
+                scope : this
+            });
+        },
+
+        _step4 : function () {
+            this.waitFor({
+                callback: this._step5,
+                condition: function () {
+                    return !this.getWidgetDropDownPopup("happySelectBox");
+                }
+            });
+        },
+
+        _step5 : function () {
+            this.assertEquals(this.templateCtxt._tpl.onChangeCalled, 1);
+            this.assertEquals(this.templateCtxt._tpl.data.value, "yes");
+
+            // as there was a refresh in the onchange callback, our happy selectbox
+            // is no longer focused
+
+            aria.utils.Json.setValue(this.templateCtxt._tpl.data, "value", "empty");
+            this.synEvent.click(this.getInputField("happySelectBox"), {
+                fn : this._step6,
+                scope : this
+            });
+        },
+
+        _step6 : function () {
+            this.waitForWidgetFocus("happySelectBox", this._step7);
+        },
+
+        _step7 : function () {
+            // clicking inside the selectbox should not change its value
+            this.assertEquals(this.templateCtxt._tpl.onChangeCalled, 1);
+            this.assertEquals(this.templateCtxt._tpl.data.value, "empty");
+            this.synEvent.click(this.getElementById("clickOutsideDiv"), {
+                fn : this._step8,
+                scope : this
+            });
+        },
+
+        _step8 : function () {
+            this.waitForWidgetBlur("happySelectBox", this._step9);
+        },
+
+        _step9 : function () {
+            // clicking outside the selectbox should not change its value
+            this.assertEquals(this.templateCtxt._tpl.onChangeCalled, 1);
+            this.assertEquals(this.templateCtxt._tpl.data.value, "empty");
+            this.end();
+        }
+
+    }
+});

--- a/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCaseTpl.tpl
+++ b/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCaseTpl.tpl
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.selectbox.emptyOption.EmptyOptionTestCaseTpl",
+    $hasScript : true
+}}
+    {var options = [
+        {
+            value : "empty",
+            label : ""
+        }, {
+            value : "yes",
+            label : "Yes"
+        }, {
+            value : "no",
+            label : "No"
+        }
+    ]/}
+
+    {var data = {
+        value : "empty"
+    }/}
+
+    {macro main()}
+        <div {id "clickOutsideDiv"/}>Question</div>
+        {@aria:SelectBox {
+            id : "happySelectBox",
+            label : "Are you happy?",
+            options : options,
+            onchange : onSelectBoxChange,
+            bind : {
+                value : {
+                    to : "value",
+                    inside : data
+                }
+            }
+        }/}
+    {/macro}
+{/Template}

--- a/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCaseTplScript.js
+++ b/test/aria/widgets/form/selectbox/emptyOption/EmptyOptionTestCaseTplScript.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.selectbox.emptyOption.EmptyOptionTestCaseTplScript',
+    $constructor : function () {
+        this.onChangeCalled = 0;
+    },
+    $prototype : {
+        onSelectBoxChange : function () {
+            this.onChangeCalled++;
+            this.$refresh();
+        }
+    }
+});


### PR DESCRIPTION
This pull request fixes the following issue: when a (non-null) value of an aria:SelectBox widget is selected and has an empty label, clicking on the field and immediately leaving it changes the value to null. On IE11 this also happens when clicking on the dropdown button.