### PR TITLE
Now raising an event when bringing popups to the front

### DIFF
--- a/src/aria/popups/Popup.js
+++ b/src/aria/popups/Popup.js
@@ -70,7 +70,8 @@ module.exports = Aria.classDefinition({
         ANCHOR_LEFT : "left",
         ANCHOR_RIGHT : "right",
         // DEBUG MESSAGE
-        DEBUG_OVERWRITE_POSITION : "Absolute %1 position %2 is used to overwrite calculated relative position %3!"
+        DEBUG_OVERWRITE_POSITION : "Absolute %1 position %2 is used to overwrite calculated relative position %3!",
+        WRONG_MODALMASK_ZINDEX : "The z-index of the modal mask (%1) is higher than the z-index of the corresponding dialog (%2)."
     },
     $constructor : function () {
         /**
@@ -701,12 +702,18 @@ module.exports = Aria.classDefinition({
                 // Compute the style after scrollbars are removed from the
                 // container. Thus the dialog can be properly centered.
                 this.computedStyle = this._getComputedStyle();
-                if (!this.modalMaskZIndex) {
-                    this.modalMaskZIndex = this.computedStyle.zIndex;
+                var modalMaskZIndex = this.modalMaskZIndex;
+                if (!modalMaskZIndex) {
+                    modalMaskZIndex = this.modalMaskZIndex = this.computedStyle.zIndex;
+                } else if (modalMaskZIndex > this.computedStyle.zIndex) {
+                    // safety check to not block the full application
+                    // this should never happen in normal circumstances
+                    this.$logError(this.WRONG_MODALMASK_ZINDEX, [modalMaskZIndex, this.computedStyle.zIndex]);
+                    modalMaskZIndex = this.computedStyle.zIndex;
                 }
 
                 this.modalMaskDomElement.style.cssText = ['left:0px;top:0px;', 'width:', containerSize.width, 'px;', 'height:',
-                        containerSize.height, 'px;', 'z-index:', this.modalMaskZIndex, ';', 'position:absolute;display:block;'].join('');
+                        containerSize.height, 'px;', 'z-index:', modalMaskZIndex, ';', 'position:absolute;display:block;'].join('');
 
                 if (this.conf.animateIn) {
                     this._getMaskAnimator().start("fade", {
@@ -1030,14 +1037,19 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Sets the zIndex of the popup, and refreshes. The zIndex of the modal mask, if any, is not changed.
+         * Sets the zIndex of the popup, and refreshes. The zIndex of the modal mask, if any, is not changed,
+         * unless the second parameter is defined.
          * This method does nothing if the popup has not already been displayed.
          * @param {Number} zIndex zIndex to set on the popup.
+         * @param {Number} modalMaskZIndex zIndex to set on the modal mask.
          */
-        setZIndex : function (zIndex) {
+        setZIndex : function (zIndex, modalMaskZIndex) {
             var computedStyle = this.computedStyle;
             if (computedStyle) {
                 computedStyle.zIndex = zIndex;
+                if (modalMaskZIndex != null) {
+                    this.modalMaskZIndex = modalMaskZIndex;
+                }
                 this.refresh();
             }
         },

--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -53,6 +53,13 @@ var ariaCoreTimer = require("../core/Timer");
                 properties : {
                     popup : "Reference to the popup"
                 }
+            },
+            "beforeBringingPopupsToFront" : {
+                description : "Notifies that several popups are being brought to the front.",
+                properties : {
+                    popups : "Array of popups being brought to the front. The last popup in the list should be on the top.",
+                    cancel : "If set to true, the zIndex of the popups will not be changed."
+                }
             }
         },
         $onload : function () {
@@ -423,6 +430,15 @@ var ariaCoreTimer = require("../core/Timer");
                 if (i < 0 || newBaseZIndex + 10 === curZIndex) {
                     // either the popup is not in openedPopups (i < 0)
                     // or it is already correctly positioned (newBaseZIndex + 10 === curZIndex)
+                    return;
+                }
+                var eventObject = {
+                    name : "beforeBringingPopupsToFront",
+                    popups : popupsToKeepInFront,
+                    cancel : false
+                };
+                this.$raiseEvent(eventObject);
+                if (eventObject.cancel) {
                     return;
                 }
                 this.currentZIndex = newBaseZIndex;


### PR DESCRIPTION
This is needed in case several popup managers need to cooperate, so that only one manages z-indexes.