### PR TITLE
Allowing to write Jaws automatic tests

### DIFF
--- a/src/aria/jsunit/JawsTestCase.js
+++ b/src/aria/jsunit/JawsTestCase.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("../Aria");
+var ariaUtilsString = require("../utils/String");
+var ariaUtilsJson = require("../utils/Json");
+
+/**
+ * Class to be extended to create a template test case which checks the behavior with
+ * the Jaws screen reader. It contains method to help checking what Jaws said.
+ */
+module.exports = Aria.classDefinition({
+    $classpath : "aria.jsunit.JawsTestCase",
+    $extends : require("./RobotTestCase"),
+    $prototype : {
+        /**
+         * Private helper function, starts the tests once the template has been successfully loaded and rendered
+         */
+        _startTests : function () {
+            // automatically clear Jaws history before starting the test
+            this.clearJawsHistory(this.$RobotTestCase._startTests);
+        },
+
+        /**
+         * Creates an empty text area that completely fills the test document, with a high zIndex,
+         * and returns its reference.
+         */
+        _createFullScreenTextArea : function () {
+            var textArea = this.testDocument.createElement("textarea");
+            var textAreaStyle = textArea.style;
+            textAreaStyle.position = "absolute";
+            textAreaStyle.display = "block";
+            textAreaStyle.top = "0px";
+            textAreaStyle.left = "0px";
+            textAreaStyle.width = "100%";
+            textAreaStyle.height = "100%";
+            textAreaStyle.zIndex = "999999";
+            this.testDocument.body.appendChild(textArea);
+            return textArea;
+        },
+
+        /**
+         * Sends the keyboard events necessary to clear Jaws history.
+         * In case Jaws is not running, the test is ended.
+         * @param {aria.core.CfgBeans:Callback} cb
+         */
+        clearJawsHistory : function (cb) {
+            var textArea = this._createFullScreenTextArea();
+            this.synEvent.execute([
+                ["click", textArea],
+                ["pause", 1000],
+                ["type", null, "[<insert>][space][>insert<][<shift>]h[>shift<]"],
+                ["pause", 2000]
+            ],{
+                fn: function () {
+                    var textAreaContent = textArea.value;
+                    textArea.parentNode.removeChild(textArea);
+                    // if there is something in the text area, there is something
+                    // wrong in the setup (e.g.: JAWS not enabled or wrong robot
+                    // implementation)
+                    if (textAreaContent === "") {
+                        this.$callback(cb);
+                    } else {
+                        // ends the test
+                        this.raiseFailure("JAWS is not running or wrong robot implementation");
+                        this.end();
+                    }
+
+                },
+                scope: this
+            });
+        },
+
+        /**
+         * Sends the keyboard/mouse events necessary to retrieve Jaws history.
+         * The raw history is processed to make it easier to compare between
+         * several executions.
+         * @param {aria.core.CfgBeans:Callback} cb
+         */
+        retrieveJawsHistory : function (cb) {
+            var textArea = this._createFullScreenTextArea();
+            this.synEvent.execute([
+                ["type", null, "[<insert>][space][>insert<]h"], // displays history window
+                ["pause", 2000],
+                ["type", null, "[<ctrl>]a[>ctrl<][<ctrl>]c[>ctrl<]"], // copies the whole history in the clipboard
+                ["pause", 1000],
+                ["type", null, "[<alt>][F4][>alt<]"], // closes history window
+                ["click", textArea],
+                ["type", null, "[<ctrl>]v[>ctrl<]"], // pastes history in our text area
+                ["pause", 2000]
+            ], {
+                fn: function () {
+                    textArea.parentNode.removeChild(textArea);
+                    var textAreaContent = textArea.value;
+                    var lines = ariaUtilsString.trim(textAreaContent).split("\n");
+                    for (var i = lines.length - 1; i >= 0; i--) {
+                        var curLine = lines[i];
+                        curLine = curLine.replace(/\s+/g, " ");
+                        curLine = ariaUtilsString.trim(curLine);
+                        if (curLine) {
+                            lines[i] = curLine;
+                        } else {
+                            lines.splice(i, 1);
+                        }
+                    }
+                    if (lines[0] == "New tab page") {
+                        lines.shift();
+                    }
+                    textAreaContent = lines.join("\n");
+                    this.$callback(cb, textAreaContent);
+                },
+                scope: this
+            });
+        },
+
+        /**
+         * Retrieves Jaws history (with this.retrieveJawsHistory) and
+         * asserts that it is equal to the expected string.
+         * @param {aria.core.CfgBeans:Callback} cb
+         */
+        assertJawsHistoryEquals : function (expectedOutput, callback) {
+            this.retrieveJawsHistory({
+                fn: function (response) {
+                    this.assertEquals(response, expectedOutput, "JAWS history: " + ariaUtilsJson.convertToJsonString(response));
+                    this.$callback(callback);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test suite grouping all tests to be run with Jaws enabled
+ */
+Aria.classDefinition({
+    $classpath : "test.JawsTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
+    }
+});

--- a/test/aria/widgets/wai/datePicker/DatePickerJawsTest1.js
+++ b/test/aria/widgets/wai/datePicker/DatePickerJawsTest1.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.datePicker.DatePickerJawsTest1",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.datePicker.DatePickerTestTpl",
+            data : {
+                dpWaiEnabledValue : new Date(2016, 0, 1)
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("dpWaiEnabledNextInput")],
+                ["pause", 1000],
+                ["type", null, "[up][up][up]"],
+                ["pause", 1000],
+                ["type", null, "[space]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[space]"],
+                ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals("Next field Edit\nType in text.\nNext field\nDisplay calendar button menu collapsed\nEntering Application Region\nCalendar table. Use arrow keys to navigate and space to validate.\nFriday 1 January 2016\nFriday 8 January 2016\nFriday 15 January 2016\nLeaving Application Region\nTravel date Edit\n15/1/16\nType in text.", this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/datePicker/DatePickerTestTpl.tpl
+++ b/test/aria/widgets/wai/datePicker/DatePickerTestTpl.tpl
@@ -27,7 +27,7 @@
     {/macro}
 
     {macro datePicker(id, waiAria)}
-        <label>Previous field <input></label> <br><br>
+        <label>Previous field <input {id id+"PreviousInput"/}></label> <br><br>
         {@aria:DatePicker {
             id: id,
             label: "Travel date",
@@ -35,6 +35,7 @@
             waiAria: waiAria,
             waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
             waiAriaDateFormat: "EEEE d MMMM yyyy",
+            calendarShowShortcuts: false,
             bind: {
                 value: {
                     to: id + "Value",
@@ -42,7 +43,7 @@
                 }
             }
         }/} <br><br>
-        <label>Next field <input></label> <br><br>
+        <label>Next field <input {id id+"NextInput"/}></label> <br><br>
     {/macro}
 
 {/Template}


### PR DESCRIPTION
This commit adds the `aria.jsunit.JawsTestCase` base class to help writing tests to be run with the Jaws screen reader enabled.
It also adds the `test.JawsTestSuite` class which is intended to reference all test cases designed to be run with Jaws enabled.
It also includes a first Jaws test, which can also be used as an example to write further tests: `test.aria.widgets.wai.datePicker.DatePickerJawsTest1`