### PR TITLE
Fix random issue in preselectAutofill tests

### DIFF
--- a/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
+++ b/test/aria/widgets/form/autocomplete/preselectAutofill/PreselectAutofillBaseTest.js
@@ -263,16 +263,20 @@ Aria.classDefinition({
 
         _testPopupOpen : function (res, args) {
             var isOpen = this.testValues.items[args[0]][0] > 0 ? 1 : 0;
-            this.waitFor({
-                condition : function () {
-                    var openedPopups = aria.popups.PopupManager.openedPopups;
-                    return openedPopups.length == isOpen;
-                },
-                callback : {
-                    fn : this[args[1]],
-                    scope : this
-                }
-            });
+            if (isOpen) {
+                this.waitForDropDownPopup("ac", this[args[1]]);
+            } else {
+                this.waitFor({
+                    condition : function () {
+                        var openedPopups = aria.popups.PopupManager.openedPopups;
+                        return openedPopups.length == isOpen;
+                    },
+                    callback : {
+                        fn : this[args[1]],
+                        scope : this
+                    }
+                });
+            }
         },
 
         /**


### PR DESCRIPTION
This PR fixes random issues in preselectAutofill tests due to the fact that the condition to wait for the popup was not complete enough. Using the dedicated `waitForDropDownPopup` method (from `TemplateTestCase`, added in 58c8e7a0402b8e97251e46793b440e4c6021defd) solves the issue.