### PR TITLE
Allowing to easily use attester-results-ui with the `npm run attest` command

### DIFF
--- a/scripts/attest.js
+++ b/scripts/attest.js
@@ -63,6 +63,6 @@ attester.event.once("attester.core.fail", function () {
 });
 
 attester.config.set(options);
-attester.campaign.create(campaign);
+attester.campaign.create(campaign, {}, 1);
 
 attester.start();


### PR DESCRIPTION
This is a small change in the `npm run attest` script which is necessary to (easily) allow connecting attester-results-ui to the attester instance started by this script.