### PR TITLE
No longer scrolls to the top of the dialog when closing a popup

### DIFF
--- a/src/aria/popups/PopupManager.js
+++ b/src/aria/popups/PopupManager.js
@@ -611,18 +611,6 @@ var ariaCoreTimer = require("../core/Timer");
                     name : "popupClose",
                     popup : popup
                 });
-
-                var topPopup = this.getTopPopup();
-
-                // the timeout waits for a possible focus change after the mousedown event that possibly triggered this
-                // method
-                setTimeout(function () {
-                    var document = Aria.$window.document;
-                    var focusedEl = document.activeElement;
-                    if (topPopup && (!focusedEl || focusedEl === document.body)) {
-                        ariaTemplatesNavigationManager.focusFirst(topPopup.domElement);
-                    }
-                }, 1);
             },
 
             /**

--- a/test/aria/popups/focus/FocusTest.js
+++ b/test/aria/popups/focus/FocusTest.js
@@ -72,22 +72,6 @@ Aria.classDefinition({
             // when a focusable element in a popup is clicked, it should take the focus even if the most recent popup
             // has lost the focus and has been closed
             this.assertEquals(this.input2, focusedEl, "The second input has not been focused by the click");
-            this.synEvent.click(this.span, {
-                scope : this,
-                fn : function () {
-                    aria.core.Timer.addCallback({
-                        fn : this.checkFirstElementFocused,
-                        scope : this,
-                        delay : 100
-                    });
-                }
-            });
-        },
-
-        checkFirstElementFocused : function () {
-            var focusedEl = Aria.$window.document.activeElement;
-            // when a not focusable element in a popup is clicked, the focus automatically goes to its first element
-            this.assertEquals(this.anchor, focusedEl, "The anchor has not been focused by the click on an inner, not focusable zone");
             this.end();
         }
     }

--- a/test/aria/widgets/container/dialog/DialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/DialogTestSuite.js
@@ -43,5 +43,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.dialog.configContainer.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.container.DialogContainerTestSuite");
         this.addTests("test.aria.widgets.container.dialog.dynamicZIndex.DynamicZIndexTestSuite");
+        this.addTests("test.aria.widgets.container.dialog.closePopupScroll.ClosePopupScrollTest");
     }
 });

--- a/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTest.js
+++ b/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTest.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.closePopupScroll.ClosePopupScrollTest",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype : {
+        runTemplateTest : function () {
+            var self = this;
+            var outsideSelect = this.getElementById("outsideSelect");
+            var outsideSelectGeometry;
+
+            function checkOutsideSelectGeometry() {
+                var newGeometry = aria.utils.Dom.getGeometry(outsideSelect);
+                self.assertJsonEquals(newGeometry, outsideSelectGeometry);
+            }
+
+            function step1() {
+                aria.utils.Dom.scrollIntoView(outsideSelect, true);
+                outsideSelectGeometry = aria.utils.Dom.getGeometry(outsideSelect);
+                var dropdownButton = self.getExpandButton("happySelect");
+                self.synEvent.click(dropdownButton, step2);
+            }
+
+            function step2() {
+                self.waitForDropDownPopup("happySelect", step3);
+            }
+
+            function step3() {
+                self.synEvent.click(outsideSelect, step4);
+            }
+
+            function step4() {
+                self.waitFor({
+                    condition: function () {
+                        return !self.getWidgetDropDownPopup("happySelect");
+                    },
+                    callback: step5
+                });
+            }
+
+            function step5() {
+                checkOutsideSelectGeometry();
+                // wait a bit more and check again to be sure
+                setTimeout(step6, 1000);
+            }
+
+            function step6() {
+                // clicking outside the select should not scroll
+                checkOutsideSelectGeometry();
+                self.end();
+            }
+
+            setTimeout(step1, 10);
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTestTpl.tpl
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.container.dialog.closePopupScroll.ClosePopupScrollTestTpl"
+}}
+    {macro main()}
+        {@aria:Dialog {
+            title: "Dialog with scrollbar",
+            macro: "dialogContent",
+            width: 300,
+            height: 400,
+            visible: true,
+            modal: true
+        }/}
+    {/macro}
+
+    {macro dialogContent()}
+        {@aria:TextField {
+            label: "Initial input"
+        }/}
+        <div style="height: 900px;">
+            This dialog contains a lot of things, so there is a scrollbar...
+        </div>
+        <div {id "outsideSelect" /}>
+            Here is the part that really matters:<br>
+        </div>
+        {@aria:Select {
+            id :"happySelect",
+            label : "What do you need to be happy?",
+            options : [
+                {label : "God", value : "God"},
+                {label : "Love", value : "Love"},
+                {label : "Forgiveness", value : "Forgiveness"},
+                {label : "Hope", value : "Hope"},
+                {label : "A spouse", value : "spouse"},
+                {label : "Good friends", value : "goodfriends"},
+                {label : "Food", value : "Food"},
+                {label : "Clothing", value : "Clothing"},
+                {label : "Shelter", value : "Shelter"},
+                {label : "A good job", value : "goodjob"},
+                {label : "A car", value : "car"},
+                {label : "A good computer", value : "goodcomputer"},
+                {label : "A smartphone", value: "smartphone"},
+                {label : "JavaScript", value : "Javascript"},
+                {label : "A good browser", value: "goodbrowser"},
+                {label : "Aria Templates", value : "ariatemplates"}
+            ]
+        }/}
+        <div style="height: 900px;">
+            And there are again many other options...
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalAndNonModalTest.js
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalAndNonModalTest.js
@@ -26,7 +26,6 @@ Aria.classDefinition({
             this._assertDialogVisibility("one");
             this._assertDialogVisibility("two");
             this._assertDialogVisibility("three", false);
-            this._assertFocus("two");
 
             aria.utils.FireDomEvent.fireEvent("keydown", this.getInputField("two"), {
                 keyCode : aria.DomEvent['KC_ESCAPE']

--- a/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
+++ b/test/aria/widgets/container/dialog/escKey/multipleDialogs/EscapeOnModalTest.js
@@ -68,7 +68,6 @@ Aria.classDefinition({
             this._assertDialogVisibility("one");
             this._assertDialogVisibility("two");
             this._assertDialogVisibility("three", false);
-            this._assertFocus("two");
 
             aria.utils.FireDomEvent.fireEvent('keydown', Aria.$window.document.body, {
                 keyCode : aria.DomEvent['KC_ESCAPE']
@@ -85,7 +84,6 @@ Aria.classDefinition({
             this._assertDialogVisibility("one");
             this._assertDialogVisibility("two", false);
             this._assertDialogVisibility("three", false);
-            this._assertFocus("one");
 
             aria.utils.FireDomEvent.fireEvent('keydown', Aria.$window.document.body, {
                 keyCode : aria.DomEvent['KC_ESCAPE']
@@ -112,12 +110,6 @@ Aria.classDefinition({
             var realId = this.templateCtxt.$getId(id);
             var field = aria.utils.Dom.getElementById(realId);
             this.assertEquals(!!field, open, "Dialog " + id + " should " + (open ? "" : "not ") + "be open");
-        },
-
-        _assertFocus : function (id) {
-            var field = this.getInputField(id);
-            var focused = Aria.$window.document.activeElement;
-            this.assertEquals(field, focused, "Element with id " + id + " should be focused.");
         }
     }
 });


### PR DESCRIPTION
This commit removes some code which was trying to focus the first element of a popup when another popup was closed. This behavior was disturbing as it could scroll to the top of the dialog in case the first element was not visible.