### PR TITLE
fix #1566 alphabetic characters are not accepted as valid entries

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -122,7 +122,7 @@ var parseNextSteps = function(state, options) {
     datetime = currentState.datetime;
 
     var matches = nextPatternRegexp.exec(state.pattern);
-    //debugger;
+
     if (matches) {
         var fullPattern = matches[1];
         var patternType = fullPattern.substr(0, 1);
@@ -492,6 +492,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             scope : this
         });
 
+        this._validateEntry = /^(?:(?![a-z])\d\s?[\\h;m,.\-:\/\s]?\s?\d?\s?(am|pm|a\.m|p\.m|a\sm|p\sm|a.m.|p.m.|a. m|p. m|a .m|p .m|a . m|p . m)?\s?)+$/;
     },
     $destructor : function () {
         this._formatCache = null;
@@ -558,8 +559,8 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
 
             entry = entryStr;
 
-            // need to check for at least one digit at the beginning of the string
-            if (!this._isValidTime(entry)) {
+            // need to check for alphabetic characters
+            if (!this._validateEntry.test(entry)) {
                 return null;
             }
 
@@ -775,12 +776,8 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             var characterCheck1 = time.charAt(0);
             var characterCheck2 = time.charAt(1);
 
-            // where the first two digits are 24 need to set the hour to 00
             if (characterCheck1 === '2' && characterCheck2 === '4') {
-                hours[0] = 0; // value to be used for hours
-                hours[1] = 2; // number of digits for hours in entry
-                // string
-                return hours;
+                return null;
             }
 
             // where there is a second digit and (the first digit is 2 the

--- a/test/aria/utils/Time.js
+++ b/test/aria/utils/Time.js
@@ -60,17 +60,7 @@ Aria.classDefinition({
             var timeReturn = "8h9m-;67\\,.45/:0123";
             this.assertEquals(aria.utils.Date._removeUnwantedCharacters(time), timeReturn);
         },
-
-        /**
-         * TestCase5 Calculate hours from string.
-         */
-        test_calculateHours : function () {
-            var time = "24";
-            var timeReturn = 0;
-            var test = aria.utils.Date._calculateHours(time);
-            this.assertEquals(test[0], timeReturn);
-        },
-
+        
         /**
          * TestCase6 Calculate minutes or seconds from string.
          */
@@ -142,10 +132,10 @@ Aria.classDefinition({
          */
         test_interpretTime : function () {
             var ariaTimeUtil = aria.utils.Date;
-            var useCases = ["22:4p:1", "99", "9p", "9h00", "9:9", "11:09   p", "9 9", "9/2", "9;2", "9-2", "9:9",
+            var useCases = ["99", "9h00", "9:9", "9 9", "9/2", "9;2", "9-2", "9:9",
                     "09:9", "0909", "9h09", "9h9", "09h9", "9.51", "9.51pm", "9,5pm"];
 
-            var checker = ["22:04:01", "09:09:00", "21:00:00", "09:00:00", "09:09:00", "23:09:00", "09:09:00",
+            var checker = ["09:09:00", "09:00:00", "09:09:00", "09:09:00",
                     "09:02:00", "09:02:00", "09:02:00", "09:09:00", "09:09:00", "09:09:00", "09:09:00", "09:09:00",
                     "09:09:00", "09:51:00", "21:51:00", "21:05:00"];
 
@@ -165,7 +155,7 @@ Aria.classDefinition({
         testInterpretTime : function (text) {
 
             var ariaDateUtil = aria.utils.Date;
-
+            
             var interpretedDate = ariaDateUtil.interpretTime('25:01');
             // should be rejected
             this.assertTrue(interpretedDate === null);
@@ -252,3 +242,4 @@ Aria.classDefinition({
 
     }
 });
+

--- a/test/aria/widgets/form/timefield/checkValue/TimeField.js
+++ b/test/aria/widgets/form/timefield/checkValue/TimeField.js
@@ -19,16 +19,112 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
         this.data = {
-            time1 : null,
-            time2 : null
-
+            time1 : null
         };
+        this.currentValue;
+        this.testValues = [];
+        this.expectedValues = [];
+        this.separators = ["/", "\\", "h", ";", ",", ".", "-", ":"];
+        this.am = ["am", "a.m.", "a m"];
+        this.pm = ["pm", "p.m.", "p m"];
+        this.start();
         this.setTestEnv({
             data : this.data
         });
     },
     $prototype : {
+        start : function () {
+            this.check1Digit();
+            this.check2Digits();
+            this.check3Digits();
+            this.check4Digits();
+            this.checkAlphabetic();
+            this.checkValuesWithAMPM();
+        },
+        check1Digit : function () {
+            var hour, result, i;
+
+            // 1 digit = [h]
+            for (i = 0; i < 10; i++) {
+                hour = i + '';
+                result = '0' + i + ':00';
+                this.testValues.push(hour);
+                this.expectedValues.push(result);
+            }
+        },
+        check2Digits : function () {
+            var hour, result, i;
+
+            // 2 digits = [h][h] (works with any of the separators after the first digit only)
+            for (i = 24; i > 22; i--) {
+                hour = i + '';
+                result = i !== 24 ? hour + ':00' : hour;
+                this.testValues.push(hour);
+                this.expectedValues.push(result);
+            }
+        },
+        check3Digits : function () {
+            var hour, result;
+            // 3 digits = [h][h][m] (works with any of the separators after the first/second digit only)
+            hour = '150';
+            result = '15:00';
+            this.testValues.push(hour);
+            this.expectedValues.push(result);
+        },
+        check4Digits : function () {
+            // 4 digits = [h][h]:[m][m] (works with any of the separators after the second digit only)
+            var value = "0000";
+            var result = "00:00";
+            this.testValues.push(value);
+            this.expectedValues.push(result);
+        },
+        checkAlphabetic : function () {
+            // alphabetic characters are invalid
+            this.testValues.push("12b", "b12", "1xx1", "xx");
+            this.expectedValues.push("12b", "b12", "1xx1", "xx");
+
+        },
+        checkValuesWithAMPM : function () {
+            var valid = 1;
+            for (var items = 0; items < this.am.length; items++) {
+                // valid AM
+                this.testValues.push(valid + this.am[items]);
+                this.expectedValues.push("01:00");
+
+                // valid PM
+                this.testValues.push(valid + this.pm[items]);
+                this.expectedValues.push("13:00");
+            }
+        },
+        checkValuesWithSeparator : function (value) {
+            for (var s = 0; s < this.separators.length; s++) {
+                if (value.length === 2) {
+                    // separator between digits 1 and 2
+                    this.testValues.push(value.charAt(0) + this.separators[s] + value.charAt(1));
+                    this.expectedValues.push('0' + value.charAt(0) + ':0' + value.charAt(1));
+                }
+
+                if (value.length === 3) {
+                    // separator between digits 1 and 2
+                    this.testValues.push(value.charAt(0) + this.separators[s] + value.charAt(1) + value.charAt(2));
+                    this.expectedValues.push('0' + value.charAt(0) + ':' + value.charAt(1) + value.charAt(2));
+
+                    // separator between digits 2 and 3
+                    this.testValues.push(value.charAt(0) + value.charAt(1) + this.separators[s] + value.charAt(2));
+                    this.expectedValues.push(value.charAt(0) + value.charAt(1) + ':0' + value.charAt(2));
+                }
+
+                if (value.length === 4) {
+                    // separator between digits 2 and 3
+                    this.testValues.push(value.charAt(0) + value.charAt(1) + this.separators[s] + value.charAt(2) + value.charAt(3));
+                    this.expectedValues.push(value.charAt(0) + value.charAt(1) + ':' + value.charAt(2) + value.charAt(3));
+                }
+            }
+        },
         runTemplateTest : function () {
+            this.onStart();
+        },
+        onStart : function () {
             this.synEvent.click(this.getInputField("tf1"), {
                 fn : function () {
                     this.waitForWidgetFocus("tf1", this.onFieldFocused);
@@ -38,20 +134,24 @@ Aria.classDefinition({
         },
         onFieldFocused : function () {
             var myField = this.getInputField("tf1");
-            this.synEvent.type(myField, "12:00am", {
+            this.currentValue = this.testValues.shift();
+            this.synEvent.type(myField, this.currentValue, {
                 fn : this.changeFocus,
                 scope : this
             });
         },
         changeFocus : function () {
             var myField = this.getInputField("tf1");
-
             myField.blur();
             this.waitForWidgetBlur("tf1", function () {
-                this.assertTrue(myField.value === "00:00", "'00:00' was expected in the timefield.");
-                this.notifyTemplateTestEnd();
+                var expectedValue = this.expectedValues.shift();
+                this.assertTrue(myField.value === expectedValue, "After typing '" + this.currentValue + "', the display value '" + expectedValue + "' was expected in the timefield and instead the timefield displays '" + myField.value + "'");
+                if (this.testValues.length) {
+                    this.onStart();
+                } else {
+                    this.notifyTemplateTestEnd();
+                }
             });
         }
     }
-
 });

--- a/test/aria/widgets/form/timefield/checkValue/TimeFieldTpl.tpl
+++ b/test/aria/widgets/form/timefield/checkValue/TimeFieldTpl.tpl
@@ -31,6 +31,7 @@
                 labelAlign:"right",
                 width:250,
                 block:true,
+                autoselect:true,
                 pattern:aria.utils.environment.Date.getTimeFormats().shortFormat,
                 bind:{
                     "value":{


### PR DESCRIPTION
Previously there were cases where some alphabetic characters were accepted as valid entries and subsequently transformed into valid times, now all alphabetic characters are illegal unless they are one of the following special cases:

- a m
- p m
- h
- m