### PR TITLE
Bridge url map and root map

### DIFF
--- a/test/aria/utils/UtilsTestSuite.js
+++ b/test/aria/utils/UtilsTestSuite.js
@@ -69,6 +69,7 @@ Aria.classDefinition({
         this.addTests("test.aria.utils.Xml");
         this.addTests("test.aria.utils.DeviceTest");
         this.addTests("test.aria.utils.OrientationTest");
+        this.addTests("test.aria.utils.bridge.BridgeTest");
         this.addTests("test.aria.utils.dragdrop.DragTestSuite");
         this.addTests("test.aria.utils.events.EventsTestSuite");
     }

--- a/test/aria/utils/bridge/BridgeTest.js
+++ b/test/aria/utils/bridge/BridgeTest.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.utils.bridge.BridgeTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.utils.Bridge"],
+    $prototype : {
+        tearDown: function () {
+            if (this.bridge) {
+                this.bridge.close();
+                this.bridge.$dispose();
+                this.bridge = null;
+            }
+        },
+
+        testAsyncCheckDownloadMgrMaps : function () {
+            aria.core.DownloadMgr.updateRootMap({
+                "bridgeTest": aria.core.DownloadMgr.resolveURL("test/aria/utils/bridge/root", true) + "/"
+            });
+            aria.core.DownloadMgr.updateUrlMap({
+                "bridgeTest": {
+                    "BridgeCtrl": "bridgeTest/BridgeCtrl-abcde.js",
+                    "BridgeTpl": "bridgeTest/BridgeTpl-efghi.tpl"
+                }
+            });
+
+            var bridge = this.bridge = new aria.utils.Bridge();
+            bridge.open({
+                title: "BridgeWindow",
+                moduleCtrlClasspath: "bridgeTest.BridgeCtrl",
+                displayClasspath: "bridgeTest.BridgeTpl"
+            });
+
+            this.waitFor({
+                condition: function () {
+                    return !! bridge._subWindow.document && bridge._subWindow.document.getElementById("myElementIsThere");
+                },
+                callback: function () {
+                    // checks that changing the root map and the url map in the main window is reflected
+                    // in the sub window as maps are linked
+                    aria.core.DownloadMgr.updateRootMap({
+                        "bridgeTest": {
+                            "later": aria.core.DownloadMgr.resolveURL("test/aria/utils/bridge/laterRoot", true) + "/"
+                        }
+                    });
+                    aria.core.DownloadMgr.updateUrlMap({
+                        "bridgeTest": {
+                            "later" : {
+                                "LaterClass": "LaterClass-xyz.js"
+                            }
+                        }
+                    });
+                    bridge._subWindow.Aria.load({
+                        classes: ["bridgeTest.later.LaterClass"],
+                        oncomplete: {
+                            scope: this,
+                            fn: function () {
+                                this.assertEquals(bridge._subWindow.bridgeTest.later.LaterClass.value, "OK-LOADED");
+                                this.notifyTestEnd();
+                            }
+                        }
+                    });
+                }
+            });
+        }
+    }
+});

--- a/test/aria/utils/bridge/laterRoot/LaterClass-xyz.js
+++ b/test/aria/utils/bridge/laterRoot/LaterClass-xyz.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath: "bridgeTest.later.LaterClass",
+    $singleton: true,
+    $prototype: {
+        value: "OK-LOADED"
+    }
+});

--- a/test/aria/utils/bridge/root/bridgeTest/BridgeCtrl-abcde.js
+++ b/test/aria/utils/bridge/root/bridgeTest/BridgeCtrl-abcde.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath: "bridgeTest.BridgeCtrl",
+    $extends: "aria.templates.ModuleCtrl",
+    $prototype: {
+        init: function (initArgs, cb) {
+            this.$callback(cb);
+        }
+    }
+});

--- a/test/aria/utils/bridge/root/bridgeTest/BridgeTpl-efghi.tpl
+++ b/test/aria/utils/bridge/root/bridgeTest/BridgeTpl-efghi.tpl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "bridgeTest.BridgeTpl"
+}}
+
+    {macro main()}
+        Hello <div id="myElementIsThere"></div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR fixes #1074.
Unlike #1075, it links the url map and root map of the popup window to the ones of the parent window, so that if the maps of the parent window are later updated, the popup window benefits from those changes. It also contains a test.