### PR TITLE
Adding WAI-ARIA accessibility support to the DatePicker widget

### DIFF
--- a/src/aria/utils/sandbox/DOMProperties.js
+++ b/src/aria/utils/sandbox/DOMProperties.js
@@ -294,6 +294,7 @@ var Aria = require("../../Aria");
             "SELECT" : "r-",
             "TEXTAREA" : "r-"
         },
+        "unselectable" : "rw",
         "useMap" : {
             "IMG" : "rw"
         },

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -791,6 +791,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "environmentBase:inputFormatTypes",
                     $description : "Date pattern used to match user input and convert it in a Javascript valid date."
                 },
+                "waiAriaDateFormat" : {
+                    $type : "environmentBase:inputFormatTypes",
+                    $description : "Date pattern used by screen readers to read the selected date in the calendar (only used when waiAria is true)."
+                },
                 "minValue" : {
                     $type : "json:Date",
                     $description : "Minimum date for the value property."
@@ -860,8 +864,11 @@ module.exports = Aria.beanDefinitions({
                 },
                 "iconTooltip" : {
                     $type : "json:String",
-                    $description : "Tooltip label for the datepicker icon",
-                    $default : "Open the Calendar"
+                    $description : "Tooltip for the datepicker icon"
+                },
+                "waiAriaCalendarLabel": {
+                    $type : "json:String",
+                    $description : "aria-label to set on the calendar (only used when waiAria is true)."
                 },
                 "bind" : {
                     $type : "DropDownTextInputCfg.bind",
@@ -1657,6 +1664,22 @@ module.exports = Aria.beanDefinitions({
                     $type : "common:Callback",
                     $description : "Function to be called when the selected date or range in the calendar changes because of user action (click or keyboard selection)."
                 },
+                "onfocus" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the calendar widget is focused."
+                },
+                "onblur" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the calendar widget is blured."
+                },
+                "onkeydown" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the user types a key while the widget is focused."
+                },
+                "onmousedown" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the user presses the mouse on the calendar."
+                },
                 "minValue" : {
                     $type : "json:Date",
                     $description : "Minimum date for the value property."
@@ -1684,6 +1707,14 @@ module.exports = Aria.beanDefinitions({
                     $description : "First day of the week. 0 = Sunday, ... 6 = Saturday. The null value means that it is set according to the application environment.",
                     $minValue : 0,
                     $maxValue : 6
+                },
+                "waiAriaDateFormat" : {
+                    $type : "environmentBase:inputFormatTypes",
+                    $description : "Date pattern used by screen readers to read the date (only used when waiAria is true)."
+                },
+                "waiAriaLabel": {
+                    $type : "json:String",
+                    $description : "aria-label to set on the whole calendar (only used when waiAria is true)."
                 },
                 "monthLabelFormat" : {
                     $type : "json:String",

--- a/src/aria/widgets/calendar/CalendarController.js
+++ b/src/aria/widgets/calendar/CalendarController.js
@@ -194,6 +194,9 @@ module.exports = Aria.classDefinition({
             if (!settings.completeDateLabelFormat) {
                 settings.completeDateLabelFormat = ariaUtilsEnvironmentDate.getDateFormats().longFormat;
             }
+            if (!settings.waiAriaDateFormat) {
+                settings.waiAriaDateFormat = ariaUtilsEnvironmentDate.getDateFormats().longFormat;
+            }
             if (settings.firstDayOfWeek == null) { // compare to null because 0 is a valid value
                 settings.firstDayOfWeek = ariaUtilsEnvironmentDate.getFirstDayOfWeek();
             }

--- a/src/aria/widgets/calendar/CalendarTemplate.tpl
+++ b/src/aria/widgets/calendar/CalendarTemplate.tpl
@@ -66,7 +66,7 @@
     {/macro}
 
     {macro renderMonth(month,first,last)}
-        <table class="${skin.baseCSS}month" cellspacing="0" style="width: ${settings.showWeekNumbers?138:128}px;">
+        <table class="${skin.baseCSS}month" cellspacing="0" style="width: ${settings.showWeekNumbers?138:128}px;" {if settings.waiAria}role="grid"{/if}>
             <thead>
                 <tr>
                     <th colspan="8">
@@ -82,9 +82,9 @@
                     </th>
                 </tr>
                 <tr>
-                    {if settings.showWeekNumbers}<th  class="${skin.baseCSS}weekNumber">&nbsp;</th>{/if}
+                    {if settings.showWeekNumbers}<th class="${skin.baseCSS}weekNumber">&nbsp;</th>{/if}
                     {foreach day inArray calendar.daysOfWeek}
-                        <th class="${skin.baseCSS}weekDaysLabel">${day.label}</th>
+                        <th class="${skin.baseCSS}weekDaysLabel" {if settings.waiAria}role="presentation"{/if}>${day.label}</th>
                     {/foreach}
                 </tr>
             </thead>
@@ -92,8 +92,8 @@
                 {var nbweeks=0/}
                 {foreach week inArray month.weeks}
                     {set nbweeks+=1/}
-                    <tr>
-                        {if settings.showWeekNumbers}<td class="${skin.baseCSS}weekNumber">{if week.overlappingDays == 0 || week.monthEnd == month.monthKey}${week.weekNumber}{else/}&nbsp;{/if}</td>{/if}
+                    <tr {if settings.waiAria}role="row"{/if}>
+                        {if settings.showWeekNumbers}<td class="${skin.baseCSS}weekNumber" {if settings.waiAria}role="presentation"{/if}>{if week.overlappingDays == 0 || week.monthEnd == month.monthKey}${week.weekNumber}{else/}&nbsp;{/if}</td>{/if}
                         {foreach day inArray week.days}
                             {call renderDay(day,month)/}
                         {/foreach}
@@ -113,6 +113,12 @@
         {var jsDate=day.jsDate/}
         {if day.monthKey==month.monthKey}
             <td {if day.isSelectable} data-date="${jsDate.getTime()}" {/if}
+                {if settings.waiAria}
+                    role="gridcell"
+                    {id settings.dayDomIdPrefix + jsDate.getTime()/}
+                    aria-selected="${!!day.isSelected}"
+                    aria-label="${jsDate|dateformat:settings.waiAriaDateFormat}"
+                {/if}
                 class="${getClassForDay(day)}"
             >${day.label}</td>
         {else/}

--- a/src/aria/widgets/calendar/CalendarTemplateScript.js
+++ b/src/aria/widgets/calendar/CalendarTemplateScript.js
@@ -56,6 +56,9 @@ module.exports = Aria.tplScriptDefinition({
             var weekWrapper = this.$getChild("month_" + position.month.monthKey, position.weekInMonthIndex);
             var dayWrapper = weekWrapper.getChild((this.settings.showWeekNumbers ? 1 : 0) + position.dayInWeekIndex);
             dayWrapper.classList.setClassName(this.getClassForDay(position.day));
+            if (this.settings.waiAria) {
+                dayWrapper.setAttribute("aria-selected", !!position.day.isSelected);
+            }
             dayWrapper.$dispose();
             weekWrapper.$dispose();
         },

--- a/src/aria/widgets/calendar/CfgBeans.js
+++ b/src/aria/widgets/calendar/CfgBeans.js
@@ -103,6 +103,19 @@ module.exports = Aria.beanDefinitions({
                     $description : "Specifies if today and selected day shortcuts should be displayed",
                     $default : true
                 },
+                "waiAria" : {
+                    $type : "json:Boolean",
+                    $description : "If true, accessibility-related DOM attributes are enabled, to comply with WAI-ARIA specifications. This allows screen readers and other accessibility tools to work better."
+                },
+                "waiAriaDateFormat" : {
+                    $type : "AppCfg:FormatTypes",
+                    $description : "Date pattern to be used for screen readers."
+                },
+                "dayDomIdPrefix": {
+                    $type : "json:String",
+                    $description : "Prefix to use when generating ids for days.",
+                    $default : "day"
+                },
                 "focus" : {
                     $type : "json:Boolean",
                     $description : "Is true if the calendar currently has the focus."

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -19,6 +19,7 @@ var ariaWidgetsFormDatePickerStyle = require("./DatePickerStyle.tpl.css");
 var ariaWidgetsCalendarCalendarStyle = require("../calendar/CalendarStyle.tpl.css");
 var ariaWidgetsContainerDivStyle = require("../container/DivStyle.tpl.css");
 var ariaWidgetsFormDropDownTextInput = require("./DropDownTextInput");
+var ariaUtilsString = require("../../utils/String");
 
 /**
  * DatePicker widget, which is a template-based widget.
@@ -45,7 +46,17 @@ module.exports = Aria.classDefinition({
         if (cfg.referenceDate) {
             controller.setReferenceDate(new Date(cfg.referenceDate));
         }
-        this._dropDownIconFocus = false;
+        this._calendarFocus = false;
+
+        var iconTooltip = cfg.iconTooltip ? ' title="' + ariaUtilsString.escapeForHTML(cfg.iconTooltip) + '"' : '';
+        this._iconsAttributes = {
+            // unselectable is necessary on IE so that, on mouse down, there is no blur of the active element
+            // (preventing the default action on mouse down does not help on IE)
+            "dropdown": 'unselectable="on"' + iconTooltip
+        };
+        if (cfg.waiAria) {
+            this._iconsAttributes.dropdown += ' role="button" aria-expanded="false" aria-haspopup="true"';
+        }
     },
     $destructor : function () {
         this._dropDownIcon = null;
@@ -61,18 +72,19 @@ module.exports = Aria.classDefinition({
 
         /**
          * Handle events raised by the frame
-         * @protected
          * @param {Object} evt
+         * @override
          */
         _frame_events : function (evt) {
-
-            if (evt.name === "iconFocus" && evt.iconName == "dropdown" && !this._cfg.disabled) {
-                this._dropDownIconFocus = true;
+            if (evt.iconName == "dropdown" && !this._cfg.disabled) {
+                var evtName = evt.name;
+                if (evtName == "iconMouseDown") {
+                    evt.event.preventDefault(true);
+                } else if (evtName == "iconClick") {
+                    this._toggleDropdown();
+                    evt.event.preventDefault(true);
+                }
             }
-            if (evt.name === "iconBlur" && evt.iconName == "dropdown" && !this._cfg.disabled) {
-                this._dropDownIconFocus = false;
-            }
-            this.$DropDownTextInput._frame_events.call(this, evt);
         },
 
         /**
@@ -103,7 +115,7 @@ module.exports = Aria.classDefinition({
          * @param {Number} end
          */
         setCaretPosition : function (start, end) {
-            if (this._dropDownIconFocus) {
+            if (this._calendarFocus) {
                 this._currentCaretPosition = {
                     start : start,
                     end : end
@@ -118,7 +130,7 @@ module.exports = Aria.classDefinition({
          * @return {Object} the caret position (start end end)
          */
         getCaretPosition : function () {
-            if (this._dropDownIconFocus) {
+            if (this._calendarFocus) {
                 var currentCaretPosition = this._currentCaretPosition;
                 if (currentCaretPosition) {
                     return currentCaretPosition;
@@ -137,19 +149,23 @@ module.exports = Aria.classDefinition({
          * @override
          */
         focus : function () {
+            // By default, keepFocus is false, unless it is set to true later:
+            this._keepFocus = false;
             if (this._dropdownPopup) {
-                if (this._hasFocus && !this._dropDownIconFocus) {
+                var calendarFocus = this._calendarFocus;
+
+                if (this._hasFocus && !calendarFocus) {
                     // passing the focus from the text field to the icon
                     this._keepFocus = true;
                 }
                 // override the focus method so that calling focus on the DatePicker while it is open
                 // actually focuses the dropdown icon
                 // focusing the DatePicker while the popup is open means focusing the dropdown icon
-                if (!this._dropDownIconFocus) {
-                    this._dropDownIcon.focus();
+                if (!calendarFocus) {
+                    this.controller.getCalendar().focus();
                 }
             } else {
-                if (this._hasFocus && this._dropDownIconFocus) {
+                if (this._hasFocus && this._calendarFocus) {
                     // passing the focus from the icon to the text field
                     this._keepFocus = true;
                 }
@@ -163,8 +179,26 @@ module.exports = Aria.classDefinition({
          */
         _dom_onclick : function () {
             this.$DropDownTextInput._dom_onclick.call(this);
-            if (!this._dropDownIconFocus) {
+            if (!this._calendarFocus) {
                 // clicking on the field while the popup is visible should close it
+                this._closeDropdown();
+            }
+        },
+
+        /**
+         * DOM Event raised when the focus is given to the datepicker.
+         */
+        _dom_onfocus : function () {
+            this.$DropDownTextInput._dom_onfocus.apply(this, arguments);
+            this._keepFocus = false;
+        },
+
+        /**
+         * DOM Event raised when the focus is removed from the datepicker.
+         */
+        _dom_onblur : function () {
+            this.$DropDownTextInput._dom_onblur.apply(this, arguments);
+            if (!this._keepFocus) {
                 this._closeDropdown();
             }
         },
@@ -199,11 +233,30 @@ module.exports = Aria.classDefinition({
                 tabIndex : -1,
                 label : cfg.calendarLabel,
                 defaultTemplate : cfg.calendarTemplate,
+                waiAria: cfg.waiAria,
+                waiAriaDateFormat: cfg.waiAriaDateFormat,
+                waiAriaLabel: cfg.waiAriaCalendarLabel,
                 minValue : cfg.minValue,
                 maxValue : cfg.maxValue,
                 onclick : {
                     fn : this._clickOnDate,
                     scope : this
+                },
+                onkeydown : {
+                    fn: this._calendar_onkeydown,
+                    scope : this
+                },
+                onmousedown : {
+                    fn: this._calendar_onmousedown,
+                    scope: this
+                },
+                onfocus : {
+                    fn: this._calendar_onfocus,
+                    scope: this
+                },
+                onblur : {
+                    fn: this._calendar_onblur,
+                    scope: this
                 },
                 bind : {
                     "value" : {
@@ -231,11 +284,73 @@ module.exports = Aria.classDefinition({
             calendar.writeMarkup(out);
         },
 
-        _closeDropdown : function () {
-            if (this._dropdownPopup) {
-                this.$DropDownTextInput._closeDropdown.call(this);
-                this.focus(null, true);
+        /**
+         * DOM Event raised when a key is pressed while the focus is on the calendar.
+         * @param {aria.templates.DomEventWrapper} domEvtWrapper event
+         */
+        _calendar_onkeydown: function (domEvtWrapper) {
+            if (domEvtWrapper.keyCode === 32) {
+                domEvtWrapper.charCode = 32;
             }
+            this._handleKey(domEvtWrapper);
+        },
+
+        /**
+         * DOM Event raised when the mouse button is pressed on the calendar.
+         * @param {aria.templates.DomEventWrapper} domEvtWrapper event
+         */
+        _calendar_onmousedown : function (domEvtWrapper) {
+            domEvtWrapper.preventDefault(true);
+            domEvtWrapper.target.setProperty("unselectable", "on");
+        },
+
+        /**
+         * DOM Event raised when the calendar receives focus.
+         */
+        _calendar_onfocus: function () {
+            this._calendarFocus = true;
+            this._dom_onfocus();
+        },
+
+        /**
+         * DOM Event raised when the calendar looses focus.
+         */
+        _calendar_onblur: function () {
+            this._dom_onblur();
+            this._calendarFocus = false;
+        },
+
+        /**
+         * Internal method called when the popup should be either closed or opened depending on the state of the
+         * controller and whether it is currently opened or closed. In any case, keep the focus on the field. Called by
+         * the widget button for example.
+         * @override
+         */
+        _toggleDropdown : function () {
+            // toggleDropdown should not make the virtual keyboard appear on touch devices
+            this._updateFocusNoKeyboard();
+            var report = this.controller.toggleDropdown(this.getTextInputField().value, this._dropdownPopup != null);
+            this._reactToControllerReport(report, {
+                hasFocus : true
+            });
+        },
+
+        /**
+         * Callback for the event onAfterOpen raised by the popup.
+         * @override
+         */
+        _afterDropdownOpen : function () {
+            if (this._cfg.waiAria) {
+                // it is important to set aria-owns and aria-expanded attributes before
+                // calling the parent _afterDropdownOpen method (which gives focus to
+                // the calendar)
+                var dropDownIcon = this._dropDownIcon;
+                var calendarId = this.controller.getCalendar().getCalendarDomId();
+                dropDownIcon.setAttribute("aria-owns", calendarId);
+                dropDownIcon.setAttribute("aria-activedescendant", calendarId);
+                dropDownIcon.setAttribute("aria-expanded", "true");
+            }
+            this.$DropDownTextInput._afterDropdownOpen.apply(this, arguments);
         },
 
         _refreshPopup : function () {
@@ -245,6 +360,13 @@ module.exports = Aria.classDefinition({
         },
 
         _afterDropdownClose : function () {
+            this._calendarFocus = false;
+            var dropDownIcon = this._dropDownIcon;
+            if (this._cfg.waiAria && dropDownIcon) {
+                dropDownIcon.removeAttribute("aria-owns");
+                dropDownIcon.removeAttribute("aria-activedescendant");
+                dropDownIcon.setAttribute("aria-expanded", "false");
+            }
             this.$DropDownTextInput._afterDropdownClose.call(this);
             this.controller.setCalendar(null);
         },

--- a/src/aria/widgets/form/InputWithFrame.js
+++ b/src/aria/widgets/form/InputWithFrame.js
@@ -50,6 +50,11 @@ module.exports = Aria.classDefinition({
         this._hideIconNames = null;
 
         /**
+         * Map of attributes for each icon name.
+         */
+        this._iconsAttributes = null;
+
+        /**
          * Flag for input that has to be displayed in full width
          * @type Boolean
          * @protected
@@ -120,7 +125,7 @@ module.exports = Aria.classDefinition({
                 state : this._state,
                 scrollBarX : false,
                 scrollBarY : false,
-                tooltipLabels : [cfg.iconTooltip],
+                iconsAttributes : this._iconsAttributes,
                 hideIconNames : this._hideIconNames,
                 inlineBlock : true,
                 // used for table frame, defaults to false

--- a/src/aria/widgets/frames/CfgBeans.js
+++ b/src/aria/widgets/frames/CfgBeans.js
@@ -101,6 +101,14 @@ module.exports = Aria.beanDefinitions({
                     },
                     $default : []
                 },
+                "iconsAttributes" : {
+                    $type : "json:Map",
+                    $description : "Describes, for each icon name, the attributes to set in the markup.",
+                    $contentType : {
+                        $type : "json:String"
+                    },
+                    $default : {}
+                },
                 "hideIconNames" : {
                     $type : "json:Array",
                     $description : "Array of icon names which will not be displayed. This property is taken into account only when calling aria.widgets.frames.FrameWithIcons.createFrame.",

--- a/src/aria/widgets/frames/FrameWithIcons.js
+++ b/src/aria/widgets/frames/FrameWithIcons.js
@@ -19,7 +19,7 @@ var ariaUtilsDom = require("../../utils/Dom");
 var ariaUtilsType = require("../../utils/Type");
 var ariaUtilsArray = require("../../utils/Array");
 var ariaUtilsDelegate = require("../../utils/Delegate");
-
+var ariaUtilsString = require("../../utils/String");
 
 /**
  * A frame with icons on the left and right. To create an object of this class, use the createFrame static method (not
@@ -51,6 +51,8 @@ module.exports = Aria.classDefinition({
          * @type Array
          */
         this._tooltipLabels = cfg.tooltipLabels;
+
+        this._iconsAttributes = cfg.iconsAttributes;
 
         ariaUtilsArray.forEach(this._iconsLeft, this._initIcon, this);
         ariaUtilsArray.forEach(this._iconsRight, this._initIcon, this);
@@ -85,31 +87,43 @@ module.exports = Aria.classDefinition({
         "iconClick" : {
             description : "Raised when an icon is clicked.",
             properties : {
-                "iconName" : "Name of the icon."
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
             }
         },
         "iconMouseDown" : {
             description : "Raised when the mouse is pressed on an icon.",
             properties : {
-                "iconName" : "Name of the icon."
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
             }
         },
         "iconMouseUp" : {
             description : "Raised when the mouse is released on an icon.",
             properties : {
-                "iconName" : "Name of the icon."
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
             }
         },
         "iconBlur" : {
             description : "Raised when an icon is blured.",
             properties : {
-                "iconName" : "Name of the icon."
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
             }
         },
         "iconFocus" : {
             description : "Raised when an icon is focused.",
             properties : {
-                "iconName" : "Name of the icon."
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
+            }
+        },
+        "iconKeyDown" : {
+            description : "Raised when a key is pressed while the icon has the focus.",
+            properties : {
+                "iconName" : "Name of the icon.",
+                "event" : "Event"
             }
         }
     },
@@ -193,7 +207,8 @@ module.exports = Aria.classDefinition({
         eventMap : {
             "click" : "iconClick",
             "mousedown" : "iconMouseDown",
-            "mouseup" : "iconMouseDown",
+            "mouseup" : "iconMouseUp",
+            "keydown" : "iconKeyDown",
             "blur" : "iconBlur",
             "focus" : "iconFocus"
         },
@@ -436,11 +451,12 @@ module.exports = Aria.classDefinition({
             // register for disposal
             this._icons[iconName].iconDelegateId = delegateId;
 
-            var title = icon.tooltip ? " title=\"" + icon.tooltip.replace(/\"/gi, "&quot;") + "\"" : "";
+            var title = icon.tooltip ? ' title="' + ariaUtilsString.escapeForHTML(icon.tooltip) + '"' : '';
+            var attributes = this._iconsAttributes[iconName] || 'tabIndex="-1"';
 
             out.write(['<span', Aria.testMode && this._baseId ? ' id="' + this._baseId + '_' + iconName + '"' : '',
                     ' class="', iconInfo.cssClass, '" style="', iconStyle,
-                    '" ' + utilDelegate.getMarkup(delegateId) + title + ' tabIndex="-1">&nbsp;</span>'].join(''));
+                    '" ', utilDelegate.getMarkup(delegateId), title, ' ', attributes, '>&nbsp;</span>'].join(''));
         },
 
         _linkIconToDom : function (icon, param) {
@@ -472,7 +488,8 @@ module.exports = Aria.classDefinition({
             if (eventName) {
                 this.$raiseEvent({
                     name : eventName,
-                    iconName : iconName
+                    iconName : iconName,
+                    event: event
                 });
             }
         }

--- a/test/aria/widgets/form/issue411/DatePickerTestCase.js
+++ b/test/aria/widgets/form/issue411/DatePickerTestCase.js
@@ -65,7 +65,14 @@ Aria.classDefinition({
             this.assertNotEquals(typeof(popup), "undefined", "Dropdown for the DatePicker is not opened");
             var expandButton = this.getExpandButton("dp");
             this.synEvent.click(expandButton, {
-                fn : this.openPopupDropdown,
+                fn : function () {
+                    this.waitFor({
+                        condition: function () {
+                            return !this.getWidgetDropDownPopup("dp");
+                        },
+                        callback: this.openPopupDropdown
+                    });
+                },
                 scope : this
             });
         },
@@ -76,11 +83,7 @@ Aria.classDefinition({
             this.assertEquals(widgetInstance._cfg.popupOpen, false, "Current value of popupOpen is true, where as it was expected to be false");
             this.assertEquals(typeof(popup), "undefined", "Dropdown for the DatePicker is still open where as it was expected to be closed.");
             aria.utils.Json.setValue(this.env.data, "popupOpenDP", true);
-            aria.core.Timer.addCallback({
-                fn : this.assertPopup1,
-                scope : this,
-                delay : 500
-            });
+            this.waitForDropDownPopup("dp", this.assertPopup1);
         },
 
         assertPopup1 : function () {

--- a/test/aria/widgets/wai/WaiTestSuite.js
+++ b/test/aria/widgets/wai/WaiTestSuite.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.widgets.wai.autoComplete.WaiAutoCompleteTestSuite");
+        this.addTests("test.aria.widgets.wai.datePicker.DatePickerTest");
         this.addTests("test.aria.widgets.wai.textInputBased.WaiTextInputBasedTestSuite");
         this.addTests("test.aria.widgets.wai.input.WaiInputTestSuite");
         this.addTests("test.aria.widgets.wai.popup.WaiPopupTestSuite");

--- a/test/aria/widgets/wai/datePicker/DatePickerTest.js
+++ b/test/aria/widgets/wai/datePicker/DatePickerTest.js
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var ariaUtilsDom = require("ariatemplates/utils/Dom");
+var ariaUtilsString = require("ariatemplates/utils/String");
+
+var isAccessibilityAttribute = function (attributeName) {
+    return (attributeName === "role") || (attributeName.substr(0, 5) === "aria-");
+};
+
+var findAccessibilityAttributes = function (domElt, recursive, array) {
+    var results = array || [];
+    var attributes = domElt.attributes;
+    if (attributes) {
+        for (var i = attributes.length - 1; i >= 0; i--) {
+            var attribute = attributes[i];
+            if (isAccessibilityAttribute(attribute.name)) {
+                results.push({
+                    name: attribute.name,
+                    value: attribute.value,
+                    ownerElement: domElt
+                });
+            }
+        }
+    }
+    if (recursive && domElt.childNodes) {
+        var childNodes = domElt.childNodes;
+        for (var i = 0, l = childNodes.length; i < l; i++) {
+            findAccessibilityAttributes(childNodes[i], true, results);
+        }
+    }
+    return results;
+};
+
+
+var findAttribute = function  (attributes, name, value) {
+    var result = [];
+    for (var i = 0, l = attributes.length; i < l; i++) {
+        var curAttribute = attributes[i];
+        if (curAttribute.name === name && curAttribute.value === value) {
+            result.push(curAttribute);
+        }
+    }
+    return result;
+};
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.datePicker.DatePickerTest",
+    $extends : require("ariatemplates/jsunit/RobotTestCase"),
+    $prototype: {
+        runTemplateTest : function () {
+            var tpl = this.templateCtxt._tpl;
+            tpl.$json.setValue(tpl.data, "dpWaiDisabledValue", new Date(2012, 11, 12));
+            tpl.$json.setValue(tpl.data, "dpWaiEnabledValue", new Date(2012, 11, 12));
+
+            function checkNoAttribute (attributes) {
+                this.assertEquals(attributes.length, 0);
+            }
+
+            function step0() {
+                this.runScenario("dpWaiDisabled", {
+                    beforeOpen: checkNoAttribute,
+                    afterOpen: checkNoAttribute,
+                    afterDownKey: checkNoAttribute,
+                    afterEnterKey: checkNoAttribute
+                }, step1);
+            }
+
+            function step1() {
+                this.runScenario("dpWaiEnabled", {
+                    beforeOpen: function (attributes, widgetInstance) {
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-haspopup"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-expanded"), "false");
+                        this.assertTrue(! this.getExpandButton("dpWaiEnabled").getAttribute("aria-owns"));
+                    },
+                    afterOpen: function (attributes, widgetInstance) {
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-haspopup"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-expanded"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-owns"), widgetInstance.controller.getCalendar().getDom().id);
+                        this.assertSelectedAttributeHasLabel(attributes, "Wednesday 12 December 2012");
+                        this.assertEquals(this.testDocument.activeElement.getAttribute("aria-label").indexOf("Calendar table. Use arrow keys to navigate and space to validate."), 0);
+                    },
+                    afterDownKey: function (attributes, widgetInstance) {
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-haspopup"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-expanded"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-owns"), widgetInstance.controller.getCalendar().getDom().id);
+                        this.assertSelectedAttributeHasLabel(attributes, "Wednesday 19 December 2012");
+                        this.assertEquals(this.testDocument.activeElement.getAttribute("aria-label"), "Calendar table. Use arrow keys to navigate and space to validate.");
+                    },
+                    afterEnterKey: function (attributes, widgetInstance) {
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-haspopup"), "true");
+                        this.assertEquals(this.getExpandButton("dpWaiEnabled").getAttribute("aria-expanded"), "false");
+                        this.assertTrue(! this.getExpandButton("dpWaiEnabled").getAttribute("aria-owns"));
+                    }
+                }, this.end);
+            }
+
+            step0.call(this);
+        },
+
+        runScenario : function (datePickerId, checkFns, cb) {
+            var widgetInstance = this.getWidgetInstance(datePickerId);
+            function step0() {
+                checkFns.beforeOpen.call(this, this.getWidgetAccessibilityAttributes(datePickerId), widgetInstance);
+                this.synEvent.click(this.getExpandButton(datePickerId), {
+                    scope: this,
+                    fn: function () {
+                        this.waitForDropDownPopup(datePickerId, step1);
+                    }
+                });
+            }
+
+            function step1() {
+                checkFns.afterOpen.call(this, this.getWidgetAccessibilityAttributes(datePickerId), widgetInstance);
+                this.synEvent.type(null, "[down]", {
+                    scope: this,
+                    fn : function () {
+                        this.waitFor({
+                            condition: function () {
+                                return widgetInstance.controller.getDataModel().calendarValue.getDate() == 19;
+                            },
+                            callback: step2
+                        });
+                    }
+                });
+            }
+
+            function step2() {
+                checkFns.afterDownKey.call(this, this.getWidgetAccessibilityAttributes(datePickerId), widgetInstance);
+                this.synEvent.type(null, "[enter]", {
+                    scope: this,
+                    fn : function () {
+                        this.waitFor({
+                            condition: function () {
+                                return !this.getWidgetDropDownPopup(datePickerId);
+                            },
+                            callback: step3
+                        });
+                    }
+                });
+            }
+
+            function step3() {
+                checkFns.afterEnterKey.call(this, this.getWidgetAccessibilityAttributes(datePickerId), widgetInstance);
+                this.assertEquals(widgetInstance.getTextInputField().value, "19/12/12");
+                var dateInModel = widgetInstance._cfg.bind.value.inside[widgetInstance._cfg.bind.value.to];
+                this.assertEquals(dateInModel.getDate(), 19);
+                this.assertEquals(dateInModel.getMonth(), 11);
+                this.assertEquals(dateInModel.getFullYear(), 2012);
+                this.$callback(cb);
+            }
+
+            step0.call(this);
+        },
+
+        assertSelectedAttributeHasLabel: function (attributes, expectedLabel) {
+            var selected = findAttribute(attributes, "aria-selected", "true");
+            this.assertEquals(selected.length, 1);
+            this.assertEquals(selected[0].ownerElement.getAttribute("aria-label"), expectedLabel);
+            var focusedElement = this.testDocument.activeElement;
+            var activeDescendant = focusedElement.getAttribute("aria-activedescendant");
+            if (activeDescendant) {
+                focusedElement = ariaUtilsDom.getElementById(activeDescendant) || focusedElement;
+            }
+            this.assertTrue(ariaUtilsString.endsWith(focusedElement.getAttribute("aria-label"), expectedLabel));
+        },
+
+        getWidgetAccessibilityAttributes : function (id) {
+            var results = [];
+            var widgetInstance = this.getWidgetInstance(id);
+            findAccessibilityAttributes(widgetInstance.getDom(), true, results);
+            var popup = widgetInstance._dropdownPopup;
+            if (popup) {
+                findAccessibilityAttributes(popup.domElement, true, results);
+            }
+            return results;
+        }
+    }
+});

--- a/test/aria/widgets/wai/datePicker/DatePickerTestTpl.tpl
+++ b/test/aria/widgets/wai/datePicker/DatePickerTestTpl.tpl
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.datePicker.DatePickerTestTpl"
+}}
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-weight:bold;">DatePicker accessibility sample</div>
+        <div style="margin:10px;">
+            With accessibility enabled: <br><br>
+            {call datePicker("dpWaiEnabled", true) /}<br>
+            With accessibility disabled: <br><br>
+            {call datePicker("dpWaiDisabled", false) /}<br>
+        </div>
+    {/macro}
+
+    {macro datePicker(id, waiAria)}
+        <label>Previous field <input></label> <br><br>
+        {@aria:DatePicker {
+            id: id,
+            label: "Travel date",
+            iconTooltip: "Display calendar",
+            waiAria: waiAria,
+            waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
+            waiAriaDateFormat: "EEEE d MMMM yyyy",
+            bind: {
+                value: {
+                    to: id + "Value",
+                    inside: data
+                }
+            }
+        }/} <br><br>
+        <label>Next field <input></label> <br><br>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR adds accessibility attributes on the DatePicker DOM elements (`role`, `aria-activedescendant`, `aria-selected`, `aria-haspopup`, `aria-expanded`, `aria-label`...) when the `waiAria` widget property is `true`.
Also, no matter what the value of `waiAria` is, the browser focus is now always on the Calendar DOM element when the popup is open, instead of being on the dropdown button.