### PR TITLE
fix #1572 Texttfield autoselect doesn't work with JAWS and the arrow keys

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -911,7 +911,6 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _dom_onclick : function () {
-            this._autoselect();
             if (!!this._cfg.onclick) {
                 this.evalCallback(this._cfg.onclick);
             }
@@ -965,6 +964,8 @@ module.exports = Aria.classDefinition({
             if (!!this._cfg.onfocus && !avoidCallback) {
                 this.evalCallback(this._cfg.onfocus);
             }
+
+            this._autoselect();
         },
 
         /**
@@ -1263,16 +1264,6 @@ module.exports = Aria.classDefinition({
               textInputField.value = textInputField.value;
             }
 
-            if (!fromSelf) {
-                // IE FIX: the focus() can be asynchronous, so let's add a timeout to manage the autoselect
-                ariaCoreTimer.addCallback({
-                    fn : function () {
-                        this._autoselect();
-                    },
-                    scope : this,
-                    delay : 25
-                });
-            }
         },
 
         /**

--- a/test/aria/widgets/form/TextInputTest.js
+++ b/test/aria/widgets/form/TextInputTest.js
@@ -213,6 +213,7 @@ Aria.classDefinition({
             var instance1 = tf1.instance;
             instance1._hasFocus = true;
             instance1._dom_onclick();
+            instance1._dom_onfocus();
             if (!aria.core.Browser.isOldIE) {
                 this.assertTrue(instance1._textInputField.selectionStart === 0);
                 this.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
@@ -222,6 +223,7 @@ Aria.classDefinition({
             instance1._textInputField.selectionEnd = 0;
             instance1._cfg.autoselect = false;
             instance1._dom_onclick();
+            instance1._dom_onfocus();
             if (!aria.core.Browser.isOldIE) {
                 this.assertTrue(instance1._textInputField.selectionEnd === 0);
             }

--- a/test/aria/widgets/form/TextareaTest.js
+++ b/test/aria/widgets/form/TextareaTest.js
@@ -219,6 +219,7 @@ Aria.classDefinition({
             var instance1 = tf1.instance;
             instance1._hasFocus = true;
             instance1._dom_onclick();
+            instance1._dom_onfocus();
             if (!aria.core.Browser.isOldIE) {
                 this.assertTrue(instance1._textInputField.selectionStart === 0);
                 this.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
@@ -228,6 +229,7 @@ Aria.classDefinition({
             instance1._textInputField.selectionEnd = 0;
             instance1._cfg.autoselect = false;
             instance1._dom_onclick();
+            instance1._dom_onfocus();
             if (!aria.core.Browser.isOldIE) {
                 this.assertTrue(instance1._textInputField.selectionEnd === 0);
             }


### PR DESCRIPTION
- Autoselect won't work when the textfield was reached with the keyboard