### PR TITLE
MultiSelect does not prevent default action with arrow down key

### DIFF
--- a/src/aria/widgets/controllers/DropDownListController.js
+++ b/src/aria/widgets/controllers/DropDownListController.js
@@ -201,7 +201,7 @@ module.exports = Aria.classDefinition({
                     report = new ariaWidgetsControllersReportsDropDownControllerReport();
                 }
                 // domEvent.KC_ESCAPE for issue#697 on FF
-                if (report && keyCode != domEvent.KC_TAB) {
+                if (report && keyCode != domEvent.KC_TAB && keyCode != domEvent.KC_ARROW_DOWN) {
                     // domEvent.KC_ESCAPE for issue#697 on FF
                     report.cancelKeyStroke = (keyCode == domEvent.KC_ESCAPE);
                 }

--- a/src/aria/widgets/controllers/MultiSelectController.js
+++ b/src/aria/widgets/controllers/MultiSelectController.js
@@ -310,13 +310,16 @@ module.exports = Aria.classDefinition({
          * @return {aria.widgets.controllers.reports.DropDownControllerReport}
          */
         _checkInputKey : function (charCode, keyCode, currentText, caretPosStart, caretPosEnd) {
+            var report;
             if (ariaDomEvent.KC_ARROW_DOWN === keyCode) {
-                return this.toggleDropdown(currentText, false);
+                report = this.toggleDropdown(currentText, false);
+                report.cancelKeyStroke = true;
+            } else {
+                report = new ariaWidgetsControllersReportsDropDownControllerReport();
+                report.ok = true;
+                report.cancelKeyStroke = false;
+                report.displayDropDown = false;
             }
-            var report = new ariaWidgetsControllersReportsDropDownControllerReport();
-            report.ok = true;
-            report.cancelKeyStroke = false;
-            report.displayDropDown = false;
             return report;
         },
 

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -24,6 +24,7 @@ Aria.classDefinition({
                 "test.aria.widgets.form.multiselect.deleteFieldValue.test1.MultiSelect",
                 "test.aria.widgets.form.multiselect.deleteFieldValue.test2.MultiSelect",
                 "test.aria.widgets.form.multiselect.downArrowKey.MultiSelect",
+                "test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey",
                 "test.aria.widgets.form.multiselect.instantbind.InstantBindTestCase",
                 "test.aria.widgets.form.multiselect.invalidcontent.MultiSelect",
                 "test.aria.widgets.form.multiselect.issue223.MultiSelect",

--- a/test/aria/widgets/form/multiselect/downArrowKeyPreventDef/MSDownArrowKey.js
+++ b/test/aria/widgets/form/multiselect/downArrowKeyPreventDef/MSDownArrowKey.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype : {
+        runTemplateTest : function () {
+            var self = this;
+            var scrollableItem = aria.utils.Dom.getDocumentScrollElement();
+
+            function step1() {
+                self.testDiv.style.position = "absolute";
+                scrollableItem.scrollTop = 3000;
+                var happyMS = self.getInputField("happyMS");
+                self.synEvent.execute([["click", happyMS], ["waitFocus", happyMS], ["type", null, "[down]"]], step2);
+            }
+
+            function step2() {
+                self.assertEquals(scrollableItem.scrollTop, 3000);
+                self.waitFor({
+                    condition: function () {
+                        return !!self.getWidgetDropDownPopup("happyMS");
+                    },
+                    callback: step3
+                });
+            }
+
+            function step3() {
+                self.synEvent.execute([["type", null, " [up]"]], step4);
+            }
+
+            function step4() {
+                self.assertEquals(scrollableItem.scrollTop, 3000);
+                var happyMS = self.getInputField("happyMS");
+                self.synEvent.execute([["click", happyMS], ["waitFocus", happyMS], ["type", null, "[down][down]"]], step5);
+            }
+
+            function step5() {
+                self.assertEquals(scrollableItem.scrollTop, 3000);
+                self.waitFor({
+                    condition: function () {
+                        return !!self.getWidgetDropDownPopup("happyMS");
+                    },
+                    callback: step6
+                });
+            }
+
+            function step6() {
+                self.synEvent.execute([["type", null, " [up][up]"]], step7);
+            }
+
+            function step7() {
+                self.assertEquals(scrollableItem.scrollTop, 3000);
+                self.end();
+            }
+
+            step1();
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/downArrowKeyPreventDef/MSDownArrowKeyTpl.tpl
+++ b/test/aria/widgets/form/multiselect/downArrowKeyPreventDef/MSDownArrowKeyTpl.tpl
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKeyTpl",
+    $hasScript:false
+}}
+
+    {macro main()}
+        <div style="height:3000px;"></div>
+        <h1>This test needs focus</h1>
+        {@aria:MultiSelect {
+            id :"happyMS",
+            label : "What do you need to be happy?",
+            labelWidth : 200,
+            width: 650,
+            numberOfRows:4,
+            displayOptions : {
+                listDisplay : "label"
+            },
+            items : [
+                {label : "God", value : "God"},
+                {label : "Love", value : "Love"},
+                {label : "Forgiveness", value : "Forgiveness"},
+                {label : "Hope", value : "Hope"},
+                {label : "A spouse", value : "spouse"},
+                {label : "Good friends", value : "goodfriends"},
+                {label : "Food", value : "Food"},
+                {label : "Clothing", value : "Clothing"},
+                {label : "Shelter", value : "Shelter"},
+                {label : "A good job", value : "goodjob"},
+                {label : "A car", value : "car"},
+                {label : "A good computer", value : "goodcomputer"},
+                {label : "A smartphone", value: "smartphone"},
+                {label : "JavaScript", value : "Javascript"},
+                {label : "A good browser", value: "goodbrowser"},
+                {label : "Aria Templates", value : "ariatemplates"}
+            ]
+        }/}
+        <div style="height:3000px;"></div>
+    {/macro}
+
+{/Template}

--- a/test/attester-nophantom.yml
+++ b/test/attester-nophantom.yml
@@ -22,6 +22,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
     - test.aria.utils.DomScrollIntoView
+    - test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey
     - test.aria.widgets.container.dialog.container.DialogContainerTestSuite
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
   # This test works in Firefox and Chrome locally but not on Travis... It is removed in .travis.yml

--- a/test/attester-packaged.yml
+++ b/test/attester-packaged.yml
@@ -24,6 +24,7 @@ tests:
     - test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTestCase
     - test.aria.utils.overlay.loadingIndicator.scrollableBody.ScrollableBodyTest
     - test.aria.utils.DomScrollIntoView
+    - test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey
     - test.aria.widgets.container.dialog.container.DialogContainerTestSuite
     - test.aria.widgets.container.dialog.indicators.DialogTestCase
     - test.aria.widgets.container.dialog.movable.test5.MovableDialogTestCaseFive


### PR DESCRIPTION
This PR makes sure the default action when pressing the arrow down key (usually: scrolling the document) is prevented when the focus is inside the aria:MultiSelect widget.