### PR TITLE
Fix wrong display of ampersand in the suggestions of the autocomplete

### DIFF
--- a/src/aria/templates/Modifiers.js
+++ b/src/aria/templates/Modifiers.js
@@ -225,8 +225,8 @@ var ariaUtilsArray = require("../utils/Array");
              * @return {String}
              */
             fn : function (str, highlight) {
-                var ariaUtil = aria.utils, highlightLen = highlight.length;
-                if (ariaUtil.Type.isString(str) && highlightLen) {
+                var highlightLen = highlight.length;
+                if (ariaUtilsType.isString(str) && highlightLen) {
                     highlight = highlight.toLowerCase();
                     var strLowerCased = str.toLowerCase(), firstOccurrenceIdx;
                     if (strLowerCased.indexOf(highlight) === 0) {
@@ -235,7 +235,7 @@ var ariaUtilsArray = require("../utils/Array");
                         var highlightRegexSafe = highlight.replace(regExSpecials, "\\$1");
                         var regexResult = new RegExp("\\s" + highlightRegexSafe, "i").exec(strLowerCased);
                         if (!regexResult) {
-                            return str;
+                            return ariaUtilsString.escapeForHTML(str);
                         } else {
                             firstOccurrenceIdx = regexResult.index + 1; // +1 for matched whitespace
                         }
@@ -243,12 +243,12 @@ var ariaUtilsArray = require("../utils/Array");
                     var a = firstOccurrenceIdx;
                     var b = firstOccurrenceIdx + highlightLen;
                     var middleOriginal = str.substring(a, b);
-                    var middle = ariaUtil.String.stripAccents(middleOriginal).toLowerCase();
+                    var middle = ariaUtilsString.stripAccents(middleOriginal).toLowerCase();
                     if (middle === highlight) {
-                        return str.substring(0, a) + "<strong>" + middleOriginal + "</strong>" + str.substring(b);
+                        return ariaUtilsString.escapeForHTML(str.substring(0, a)) + "<strong>" + ariaUtilsString.escapeForHTML(middleOriginal) + "</strong>" + ariaUtilsString.escapeForHTML(str.substring(b));
                     }
                 }
-                return str;
+                return str ? ariaUtilsString.escapeForHTML(str) : str;
             }
         },
         "starthighlight" : {
@@ -272,11 +272,11 @@ var ariaUtilsArray = require("../utils/Array");
                     var beginning = ariaUtilsString.stripAccents(str.substring(0, highlight.length)).toLowerCase();
                     highlight = highlight.toLowerCase();
                     if (beginning === highlight) {
-                        return "<strong>" + str.substring(0, highlight.length) + "</strong>"
-                                + str.substring(highlight.length);
+                        return "<strong>" + ariaUtilsString.escapeForHTML(str.substring(0, highlight.length)) + "</strong>"
+                                + ariaUtilsString.escapeForHTML(str.substring(highlight.length));
                     }
                 }
-                return str;
+                return str ? ariaUtilsString.escapeForHTML(str) : str;
             }
         },
         "highlight" : {

--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -27,9 +27,9 @@
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}
-                ${item.label|escapeForHTML:{text:true}|highlightfromnewword:entry|escapeForHTML:false}
+                ${item.label|highlightfromnewword:entry|escapeForHTML:false}
             {else/}
-                ${item.label|escapeForHTML:{text:true}|starthighlight:entry|escapeForHTML:false}
+                ${item.label|starthighlight:entry|escapeForHTML:false}
             {/if}
         </a>
     {/macro}

