### PR TITLE
Issues with the sortKeyGetter property of the SortIndicator widget

### DIFF
--- a/src/aria/templates/View.js
+++ b/src/aria/templates/View.js
@@ -661,8 +661,6 @@ var ariaUtilsType = require("../utils/Type");
                     } else /* if (this.sortOrder == this.SORT_DESCENDING) */{
                         this.$assert(330, this.sortOrder == this.SORT_DESCENDING);
                         this.sortOrder = this.SORT_ASCENDING;
-                        this.sortName = sortName;
-                        this.sortKeyGetter = this.$normCallback(sortKeyGetter);
                     }
                 } else {
                     this.sortName = sortName;

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -469,8 +469,8 @@ module.exports = Aria.beanDefinitions({
                     $classpath : "aria.templates.View"
                 },
                 "sortKeyGetter" : {
-                    $type : "json:FunctionRef",
-                    $description : "An anonymous function to pass the field by which we want to sort"
+                    $type : "common:Callback",
+                    $description : "An callback to return the field by which we want to sort. If this property is null, clicking on the sort indicator does not change the sort order, and only calls the onclick callback."
                 },
                 "refreshArgs" : {
                     $type : "json:Array",

--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -249,8 +249,18 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _sortList : function () {
-            this._cfg.view.toggleSortOrder(this._cfg.sortName, this._cfg.sortKeyGetter);
-            this._cfg.view.refresh();
+            var cfg = this._cfg, sortKeyGetter = cfg.sortKeyGetter;
+            if (sortKeyGetter) {
+                var view = cfg.view;
+                view.toggleSortOrder(cfg.sortName, sortKeyGetter);
+                view.refresh();
+            }
+        },
+
+        /**
+         * Updates the state and the icon to match the state of the view.
+         */
+        _updateDisplay : function () {
             this._state = this._setState(this._cfg);
             this._icon.changeIcon(this._getIconName(this._state));
         },
@@ -413,16 +423,19 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _dom_onclick : function (domEvt) {
-
             this._sortList();
 
             // handle an onclick event
             this.$ActionWidget._dom_onclick.apply(this, arguments);
 
-            if (this._cfg.refreshArgs) {
-                this._doPartialRefresh(this._cfg.refreshArgs);
-            } else {
-                this._context.$refresh();
+            if (this._cfg) {
+                this._updateDisplay();
+
+                if (this._cfg.refreshArgs) {
+                    this._doPartialRefresh(this._cfg.refreshArgs);
+                } else {
+                    this._context.$refresh();
+                }
             }
             domEvt.preventDefault();
 

--- a/test/aria/widgets/action/ActionTestSuite.js
+++ b/test/aria/widgets/action/ActionTestSuite.js
@@ -23,6 +23,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.action.sortindicator.SortIndicatorTest");
         this.addTests("test.aria.widgets.action.sortindicator.onclick.OnclickCallback");
         this.addTests("test.aria.widgets.action.sortindicator.block.SortIndicatorBlockTest");
-
+        this.addTests("test.aria.widgets.action.sortindicator.fixSortKeyGetter.SortIndicatorSortKeyGetterTest");
     }
 });

--- a/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTest.js
+++ b/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTest.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.action.sortindicator.fixSortKeyGetter.SortIndicatorSortKeyGetterTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $prototype : {
+        getCurrentOrder : function() {
+            var tableBody = this.getElementById("tableBody");
+            var rows = tableBody.rows;
+            var res = [];
+            for (var i = 0, l = rows.length; i < l; i++) {
+                res[i] = rows[i].cells[0].innerHTML;
+            }
+            return res.join(",");
+        },
+
+        runTemplateTest : function () {
+            this.assertEquals(this.getCurrentOrder(), "Jeremy,Timothee,Marie,Anne-Claire,Mathilde");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 0);
+            this.assertEquals(this.templateCtxt._tpl.refreshes, 1);
+            this.synEvent.click(this.getSortIndicator("sortIndicatorFirstName"), this.waitForRefresh(2, this._step1));
+        },
+
+        _step1 : function () {
+            this.assertEquals(this.getCurrentOrder(), "Anne-Claire,Jeremy,Marie,Mathilde,Timothee");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 5);
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldArgs.field, "firstName");
+            this.templateCtxt._tpl.sortByFieldCalls = 0;
+            this.templateCtxt._tpl.sortByFieldArgs = null;
+            this.synEvent.click(this.getSortIndicator("sortIndicatorFirstName"), this.waitForRefresh(3, this._step2));
+        },
+
+        _step2: function () {
+            this.assertEquals(this.getCurrentOrder(), "Timothee,Mathilde,Marie,Jeremy,Anne-Claire");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 0);
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldArgs, null);
+            this.synEvent.click(this.getSortIndicator("sortIndicatorBirthDate"), this.waitForRefresh(4, this._step3));
+        },
+
+        _step3: function () {
+            this.assertEquals(this.getCurrentOrder(), "Anne-Claire,Jeremy,Mathilde,Marie,Timothee");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 5);
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldArgs.field, "birthDate");
+            this.templateCtxt._tpl.sortByFieldCalls = 0;
+            this.templateCtxt._tpl.sortByFieldArgs = null;
+            this.synEvent.click(this.getLink("linkBirthDate"), this.waitForRefresh(5, this._step4));
+        },
+
+        _step4: function () {
+            this.assertEquals(this.getCurrentOrder(), "Timothee,Marie,Mathilde,Jeremy,Anne-Claire");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 0);
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldArgs, null);
+            this.synEvent.click(this.getSortIndicator("sortIndicatorBirthDate"), this.waitForRefresh(6, this._step5));
+        },
+
+        _step5: function () {
+            this.assertEquals(this.getCurrentOrder(), "Anne-Claire,Jeremy,Mathilde,Marie,Timothee");
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldCalls, 0);
+            this.assertEquals(this.templateCtxt._tpl.sortByFieldArgs, null);
+            this.end();
+        },
+
+        waitForRefresh : function (refreshNumber, cb) {
+            var self = this;
+            return function () {
+                self.waitFor({
+                    condition: function () {
+                        return this.templateCtxt._tpl.refreshes === refreshNumber;
+                    },
+                    callback: cb
+                });
+            };
+        }
+    }
+});

