### PR TITLE
Introduction of a new cfg for the Dialog called focusIfModal which will

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1971,6 +1971,11 @@ module.exports = Aria.beanDefinitions({
                     $description : "If true, the dialog is always centered in the browser window. Takes priority over xpos and ypos. However, if the dialog box is movable and the user manually moves it, the centered behavior will be switched off.",
                     $default : true
                 },
+                "focusIfModal" : {
+                    $type : "json:Boolean",
+                    $description : "If true, the dialog with the modal flag set to true, will set the focus on the first focusable element when opened",
+                    $default : true
+                },
                 "xpos" : {
                     $type : "json:Integer",
                     $description : "x position of the top left corner of the dialog box.",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -609,9 +609,14 @@ module.exports = Aria.classDefinition({
 
             this._calculatePosition();
 
-            if (cfg.focusIfModal && cfg.modal) {
-                ariaTemplatesNavigationManager.focusFirst(this._domElt);
+            if (cfg.modal) {
+                if (cfg.focusIfModal) {
+                    ariaTemplatesNavigationManager.focusFirst(this._domElt);
+                } else {
+                    Aria.$window.document.activeElement.blur();
+                }
             }
+            
 
             ariaCoreTimer.addCallback({
                 fn : function () {

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -609,7 +609,7 @@ module.exports = Aria.classDefinition({
 
             this._calculatePosition();
 
-            if (cfg.modal) {
+            if (cfg.focusIfModal && cfg.modal) {
                 ariaTemplatesNavigationManager.focusFirst(this._domElt);
             }
 


### PR DESCRIPTION
set the focus on the first focusable element when the Dialog is opened and
if and only if the dialog has the modal flag set to true