--- a/test/aria/templates/ModifiersTest.js
+++ b/test/aria/templates/ModifiersTest.js
@@ -292,7 +292,13 @@ Aria.classDefinition({
                     ["x abc", "a.c"],
                     // Dangerous expression
                     ["abcd .efg", ".efg"], ["abcd [efg]", "[efg]"], ["abcd efg", ".efg"], ["abcd @efg", "@ef"],
-                    ["abcd (1-123)", "(1-"], ["abcd (1-123)", "(1-123)"], ["abc-defgh", "abc-de"]];
+                    ["abcd (1-123)", "(1-"], ["abcd (1-123)", "(1-123)"], ["abc-defgh", "abc-de"],
+                    // HTML escaping:
+                    ["R&D-AFW", "R&"],
+                    ["<strong>expression</strong>", "<strong>"],
+                    ["TEST R&D-AFW", "R&"],
+                    ["test <strong>expression</strong>", "<strong>"]
+                ];
 
             var expected = [
                     // basic: finds highlights on word boundaries
@@ -330,9 +336,76 @@ Aria.classDefinition({
                     // Dangerous expression
                     "abcd <strong>.efg</strong>", "abcd <strong>[efg]</strong>", "abcd efg",
                     "abcd <strong>@ef</strong>g", "abcd <strong>(1-</strong>123)", "abcd <strong>(1-123)</strong>",
-                    "<strong>abc-de</strong>fgh"];
+                    "<strong>abc-de</strong>fgh",
+                    // HTML escaping:
+                    "<strong>R&amp;</strong>D-AFW",
+                    "<strong>&lt;strong&gt;</strong>expression&lt;&#x2F;strong&gt;",
+                    "TEST <strong>R&amp;</strong>D-AFW",
+                    "test <strong>&lt;strong&gt;</strong>expression&lt;&#x2F;strong&gt;"
+                ];
             for (var i = 0, len = testThese.length; i < len; i += 1) {
                 var got = aria.templates.Modifiers.callModifier("highlightfromnewword", testThese[i]);
+                this.assertEquals(got, expected[i], "Expecting '" + expected[i] + "', got '" + got + "'");
+            }
+        },
+
+        /**
+         * Unit test the starthighlight modifier.
+         */
+        testStartHighlight : function () {
+            var testThese = [
+                    ["abc def ghi", "abc d"], ["abc def ghi", "def g"], ["abc def ghi", "ghi"],
+                    ["abc abd", "ab"], ["abc abd abc", "abd a"],
+                    ["abc defgh ikj", "efg"],
+                    ["abc    defgh", "def"],
+                    ["abc				defgh", "def"],
+                    ["", "aaa"],
+                    ["abc", ""],
+                    ["    ", "aaa"],
+                    ["abc", "   "],
+                    [" abc def", "ab"],
+                    ["aBcDe", "abcd"], ["aBcDe", "AbCd"], ["ABCDe", "abcd"],
+                    ["abcd (123)", "123"], ["abcd +123", "123"], ["abcd .123", "123"],
+                    ["x abc", "a.c"],
+                    ["abcd .efg", ".efg"], ["abcd [efg]", "[efg]"], ["abcd efg", ".efg"], ["abcd @efg", "@ef"],
+                    ["abcd (1-123)", "(1-"], ["abcd (1-123)", "(1-123)"], ["abc-defgh", "abc-de"],
+                    ["R&D-AFW", "R&"],
+                    ["<strong>expression</strong>", "<strong>"],
+                    ["TEST R&D-AFW", "R&"],
+                    ["test <strong>expression</strong>", "<strong>"]
+                ];
+
+            var expected = [
+                    "<strong>abc d</strong>ef ghi",
+                    "abc def ghi",
+                    "abc def ghi",
+                    "<strong>ab</strong>c abd",
+                    "abc abd abc",
+                    "abc defgh ikj",
+                    "abc    defgh",
+                    "abc				defgh",
+                    "",
+                    "abc",
+                    "    ",
+                    "abc",
+                    " abc def",
+                    "<strong>aBcD</strong>e", "<strong>aBcD</strong>e",
+                    "<strong>ABCD</strong>e",
+                    "abcd (123)",
+                    "abcd +123",
+                    "abcd .123",
+                    "x abc",
+                    "abcd .efg", "abcd [efg]", "abcd efg",
+                    "abcd @efg", "abcd (1-123)", "abcd (1-123)",
+                    "<strong>abc-de</strong>fgh",
+                    // HTML escaping:
+                    "<strong>R&amp;</strong>D-AFW",
+                    "<strong>&lt;strong&gt;</strong>expression&lt;&#x2F;strong&gt;",
+                    "TEST R&amp;D-AFW",
+                    "test &lt;strong&gt;expression&lt;&#x2F;strong&gt;"
+                ];
+            for (var i = 0, len = testThese.length; i < len; i += 1) {
+                var got = aria.templates.Modifiers.callModifier("starthighlight", testThese[i]);
                 this.assertEquals(got, expected[i], "Expecting '" + expected[i] + "', got '" + got + "'");
             }
         }