--- a/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTestTpl.tpl
+++ b/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTestTpl.tpl
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.action.sortindicator.fixSortKeyGetter.SortIndicatorSortKeyGetterTestTpl",
+    $hasScript : true
+}}
+    {createView vFriends on friends /}
+
+    {macro main()}
+        <table>
+            <thead>
+                <tr>
+                    <th>
+                        {@aria:SortIndicator {
+                            id: "sortIndicatorFirstName",
+                            label: "First name",
+                            sortName: "firstName",
+                            view: vFriends,
+                            sortKeyGetter: {
+                                scope: this,
+                                fn: this.sortByField,
+                                args: {
+                                    field: "firstName"
+                                }
+                            }
+                        }/}
+                    </th>
+                    <th>
+                        {@aria:Link {
+                            id: "linkBirthDate",
+                            label: "Birth date (age)",
+                            onclick: this.sortBirthDateClick
+                        }/}
+                        {@aria:SortIndicator {
+                            id: "sortIndicatorBirthDate",
+                            sortName: "birthDate",
+                            view: vFriends,
+                            refreshArgs: [],
+                            onclick: this.sortBirthDateClick
+                        }/}
+                    </th>
+                </tr>
+            </thead>
+            <tbody {id "tableBody"/}>
+                {foreach person inView vFriends}
+                    <tr>
+                        <td>${person.firstName}</td>
+                        <td>${person.birthDate|dateFormat:"dd/MM/yyyy"} (${computeAge(person.birthDate)})</td>
+                    </tr>
+                {/foreach}
+            </tbody>
+        </table>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTestTplScript.js
+++ b/test/aria/widgets/action/sortindicator/fixSortKeyGetter/SortIndicatorSortKeyGetterTestTplScript.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.action.sortindicator.fixSortKeyGetter.SortIndicatorSortKeyGetterTestTplScript",
+    $dependencies : ["aria.utils.Date"],
+    $statics: {
+        friends: [
+            {
+                firstName: "Jeremy",
+                birthDate: new Date(1990,5,24)
+            }, {
+                firstName: "Timothee",
+                birthDate: new Date(1996,8,7)
+            }, {
+                firstName: "Marie",
+                birthDate: new Date(1992,7,29)
+            }, {
+                firstName: "Anne-Claire",
+                birthDate: new Date(1988,9,21)
+            }, {
+                firstName: "Mathilde",
+                birthDate: new Date(1990,11,12)
+            }
+        ]
+    },
+    $destructor : function () {
+        if (this.vFriends) {
+            // dispose the view as it is not disposed automatically
+            this.vFriends.$dispose();
+            this.vFriends = null;
+        }
+    },
+    $prototype : {
+        refreshes: 0,
+        sortByFieldArgs: null,
+        sortByFieldCalls: 0,
+
+        sortByField: function (o, args) {
+            if (args === this.sortByFieldArgs) {
+                this.sortByFieldCalls++;
+            } else {
+                this.sortByFieldCalls = 1;
+                this.sortByFieldArgs = args;
+            }
+            return o.value[args.field];
+        },
+
+        sortBirthDateClick: function () {
+            this.vFriends.toggleSortOrder("birthDate", {
+                scope: this,
+                fn: this.sortByField,
+                args: {
+                    field: "birthDate"
+                }
+            });
+            this.vFriends.refresh();
+            this.$refresh();
+        },
+
+        computeAge: function (date) {
+            var now = new Date();
+            var diff = now.getFullYear() - date.getFullYear();
+            if (now.getMonth() < date.getMonth() || (now.getMonth() == date.getMonth() && now.getDate() < date.getDate())) {
+                diff -= 1;
+            }
+            return diff;
+        },
+
+        $afterRefresh: function () {
+            this.refreshes++;
+        }
+    }
+});


### PR DESCRIPTION
This PR fixes the following issues with the sortKeyGetter property of the SortIndicator widget:
- it was not possible to use an object with `scope`, `fn` and `args` properties
- it could not be `null`, to disable the automatic sort done by the widget