### PR TITLE
Logging error for classpath dependencies outside the old loader

### DIFF
--- a/src/aria/core/JsonValidator.js
+++ b/src/aria/core/JsonValidator.js
@@ -727,7 +727,7 @@ var Aria = require("../Aria");
                     classpaths : {
                         "JS" : dep
                     },
-                    oldModuleLoader : def.$oldModuleLoader,
+                    classDefinition : def,
                     complete : {
                         scope : this,
                         fn : this.__loadBeans,

--- a/src/aria/node.js
+++ b/src/aria/node.js
@@ -24,7 +24,7 @@ try {
     // For all the other classes we use IO, define our node transport
     Aria.classDefinition({
         $classpath : "aria.node.Transport",
-        $implements : ["aria.core.transport.ITransports"],
+        $implements : [aria.core.transport.ITransports],
         $singleton : true,
         $prototype : {
             isReady : true,

--- a/test/aria/AriaTest.js
+++ b/test/aria/AriaTest.js
@@ -116,7 +116,7 @@ Aria.classDefinition({
             // Same class name as one of the class parents
             this.callAriaClassDefError({
                 $classpath : 'test.aria.test.Assert',
-                $extends : 'aria.jsunit.TestCase',
+                $extends : aria.jsunit.TestCase,
                 $constructor : function () {}
             });
             this.assertErrorInLogs(Aria.DUPLICATE_CLASSNAME);
@@ -131,7 +131,7 @@ Aria.classDefinition({
             // Inherit from Singleton
             this.callAriaClassDefError({
                 $classpath : 'test.aria.test.ClassSExtended',
-                $extends : 'test.aria.test.ClassS'
+                $extends : test.aria.test.ClassS
             });
             this.assertErrorInLogs(Aria.CANNOT_EXTEND_SINGLETON);
 

--- a/test/aria/core/JsonValidatorTest.js
+++ b/test/aria/core/JsonValidatorTest.js
@@ -147,7 +147,7 @@ Aria.classDefinition({
                             }
                         }
                     }, {
-                        errorMsgs : [jv.MISSING_BEANSPACKAGE],
+                        errorMsgs : [jv.MISSING_BEANSPACKAGE, Aria.OLD_DEPENDENCIES_SYNTAX],
                         beans : {
                             TestBean : {
                                 $type : "missing:MyBean",
@@ -352,7 +352,9 @@ Aria.classDefinition({
                     $package : "test.aria.core.test.InvalidBeans",
                     $description : "Bean package to test errors in preprocessing",
                     $namespaces : (btt.namespaces !== undefined ? btt.namespaces : {
-                        "json" : "aria.core.JsonTypes"
+                        "json" : jv.__loadedBeans["aria.core.JsonTypes"]
+                        // the previous line is equivalent to:
+                        // "json" : require("ariatemplates/core/JsonTypes")
                     }),
                     $beans : btt.beans
                 };

--- a/test/aria/core/io/IOTransportTest.js
+++ b/test/aria/core/io/IOTransportTest.js
@@ -58,7 +58,7 @@ Aria.classDefinition({
             /**
              * Base Custom Transport class.
              */
-            Aria.classDefinition({
+            var BaseXHR = Aria.classDefinition({
                 $classpath : "myApplication.transports.BaseXHR",
                 $constructor : function () {},
                 $prototype : {}
@@ -69,7 +69,7 @@ Aria.classDefinition({
              */
             Aria.classDefinition({
                 $classpath : "myApplication.transports.SameDomainCustomTransport",
-                $extends : "myApplication.transports.BaseXHR",
+                $extends : BaseXHR,
                 $singleton : true,
                 $constructor : function () {
                     this.$BaseXHR.constructor.call(this);
@@ -82,7 +82,7 @@ Aria.classDefinition({
              */
             Aria.classDefinition({
                 $classpath : "myApplication.transports.CrossDomainCustomTransport",
-                $extends : "myApplication.transports.BaseXHR",
+                $extends : BaseXHR,
                 $singleton : true,
                 $constructor : function () {
                     this.$BaseXHR.constructor.call(this);
@@ -95,7 +95,7 @@ Aria.classDefinition({
              */
             Aria.classDefinition({
                 $classpath : "myApplication.transports.JsonPCustomTransport",
-                $extends : "myApplication.transports.BaseXHR",
+                $extends : BaseXHR,
                 $singleton : true,
                 $constructor : function () {
                     this.$BaseXHR.constructor.call(this);
@@ -108,7 +108,7 @@ Aria.classDefinition({
              */
             Aria.classDefinition({
                 $classpath : "myApplication.transports.LocalCustomTransport",
-                $extends : "myApplication.transports.BaseXHR",
+                $extends : BaseXHR,
                 $singleton : true,
                 $constructor : function () {
                     this.$BaseXHR.constructor.call(this);
@@ -121,7 +121,7 @@ Aria.classDefinition({
              */
             Aria.classDefinition({
                 $classpath : "myApplication.transports.IFrameCustomTransport",
-                $extends : "myApplication.transports.BaseXHR",
+                $extends : BaseXHR,
                 $singleton : true,
                 $constructor : function () {
                     this.$BaseXHR.constructor.call(this);


### PR DESCRIPTION
This PR adds an error in the console in case classpath dependencies are used outside the backward-compatible loader.

The backward-compatible loader is automatically used to load a class when no call to "require" is done in the module being loaded.

However, using both "require" and old-style classpath dependencies in a module can cause issues, because, in CommonJS, a module is considered loaded as soon as its content has been executed, but this is too early if classpath dependencies still have to be loaded. As a consequence, another class can be executed when its dependencies are not all fully loaded.

So this commit helps the developer to detect such issues and to fix them as early as possible.