### PR TITLE
Fixing test.aria.widgets.autoselect.programmatic.AutoSelect on IE9 and IE10

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -965,7 +965,12 @@ module.exports = Aria.classDefinition({
                 this.evalCallback(this._cfg.onfocus);
             }
 
-            this._autoselect();
+            // on IE9 and IE10, it is necessary to add some delay before being able to set the selection
+            ariaCoreTimer.addCallback({
+                fn : this._autoselect,
+                scope : this,
+                delay : 1
+            });
         },
 
         /**

--- a/test/aria/widgets/form/TextInputTest.js
+++ b/test/aria/widgets/form/TextInputTest.js
@@ -201,9 +201,10 @@ Aria.classDefinition({
             });
         },
 
-        testAutoSelect : function () {
+        testAsyncAutoSelect : function () {
+            var self = this;
             // test autoselect is turned on
-            var tf1 = this._createTextInput({
+            var tf1 = self._createTextInput({
                 label : "TESTLABEL",
                 value : "Selected?",
                 autoselect : true
@@ -211,23 +212,40 @@ Aria.classDefinition({
 
             // autoselect on
             var instance1 = tf1.instance;
-            instance1._hasFocus = true;
-            instance1._dom_onclick();
-            instance1._dom_onfocus();
-            if (!aria.core.Browser.isOldIE) {
-                this.assertTrue(instance1._textInputField.selectionStart === 0);
-                this.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
+
+            function step0() {
+                instance1._dom_onclick();
+                instance1._dom_onfocus();
+                setTimeout(step1, 10);
             }
 
-            // autoselect off
-            instance1._textInputField.selectionEnd = 0;
-            instance1._cfg.autoselect = false;
-            instance1._dom_onclick();
-            instance1._dom_onfocus();
-            if (!aria.core.Browser.isOldIE) {
-                this.assertTrue(instance1._textInputField.selectionEnd === 0);
+            function step1() {
+                if (!aria.core.Browser.isOldIE) {
+                    self.assertTrue(instance1._textInputField.selectionStart === 0);
+                    self.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
+                }
+                instance1._textInputField.selectionEnd = 0;
+                instance1._dom_onblur();
+                setTimeout(step2, 10);
             }
-            this._destroyTextInput(instance1);
+
+            function step2() {
+                // autoselect off
+                instance1._cfg.autoselect = false;
+                instance1._dom_onclick();
+                instance1._dom_onfocus();
+                setTimeout(step3, 10);
+            }
+
+            function step3() {
+                if (!aria.core.Browser.isOldIE) {
+                    self.assertTrue(instance1._textInputField.selectionEnd === 0);
+                }
+                self._destroyTextInput(instance1);
+                self.notifyTestEnd("testAsyncAutoSelect");
+            }
+
+            step0();
         },
 
         /**

--- a/test/aria/widgets/form/TextareaTest.js
+++ b/test/aria/widgets/form/TextareaTest.js
@@ -207,9 +207,10 @@ Aria.classDefinition({
             });
         },
 
-        testAutoSelect : function () {
+        testAsyncAutoSelect : function () {
+            var self = this;
             // test autoselect is turned on
-            var tf1 = this._createTextarea({
+            var tf1 = self._createTextarea({
                 label : "TESTLABEL",
                 value : "Selected?",
                 autoselect : true
@@ -217,23 +218,41 @@ Aria.classDefinition({
 
             // autoselect on
             var instance1 = tf1.instance;
-            instance1._hasFocus = true;
-            instance1._dom_onclick();
-            instance1._dom_onfocus();
-            if (!aria.core.Browser.isOldIE) {
-                this.assertTrue(instance1._textInputField.selectionStart === 0);
-                this.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
+
+            function step0() {
+                instance1._dom_onclick();
+                instance1._dom_onfocus();
+                setTimeout(step1, 10);
             }
 
-            // autoselect off
-            instance1._textInputField.selectionEnd = 0;
-            instance1._cfg.autoselect = false;
-            instance1._dom_onclick();
-            instance1._dom_onfocus();
-            if (!aria.core.Browser.isOldIE) {
-                this.assertTrue(instance1._textInputField.selectionEnd === 0);
+            function step1() {
+                if (!aria.core.Browser.isOldIE) {
+                    self.assertTrue(instance1._textInputField.selectionStart === 0);
+                    self.assertTrue(instance1._textInputField.selectionEnd === instance1._textInputField.value.length);
+                }
+
+                instance1._textInputField.selectionEnd = 0;
+                instance1._dom_onblur();
+                setTimeout(step2, 10);
             }
-            this._destroyTextarea(instance1);
+
+            function step2() {
+                // autoselect off
+                instance1._cfg.autoselect = false;
+                instance1._dom_onclick();
+                instance1._dom_onfocus();
+                setTimeout(step3, 10);
+            }
+
+            function step3() {
+                if (!aria.core.Browser.isOldIE) {
+                    self.assertTrue(instance1._textInputField.selectionEnd === 0);
+                }
+                self._destroyTextarea(instance1);
+                self.notifyTestEnd("testAsyncAutoSelect");
+            }
+
+            step0();
         },
 
         /**


### PR DESCRIPTION
This PR fixes a regression introduced by commit f9d30b69f19e3d472f6b4c93ddbbb210776507d8.
On IE9 and IE10, setting the selection on the focus event handler itself does not work, it has to be delayed.