### PR TITLE
span elements made focusable by Firefox when `overflow-y:hidden` is used alone

### DIFF
--- a/src/aria/widgets/frames/FixedHeightFrame.js
+++ b/src/aria/widgets/frames/FixedHeightFrame.js
@@ -99,9 +99,7 @@ var ariaWidgetsFramesFrame = require("./Frame");
                     className : 'xFrameContent ' + cssPrefix + 'c ' + cfg.cssClass
                 };
 
-                this._appendInnerWidthInfo(sizeInfo);
-                // added in PTR 05170822 to avoid the internal scrollbar for widget content
-                this._appendInnerHeightInfo(sizeInfo);
+                this._appendInnerSizeInfo(sizeInfo);
 
                 out.write(['<span class="xFixedHeightFrame_w ', cssPrefix, 'w">'].join(''));
                 var hasBorder = this._hasBorder(this._cfg.stateObject.skipLeftBorder, this._cfg.iconsLeft);
@@ -155,9 +153,7 @@ var ariaWidgetsFramesFrame = require("./Frame");
                 var sizeInfo = {
                     className : ['xFrameContent ', cssPrefix, 'c ', cfg.cssClass].join("")
                 };
-                this._appendInnerWidthInfo(sizeInfo);
-                // added in PTR 05170822 to avoid the internal scrollbar for widget content
-                this._appendInnerHeightInfo(sizeInfo);
+                this._appendInnerSizeInfo(sizeInfo);
                 curSpan.style.width = sizeInfo.width;
                 curSpan.style.height = sizeInfo.height;
                 curSpan.className = sizeInfo.className;

