### PR TITLE
Issue when a resizable/movable dialog is disposed shortly after its creation

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -968,6 +968,10 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _createDraggable : function () {
+            if (!this._cfg) {
+                // maybe the widget was disposed while loading aria.utils.dragdrop.Drag
+                return;
+            }
             this._draggable = new aria.utils.dragdrop.Drag(this._domElt, {
                 handle : this._titleBarDomElt,
                 cursor : "move",
@@ -995,6 +999,10 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _createResize : function () {
+            if (!this._cfg) {
+                // maybe the widget was disposed while loading aria.utils.resize.Resize
+                return;
+            }
             if (this._handlesArr) {
                 this._resizable = {};
                 var handleArr = this._handlesArr, index = 0, parent = this._domElt, getDomElementChild = ariaUtilsDom.getDomElementChild;


### PR DESCRIPTION
As the aria.utils.dragdrop.Drag and aria.utils.resize.Resize utilities are loaded asynchronously (only if the dialog configuration requires those classes), it is possible that the dialog is disposed before those
classes are loaded, so the callback should check it before doing anything else.