### PR TITLE
Fix regressions caused by the dynamic zIndex popup management feature

### DIFF
--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -135,6 +135,11 @@ module.exports = Aria.beanDefinitions({
                     $description : "When the popup is being opened, the animation is applied",
                     $sample : "slide left"
                 },
+                "zIndexKeepOpenOrder" : {
+                    $type : "json:Boolean",
+                    $description : "If true, this popup must always be kept in front of any popup that was opened before.",
+                    $default : true
+                },
                 "popupContainer" : {
                     $type : "json:ObjectRef",
                     $description : "[Optional] Object implementing the IPopupContainer interface, which defines in which container the popup will be added. By default, the aria.popups.container.Viewport singleton is used and the popup is a direct child of document.body."

--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -21,7 +21,6 @@ var ariaTemplatesNavigationManager = require("../templates/NavigationManager");
 var ariaUtilsAriaWindow = require("../utils/AriaWindow");
 var ariaCoreBrowser = require("../core/Browser");
 var ariaCoreTimer = require("../core/Timer");
-var ariaUtilsDelegate = require("../utils/Delegate");
 
 (function () {
 
@@ -374,13 +373,62 @@ var ariaUtilsDelegate = require("../utils/Delegate");
             },
 
             /**
+             * Returns the popup with the highest zIndex.
+             */
+            getTopPopup : function () {
+                var openedPopups = this.openedPopups;
+                var topPopup = null;
+                if (openedPopups.length > 0) {
+                    topPopup = openedPopups[openedPopups.length - 1];
+                    var topZIndex = topPopup.getZIndex();
+                    for (var i = openedPopups.length - 2; i >= 0; i--) {
+                        var curPopup = openedPopups[i];
+                        var curZIndex = curPopup.getZIndex();
+                        if (curZIndex > topZIndex) {
+                            topPopup = curPopup;
+                            topZIndex = curZIndex;
+                        }
+                    }
+                }
+                return topPopup;
+            },
+
+            /**
              * Bring the given popup to the front, changing its zIndex, if it is necessary.
              * @param {aria.popups.Popup} popup popup whose zIndex is to be changed
              */
             bringToFront : function (popup) {
                 var curZIndex = popup.getZIndex();
-                if (curZIndex !== this.currentZIndex) {
-                    popup.setZIndex(this.getZIndexForPopup(popup));
+                var newBaseZIndex = this.currentZIndex;
+                if (curZIndex === newBaseZIndex) {
+                    // already top most, nothing to do in any case!
+                    return;
+                }
+                // gets all popups supposed to be in front of this one, including this one
+                var openedPopups = this.openedPopups;
+                var popupsToKeepInFront = [];
+                var i, l;
+                for (i = openedPopups.length - 1; i >= 0; i--) {
+                    var curPopup = openedPopups[i];
+                    if (curPopup === popup || curPopup.conf.zIndexKeepOpenOrder) {
+                        popupsToKeepInFront.unshift(curPopup);
+                        if (curPopup.getZIndex() === newBaseZIndex) {
+                            newBaseZIndex -= 10;
+                        }
+                        if (curPopup === popup) {
+                            break;
+                        }
+                    }
+                }
+                if (i < 0 || newBaseZIndex + 10 === curZIndex) {
+                    // either the popup is not in openedPopups (i < 0)
+                    // or it is already correctly positioned (newBaseZIndex + 10 === curZIndex)
+                    return;
+                }
+                this.currentZIndex = newBaseZIndex;
+                for (i = 0, l = popupsToKeepInFront.length; i < l; i++) {
+                    var curPopup = popupsToKeepInFront[i];
+                    curPopup.setZIndex(this.getZIndexForPopup(curPopup));
                 }
             },
 
@@ -503,7 +551,7 @@ var ariaUtilsDelegate = require("../utils/Delegate");
             },
 
             /**
-             * Manager handler when a popup is open. Unregister the popup as opened, unregister global events if needed.
+             * Manager handler when a popup is closed. Unregister the popup as opened, unregister global events if needed.
              * @param {aria.popups.Popup} popup
              */
             onPopupClose : function (popup) {
@@ -519,19 +567,24 @@ var ariaUtilsDelegate = require("../utils/Delegate");
                 if (utilsArray.isEmpty(openedPopups)) {
                     this.disconnectEvents();
                 }
+                var curZIndex = popup.getZIndex();
+                if (curZIndex === this.currentZIndex) {
+                    this.currentZIndex -= 10;
+                }
 
                 this.$raiseEvent({
                     name : "popupClose",
                     popup : popup
                 });
 
-                var topPopup = openedPopups.length > 0 ? openedPopups[openedPopups.length - 1] : null;
+                var topPopup = this.getTopPopup();
 
                 // the timeout waits for a possible focus change after the mousedown event that possibly triggered this
                 // method
                 setTimeout(function () {
-                    var focusedEl = ariaUtilsDelegate.getFocus();
-                    if (topPopup && !utilsDom.isAncestor(focusedEl, topPopup.domElement)) {
+                    var document = Aria.$window.document;
+                    var focusedEl = document.activeElement;
+                    if (topPopup && (!focusedEl || focusedEl === document.body)) {
                         ariaTemplatesNavigationManager.focusFirst(topPopup.domElement);
                     }
                 }, 1);

--- a/src/aria/touch/widgets/Popup.js
+++ b/src/aria/touch/widgets/Popup.js
@@ -212,6 +212,7 @@ module.exports = Aria.classDefinition({
                 offset : cfg.offset,
                 ignoreClicksOn : cfg.ignoreClicksOn,
                 parentDialog : cfg.parentDialog,
+                zIndexKeepOpenOrder : cfg.zIndexKeepOpenOrder,
                 preferredWidth : cfg.preferredWidth,
                 animateOut : cfg.animateOut,
                 animateIn : cfg.animateIn

--- a/src/aria/touch/widgets/PopupCfgBeans.js
+++ b/src/aria/touch/widgets/PopupCfgBeans.js
@@ -135,6 +135,11 @@ module.exports = Aria.beanDefinitions({
                     $description : "[Optional] The dialog the popup belongs to",
                     $default : null
                 },
+                "zIndexKeepOpenOrder" : {
+                    $type : "json:Boolean",
+                    $description : "If true, this popup must always be kept in front of any popup that was opened before.",
+                    $default : true
+                },
                 "preferredWidth" : {
                     $type : "json:Integer",
                     $description : "Width of the popup in px - if negative, the width is computed dynamically depending on the content.",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -578,6 +578,7 @@ module.exports = Aria.classDefinition({
                 closeOnMouseClick : cfg.closeOnMouseClick,
                 closeOnMouseScroll : false,
                 parentDialog : this,
+                zIndexKeepOpenOrder : false, // allows to re-order dialogs (dynamic z-index)
                 role: isModal ? "dialog" : null,
                 waiAria: cfg.waiAria
             });

--- a/test/aria/widgets/container/dialog/dynamicZIndex/BaseDynamicZIndexTestCase.js
+++ b/test/aria/widgets/container/dialog/dynamicZIndex/BaseDynamicZIndexTestCase.js
@@ -59,7 +59,7 @@ Aria.classDefinition({
             };
             this.incrementPopup(counts, 124, 223); // 1, 2 or 3
             this.incrementPopup(counts, 124, 115); // 1 or 2
-            this.incrementPopup(counts, 403, 223); // 2 or 3
+            this.incrementPopup(counts, 430, 223); // 2 or 3
             this.incrementPopup(counts, 34, 223); // 1 or 3
             return ["nonModalDialog1", "nonModalDialog2", "nonModalDialog3"].sort(function (a, b) {
                 var res = counts[b] - counts[a];
@@ -95,7 +95,11 @@ Aria.classDefinition({
         getPopupNameFromElement: function (element) {
             var foundPopup = this.getPopupFromElement(element);
             if (foundPopup) {
-                return this.getElementsByClassName(foundPopup.domElement, "xDialog_title")[0].innerHTML;
+                var dialogTitle = this.getElementsByClassName(foundPopup.domElement, "xDialog_title");
+                if (dialogTitle.length > 0) {
+                    return dialogTitle[0].innerHTML;
+                }
+                return "unknown";
             }
             return "none";
         },

--- a/test/aria/widgets/container/dialog/dynamicZIndex/DynamicZIndexClickTestCase.js
+++ b/test/aria/widgets/container/dialog/dynamicZIndex/DynamicZIndexClickTestCase.js
@@ -49,7 +49,7 @@ Aria.classDefinition({
                 self.clickAndCheck(403, 115, ["nonModalDialog2", "nonModalDialog3", "nonModalDialog1"], this.end); // click on dialog 2
             }
 
-            step0();
+            setTimeout(step0, 1); // setTimeout here helps IE8
         },
 
         clickAndCheck : function (x, y, order, cb) {

--- a/test/aria/widgets/container/dialog/dynamicZIndex/DynamicZIndexTestSuite.js
+++ b/test/aria/widgets/container/dialog/dynamicZIndex/DynamicZIndexTestSuite.js
@@ -21,7 +21,8 @@ Aria.classDefinition({
 
         this._tests = [
             "test.aria.widgets.container.dialog.dynamicZIndex.DynamicZIndexClickTestCase",
-            "test.aria.widgets.container.dialog.dynamicZIndex.DynamicZIndexFocusTestCase"
+            "test.aria.widgets.container.dialog.dynamicZIndex.DynamicZIndexFocusTestCase",
+            "test.aria.widgets.container.dialog.dynamicZIndex.innerPopup.DynamicZIndexInnerPopupTestCase"
         ];
     }
 });

--- a/test/aria/widgets/container/dialog/dynamicZIndex/innerPopup/DynamicZIndexInnerPopupTestCase.js
+++ b/test/aria/widgets/container/dialog/dynamicZIndex/innerPopup/DynamicZIndexInnerPopupTestCase.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.dynamicZIndex.innerPopup.DynamicZIndexInnerPopupTestCase",
+    $extends : "test.aria.widgets.container.dialog.dynamicZIndex.BaseDynamicZIndexTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $constructor : function () {
+        this.$BaseDynamicZIndexTestCase.constructor.call(this);
+        this.setTestEnv({
+            template: "test.aria.widgets.container.dialog.dynamicZIndex.innerPopup.DynamicZIndexInnerPopupTestTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var self = this;
+
+            function step0() {
+                self.assertDialogOrder(["nonModalDialog3", "nonModalDialog2", "nonModalDialog1"]);
+                self.synEvent.click(self.getElementById("nonModalDialog2Input1"), function () {
+                    self.waitForDropDownPopup("nonModalDialog2Input1", step1);
+                });
+            }
+
+            function step1() {
+                // clicking should both bring dialog2 to the front and open the select popup
+                self.assertDialogOrder(["nonModalDialog2", "nonModalDialog3", "nonModalDialog1"]);
+                var expectedPopup = self.getWidgetDropDownPopup("nonModalDialog2Input1");
+                var expectedPopupPosition = aria.utils.Dom.getGeometry(expectedPopup);
+                var pointInPopup = {
+                    x: expectedPopupPosition.x + 25,
+                    y: expectedPopupPosition.y + expectedPopupPosition.height - 25
+                };
+                var actualPopup = self.getPopupFromElement(self.testDocument.elementFromPoint(pointInPopup.x, pointInPopup.y)).domElement;
+                self.assertEquals(expectedPopup, actualPopup);
+                self.synEvent.click(pointInPopup, function () {
+                    // waits for the popup to disappear
+                    self.waitFor({
+                        condition: function () {
+                            return !self.getWidgetDropDownPopup("nonModalDialog2Input1");
+                        },
+                        callback: step2
+                    });
+                });
+            }
+
+            function step2() {
+                self.assertDialogOrder(["nonModalDialog2", "nonModalDialog3", "nonModalDialog1"]);
+                self.assertEquals(self.data.nonModalDialog2Input1, "IL");
+                var datePicker = self.getInputField("nonModalDialog2Input2");
+                var outside = self.getElementById("input1");
+                self.synEvent.execute([
+                    ["click", datePicker],
+                    ["waitFocus", datePicker],
+                    ["type", null, "xxx"], // type something wrong
+                    ["click", outside], // go out of the field
+                    ["waitFocus", outside],
+                    ["click", datePicker], // come back to the field, this should trigger the display of the error popup
+                    ["waitFocus", datePicker]
+                ], step3);
+            }
+
+            function step3() {
+                var expectedPopup = self.getWidgetInstance("nonModalDialog2Input2")._onValidatePopup._validationPopup.domElement;
+                var expectedPopupPosition = aria.utils.Dom.getGeometry(expectedPopup);
+                var pointInPopup = {
+                    x: expectedPopupPosition.x + 25,
+                    y: expectedPopupPosition.y + expectedPopupPosition.height - 25
+                };
+                var actualPopup = self.getPopupFromElement(self.testDocument.elementFromPoint(pointInPopup.x,pointInPopup.y)).domElement;
+                self.assertEquals(expectedPopup, actualPopup);
+                self.synEvent.click(pointInPopup, step4);
+            }
+
+            function step4() {
+                self.end();
+            }
+
+            setTimeout(step0, 1); // setTimeout here helps IE8
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/dynamicZIndex/innerPopup/DynamicZIndexInnerPopupTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/dynamicZIndex/innerPopup/DynamicZIndexInnerPopupTestTpl.tpl
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.dynamicZIndex.innerPopup.DynamicZIndexInnerPopupTestTpl",
+   $extends: "test.aria.widgets.container.dialog.dynamicZIndex.DynamicZIndexTestTpl"
+}}
+
+    {macro dialogContent(name)}
+        This is dialog ${name}. <br>
+        {@aria:Select {
+            id: name + "Input1",
+            label: "Select country",
+            options: [
+                {
+                    label: "France",
+                    value: "FR"
+                },
+                {
+                    label: "United States",
+                    value: "US"
+                },
+                {
+                    label: "United Kingdom",
+                    value: "UK"
+                },
+                {
+                    label: "Israel",
+                    value: "IL"
+                }
+            ],
+            bind: {
+                value: {
+                    to: name + "Input1",
+                    inside: data
+                }
+            }
+        } /}<br />
+        {@aria:DatePicker {
+            id: name + "Input2",
+            label: "Select date"
+        } /}<br />
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This commit fixes regressions introduced by commit 8fed6379173c4bfbc48b2d2d962bd197d8edde9a (#1555): if a dialog contains widgets which have a popup (such as the dropdown list of an `@aria:Select`, or the validation error popup of most widgets) the popup is often displayed behind the dialog.
This is fixed by adding a new `zIndexKeepOpenOrder` property on popups, which, when set to `true` (which is the default), makes sure the newly opened popup is always kept in front of any popup that was opened before.
This property is set to `false` on all dialogs, to make sure they can be reordered as needed.