--- a/src/aria/widgets/frames/Frame.js
+++ b/src/aria/widgets/frames/Frame.js
@@ -176,14 +176,15 @@ module.exports = Aria.classDefinition({
 
         /**
          * Method intended to be used by classes which extend this class. It reads the frame configuration (this._cfg),
-         * the inner width (this.innerWidth) and appends width info (actual width and also CSS classes for
-         * scrollbars...) to the obj parameter, so that it is easier for each frame to set this in the DOM (both at
-         * markup generation time and when updating the state of the frame).
+         * the inner dimensions (this.innerWidth and this.innerHeight) and appends size info (actual width and height
+         * and also CSS classes for scrollbars...) to the obj parameter, so that it is easier for each frame to set
+         * this in the DOM (both at markup generation time and when updating the state of the frame).
          * @param {Object} obj object with style and className properties. This method sets the width property on this
          * object (e.g. "100px"), and appends to the className property the CSS classes (e.g. " xOverflowXAuto").
          * Moreover, if the style property is not null, the width is appended to it (e.g. "width:100px;").
          */
-        _appendInnerWidthInfo : function (obj) {
+        _appendInnerSizeInfo : function (obj) {
+            var overflowX = null, overflowY = null;
             if (this.innerWidth > -1) {
                 obj.width = this.innerWidth + "px";
                 if (obj.style != null) {
@@ -193,42 +194,35 @@ module.exports = Aria.classDefinition({
                 obj.width = "";
             }
             if (this.innerWidth > -1 || this._cfg.fullWidth) {
-                if (this._cfg.scrollBarX) {
-                    obj.className += " xOverflowXAuto";
-                } else {
-                    obj.className += " xOverflowXHidden";
-                }
+                overflowX = this._cfg.scrollBarX ? "Auto" : "Hidden";
                 if (this._cfg.printOptions == "adaptX" || this._cfg.printOptions == "adaptXY") {
                     obj.className += " xPrintAdaptX";
                 }
             }
-        },
-
-        /**
-         * Method intended to be used by classes which extend this class. It reads the frame configuration (this._cfg),
-         * the inner height (this.innerHeight) and appends height info (actual height and also CSS classes for
-         * scrollbars...) to the obj parameter, so that it is easier for each frame to set this in the DOM (both at
-         * markup generation time and when updating the state of the frame).
-         * @param {Object} obj object with style and className properties. This method sets the height property on this
-         * object (e.g. "100px"), and appends to the className property the CSS classes (e.g. " xOverflowYAuto").
-         * Moreover, if the style property is not null, the height is appended to it (e.g. "height:100px;").
-         */
-        _appendInnerHeightInfo : function (obj) {
             if (this.innerHeight > -1) {
                 var height = obj.height = this.innerHeight + "px";
                 if (obj.style != null) {
                     obj.style += "height:" + height + ";";
                 }
-                if (this._cfg.scrollBarY) {
-                    obj.className += " xOverflowYAuto";
-                } else {
-                    obj.className += " xOverflowYHidden";
-                }
+                overflowY = this._cfg.scrollBarY ? "Auto" : "Hidden";
                 if (this._cfg.printOptions == "adaptY" || this._cfg.printOptions == "adaptXY") {
                     obj.className += " xPrintAdaptY";
                 }
             } else {
                 obj.height = "";
+            }
+            var overflowValue = overflowX || overflowY;
+            if (overflowValue) {
+                // Specifying only overflow-x or only overflow-y makes Firefox behave strangely
+                // (especially: it makes the corresponding element focusable)
+                // Here we make sure both values are always specified:
+                if (overflowX === overflowY || !overflowX || !overflowY) {
+                    // when both values are the same or one is missing, use the value for both X and Y without distinction:
+                    obj.className += " xOverflow" + overflowValue;
+                } else {
+                    // When both values are specified, use them as they are:
+                    obj.className += " xOverflowX" + overflowX + " xOverflowY" + overflowY;
+                }
             }
         }
     }

--- a/src/aria/widgets/frames/SimpleFrame.js
+++ b/src/aria/widgets/frames/SimpleFrame.js
@@ -87,8 +87,7 @@ module.exports = Aria.classDefinition({
                 sizeInfo.style += "line-height: " + this.innerHeight + "px;";
             }
 
-            this._appendInnerWidthInfo(sizeInfo);
-            this._appendInnerHeightInfo(sizeInfo);
+            this._appendInnerSizeInfo(sizeInfo);
             if (!this._hasBorder(state.skipLeftBorder, cfg.iconsLeft)) {
                 sizeInfo.style = sizeInfo.style
                         + 'border-left:0px;border-top-left-radius:0px;border-bottom-left-radius:0px;';
@@ -155,8 +154,7 @@ module.exports = Aria.classDefinition({
             var sizeInfo = {
                 className : "xSimpleFrame " + this._cssPrefix + "frame " + this._cfg.cssClass
             };
-            this._appendInnerWidthInfo(sizeInfo);
-            this._appendInnerHeightInfo(sizeInfo);
+            this._appendInnerSizeInfo(sizeInfo);
             domElt.style.width = sizeInfo.width;
             domElt.style.height = sizeInfo.height;
             if (this._verticalAlignApplied) {

--- a/src/aria/widgets/frames/TableFrame.js
+++ b/src/aria/widgets/frames/TableFrame.js
@@ -105,8 +105,7 @@ module.exports = Aria.classDefinition({
                  */
                 className : 'xFrameContent ' + cssPrefix + 'c ' + cfg.cssClass
             };
-            this._appendInnerWidthInfo(sizeInfo);
-            this._appendInnerHeightInfo(sizeInfo);
+            this._appendInnerSizeInfo(sizeInfo);
             var displayInline = "";
 
             if (this._inlineBlock) {
@@ -252,8 +251,7 @@ module.exports = Aria.classDefinition({
             var sizeInfo = {
                 className : 'xFrameContent ' + cssPrefix + 'c ' + cfg.cssClass
             };
-            this._appendInnerWidthInfo(sizeInfo);
-            this._appendInnerHeightInfo(sizeInfo);
+            this._appendInnerSizeInfo(sizeInfo);
             this._childRootElt.style.width = sizeInfo.width;
             this._childRootElt.style.height = sizeInfo.height;
             this._childRootElt.className = sizeInfo.className;

--- a/test/aria/widgets/form/FormTestSuite.js
+++ b/test/aria/widgets/form/FormTestSuite.js
@@ -35,6 +35,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.form.textinput.TextInputTestSuite");
         this.addTests("test.aria.widgets.form.issue411.DropdownTestSuite");
         this.addTests("test.aria.widgets.form.issue599.LabelColorTestCase");
+        this.addTests("test.aria.widgets.form.issue1569.FocusableSpanIssue");
         this.addTests("test.aria.widgets.form.autocomplete.AutoCompleteTestSuite");
         this.addTests("test.aria.widgets.form.multiautocomplete.MultiAutoCompleteTestSuite");
         this.addTests("test.aria.widgets.form.selectbox.SelectboxTestSuite");

--- a/test/aria/widgets/form/issue1569/FocusableSpanIssue.js
+++ b/test/aria/widgets/form/issue1569/FocusableSpanIssue.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.issue1569.FocusableSpanIssue",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.widgets.AriaSkinNormalization"],
+    $prototype : {
+
+        createSimpleFrameTextInput : function () {
+            var widgetSkin = aria.widgets.AriaSkin.skinObject["TextInput"];
+            delete widgetSkin["aria:skinNormalized"];
+            widgetSkin.simpleframe = {
+                frame: {
+                    frameType: "Simple"
+                }
+            };
+            aria.widgets.AriaSkinNormalization.normalizeWidget("TextInput", widgetSkin);
+        },
+
+        setUp : function () {
+            this.createSimpleFrameTextInput();
+        },
+
+        runTemplateTest : function () {
+            var startInput = this.getElementById("start");
+            var textfield1 = this.getInputField("textfield1");
+            var textfield2 = this.getInputField("textfield2");
+            var textfield3 = this.getInputField("textfield3");
+            var button = this.getWidgetInstance("button");
+            var textarea = this.getInputField("textarea");
+            var endInput = this.getElementById("end");
+            button.getDom();
+            this.synEvent.execute([
+                ["click", startInput],
+                ["waitFocus", startInput],
+                ["type", null, "\t"],
+                ["waitFocus", textfield1],
+                ["type", null, "\t"],
+                ["waitFocus", textfield2],
+                ["type", null, "\t"],
+                ["waitFocus", textfield3],
+                ["type", null, "\t"],
+                ["waitFocus", button._focusElt],
+                ["type", null, "\t"],
+                ["waitFocus", textarea],
+                ["type", null, "\t"],
+                ["waitFocus", endInput]
+            ], {
+                scope: this,
+                fn: this.end
+            });
+        }
+    }
+});

--- a/test/aria/widgets/form/issue1569/FocusableSpanIssueTpl.tpl
+++ b/test/aria/widgets/form/issue1569/FocusableSpanIssueTpl.tpl
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "test.aria.widgets.form.issue1569.FocusableSpanIssueTpl"
+}}
+
+    {macro main()}
+        <div style="margin: 10px;">
+            <input {id "start"/}><br><br>
+            {@aria:TextField {
+                id: "textfield1",
+                label: "Text field"
+            }/}<br><br>
+            {@aria:TextField {
+                id: "textfield2",
+                sclass: "simple",
+                label: "Text field"
+            }/}<br><br>
+            {@aria:TextField {
+                id: "textfield3",
+                sclass: "simpleframe",
+                label: "Text field"
+            }/}<br><br>
+            {@aria:Button {
+                id: "button",
+                label: "Button"
+            }/}<br><br>
+            {@aria:Textarea {
+                id: "textarea",
+                label: "Textarea"
+            }/}<br><br>
+            <input {id "end"/}>
+        </div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR makes sure we always specify both `overflow-x` and `overflow-y` (or none of them) so that Firefox does not make the corresponding &lt;span&gt; element focusable when it is not supposed to be focusable.