### PR TITLE
waitForDropDownPopup in TemplateTestCase and making AdaptToContentWidthTest more reliable

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -524,6 +524,27 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Waits for the the given widget to fully display its popup.
+         * @param {String} widgetId
+         * @param {Function} cb : callback which will be called when the popup is fully displayed
+         */
+        waitForDropDownPopup : function (widgetId, cb) {
+            this.waitFor({
+                condition : function () {
+                    var controller = this.getWidgetInstance(widgetId).controller;
+                    var popupWidget;
+                    if (controller && controller.getListWidget) {
+                        popupWidget = controller.getListWidget();
+                    } else if (controller && controller.getCalendar) {
+                        popupWidget = controller.getCalendar();
+                    }
+                    return popupWidget && popupWidget._subTplCtxt;
+                },
+                callback : cb
+            });
+        },
+
+        /**
          * Get the &lt;input&gt; DOM element of an input based widget.
          * @param {String} templateWidgetID
          * @return {HTMLElement} Returns directly the input element from the DOM, or null if the ID was not found or

--- a/src/aria/widgets/controllers/DatePickerController.js
+++ b/src/aria/widgets/controllers/DatePickerController.js
@@ -47,6 +47,14 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Returns the calendar associated to this controller.
+         * @return {aria.widgets.calendar.Calendar}
+         */
+        getCalendar : function () {
+            return this._calendar;
+        },
+
+        /**
          * Verify a given value
          * @param {String} displayValue the displayed text
          * @return {aria.widgets.controllers.reports.ControllerReport}

--- a/src/aria/widgets/controllers/SelectController.js
+++ b/src/aria/widgets/controllers/SelectController.js
@@ -362,6 +362,14 @@ var ariaCoreTimer = require("../../core/Timer");
                 // list widget, if any. This is done when the section containing the
                 // list widget is disposed.
                 this._listWidget = listWidget;
+            },
+
+            /**
+             * Get the list widget.
+             * @return {aria.widgets.form.list.List} listWidget
+             */
+            getListWidget : function () {
+                return this._listWidget;
             }
         }
     });

--- a/test/aria/widgets/form/autocomplete/popupWidth/AdaptToContentWidthTest.js
+++ b/test/aria/widgets/form/autocomplete/popupWidth/AdaptToContentWidthTest.js
@@ -29,28 +29,11 @@ Aria.classDefinition({
         runTemplateTest : function () {
             var field = this.getInputField("ac");
             this.synEvent.execute([["click", field], ["type", field, "a"]], {
-                fn : this._afterTyping,
+                fn : this.waitForDropDownPopup,
+                args : ["ac", this._afterDropdownOpen],
+                apply : true,
+                resIndex : -1,
                 scope : this
-            });
-        },
-
-        _afterTyping : function () {
-            var testCase = this;
-
-            this.waitFor({
-                condition : function () {
-                    var listWidget = this.getWidgetInstance("ac").controller.getListWidget();
-                    if (listWidget && listWidget._subTplCtxt) {
-                        return !! this.getElementById("Items", false, listWidget._subTplCtxt);
-                    }
-                    return false;
-                },
-                callback : function () {
-                    testCase.$callback({
-                        fn : testCase._afterDropdownOpen,
-                        scope : testCase
-                    });
-                }
             });
         },
 
@@ -58,7 +41,10 @@ Aria.classDefinition({
             this._checkDropdownWidth();
             var field = this.getInputField("ac");
             this.synEvent.execute([["type", field, "[BACK_SPACE]a"]], {
-                fn : this._afterSecondDropdownOpen,
+                fn : this.waitForDropDownPopup,
+                args : ["ac", this._afterSecondDropdownOpen],
+                apply : true,
+                resIndex : -1,
                 scope : this
             });
 


### PR DESCRIPTION
This PR adds the `waitForDropDownPopup` method in `TemplateTestCase` and uses it in `AdaptToContentWidthTest` so that this test is more reliable.