--- a/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
+++ b/test/aria/widgets/form/autocomplete/AutoCompleteTestSuite.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.widgets.form.autocomplete.ampersand.AutoComplete");
+        this.addTests("test.aria.widgets.form.autocomplete.ampersandSuggestion.AmpersandSuggestion");
         this.addTests("test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonTest");
         this.addTests("test.aria.widgets.form.autocomplete.selectionKey.AutoComplete");
         this.addTests("test.aria.widgets.form.autocomplete.selectionKey.AutoCompleteModifier");

--- a/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestion.js
+++ b/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestion.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.ampersandSuggestion.AmpersandSuggestion",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.String"],
+    $prototype : {
+        runTemplateTest : function () {
+            this.clickAndType("ac", "R&", {
+                fn : function () {
+                    this.waitForDropDownPopup("ac", this.afterTypingAmpersand);
+                },
+                scope : this
+            }, false);
+        },
+
+        afterTypingAmpersand : function () {
+            var inputField = this.getInputField("ac");
+            this.checkLastSuggestion();
+            this.synEvent.type(inputField, "D", {
+                fn: function () {
+                    this.waitFor({
+                        condition: function () {
+                            return inputField.value === "R&D";
+                        },
+                        callback: this.afterTypingD
+                    });
+                },
+                scope: this
+            });
+        },
+
+        afterTypingD : function () {
+            this.checkLastSuggestion();
+            this.end();
+        },
+
+        checkLastSuggestion : function () {
+            var expectedLabel = "R&D-AFW";
+            var popup = this.getWidgetDropDownPopup("ac");
+            var links = popup.getElementsByTagName("a");
+            var lastLink = links[links.length - 1];
+            var lastLinkText = aria.utils.String.trim(lastLink.textContent || lastLink.innerText);
+            this.assertEquals(lastLinkText, expectedLabel);
+            var strongTags = lastLink.getElementsByTagName("strong");
+            this.assertEquals(strongTags.length, 1);
+            var strongTagText = aria.utils.String.trim(strongTags[0].textContent || strongTags[0].innerText);
+            this.assertTrue(strongTagText.length > 1);
+            this.assertEquals(strongTagText, expectedLabel.substr(0, strongTagText.length));
+            var inputField = this.getInputField("ac");
+            this.assertEquals(inputField.value, strongTagText);
+        }
+    }
+});

--- a/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestionTpl.tpl
+++ b/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestionTpl.tpl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+  $classpath:"test.aria.widgets.form.autocomplete.ampersandSuggestion.AmpersandSuggestionTpl",
+  $hasScript:true
+}}
+
+  {macro main()}
+    {@aria:AutoComplete {
+        id: "ac",
+        resourcesHandler: this.getResHandler()
+      }/}
+  {/macro}
+
+{/Template}

--- a/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestionTplScript.js
+++ b/test/aria/widgets/form/autocomplete/ampersandSuggestion/AmpersandSuggestionTplScript.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.form.autocomplete.ampersandSuggestion.AmpersandSuggestionTplScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $destructor : function () {
+        if (this.resHandler) {
+            this.resHandler.$dispose();
+        }
+    },
+    $prototype : {
+        getResHandler : function () {
+            if (!this.resHandler) {
+                this.resHandler = new aria.resources.handlers.LCResourcesHandler();
+                this.resHandler.setSuggestions([
+                    {
+                        label : "R&D-BA-BA",
+                        code : "R&D-BA-BA"
+                    }, {
+                        label : "R&D-CAC",
+                        code : "R&D-CAC"
+                    }, {
+                        label : "R&D-AFW",
+                        code : "R&D-AFW"
+                    }, {
+                        label : "R*D-BA-BA",
+                        code : "R*D-BA-BA"
+                    }, {
+                        label : "R*D-CAC",
+                        code : "R*D-CAC"
+                    }, {
+                        label : "R*D-AFW",
+                        code : "R*D-AFW"
+                    }
+                ]);
+            }
+            return this.resHandler;
+        }
+    }
+});


### PR DESCRIPTION
This PR fixes the following issue: when typing an ampersand in the autocomplete, and if some suggestions match, suggestions are wrongly displayed with '&' replaced by the corresponding '&amp;amp;' entity. Adding another letter afterwards switches back to the correct display, but then the highlighting in the suggestion no longer works (while there is an ampersand in the input).