### PR TITLE
fixing issue in AdaptToContentWidthTest after reducing the default delay in waitFor

### DIFF
--- a/test/aria/widgets/form/autocomplete/popupWidth/AdaptToContentWidthTest.js
+++ b/test/aria/widgets/form/autocomplete/popupWidth/AdaptToContentWidthTest.js
@@ -39,7 +39,7 @@ Aria.classDefinition({
 
             this.waitFor({
                 condition : function () {
-                    return !!testCase.getWidgetDropDownPopup("ac");
+                    return !!(testCase.getWidgetDropDownPopup("ac") && this.getElementById("Items", false, this.getWidgetInstance("ac").controller.getListWidget()._subTplCtxt));
                 },
                 callback : function () {
                     testCase.$callback({


### PR DESCRIPTION
The condition in the waitFor call in test.aria.widgets.form.autocomplete.popupWidth.AdaptToContentWidthTest
did not correctly check whether the popup was fully loaded.
Before reducing the delay of the waitFor (in da838e16a05cc6943639b55528fc07fbcd2a238e),
the test was randomly failing, but after the delay was reduced, the test
was always failing, before the correct condition was set in this PR
(which makes it pass in a reliable way).