### PR TITLE
WAI-ARIA Improvements  for the AutoComplete

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1074,6 +1074,14 @@ module.exports = Aria.beanDefinitions({
                         }
                     },
                     $default : {}
+                },
+                "waiSuggestionsStatusGetter" : {
+                    $type : "common:Callback",
+                    $description : "The callback specified in this parameter is called when the number of suggestions changes. It receives the new number of suggestions and should return the message to be read by screen readers. This parameter is only used if waiAria is true."
+                },
+                "waiSuggestionAriaLabelGetter" : {
+                    $type : "common:Callback",
+                    $description : "The callback specified in this parameter is called for each suggestion when the set of suggestions changes. It should return the aria-label attribute to set on the suggestion. This parameter is only used if waiAria is true."
                 }
             }
         },
@@ -1775,6 +1783,10 @@ module.exports = Aria.beanDefinitions({
                                         "value" : {
                                             $type : "json:MultiTypes",
                                             $description : "The value of the item"
+                                        },
+                                        "ariaLabel" : {
+                                            $type : "json:String",
+                                            $description : "The string to set in the aria-label attribute (only used when waiAria is true)"
                                         }
                                     }
                                 }
@@ -1790,6 +1802,11 @@ module.exports = Aria.beanDefinitions({
                                     "labelProperty" : {
                                         $type : "json:String",
                                         $description : "The name of the property containing the label",
+                                        $default : ""
+                                    },
+                                    "ariaLabelProperty" : {
+                                        $type : "json:String",
+                                        $description : "The name of the property containing the aria-label",
                                         $default : ""
                                     },
                                     "valueProperty" : {

--- a/src/aria/widgets/controllers/AutoCompleteController.js
+++ b/src/aria/widgets/controllers/AutoCompleteController.js
@@ -94,6 +94,13 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
              */
             this.preselect = null;
 
+            /**
+             * Function set by the widget. It is passed the suggestion, its index, and the array of suggestions and
+             * should return the aria-label attribute to set for the current suggestion.
+             * @type Function
+             */
+            this.waiSuggestionAriaLabelGetter = null;
+
             // Inherited from aria.html.controllers.Suggestions
             this._init();
         },
@@ -412,7 +419,7 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
              */
             _prepareSuggestionsAndMatch : function (suggestions, textEntry) {
                 var matchValueIndex = -1, suggestion;
-                for (var index = 0, len = suggestions.length, label; index < len; index += 1) {
+                for (var index = 0, len = suggestions.length, label, ariaLabel; index < len; index += 1) {
                     suggestion = suggestions[index];
                     // if it's the first exact match, store it
                     if (matchValueIndex == -1) {
@@ -421,9 +428,15 @@ var ariaCoreJsonValidator = require("../../core/JsonValidator");
                         }
                     }
                     label = this._getLabelFromSuggestion(suggestion);
+                    ariaLabel = this.waiSuggestionAriaLabelGetter ? this.waiSuggestionAriaLabelGetter({
+                        value: suggestion,
+                        index: index,
+                        total: len
+                    }) : null;
                     var tmp = {
                         entry : textEntry,
                         label : label,
+                        ariaLabel : ariaLabel,
                         value : suggestion
                     };
                     suggestions[index] = tmp;

--- a/src/aria/widgets/form/list/CfgBeans.js
+++ b/src/aria/widgets/form/list/CfgBeans.js
@@ -174,6 +174,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "Internal value associated to the item - usually a language-independent code."
                 },
+                "ariaLabel" : {
+                    $type : "json:String",
+                    $description : "Text to set in the aria-label attribute."
+                },
                 "currentlyDisabled" : {
                     $type : "json:Boolean",
                     $description : "Whether the item is disabled (true) or enabled (false), taking into account whether the maximum number of selected items has been reached or not."

--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -394,11 +394,13 @@ module.exports = Aria.classDefinition({
             // Identify from which container we'll take the items and from which properties.
             var container = items;
             var labelProperty = "label";
+            var ariaLabelProperty = "ariaLabel";
             var valueProperty = "value";
             var disabledProperty = "disabled";
             if (!ariaUtilsType.isArray(items)) {
                 container = items.container;
                 labelProperty = items.labelProperty;
+                ariaLabelProperty = items.ariaLabelProperty;
                 valueProperty = items.valueProperty;
                 disabledProperty = items.disabledProperty;
             }
@@ -435,6 +437,7 @@ module.exports = Aria.classDefinition({
                 listItems[item] = {
                     index : item,
                     label : itemObj[labelProperty],
+                    ariaLabel : itemObj[ariaLabelProperty],
                     value : itemObj[valueProperty],
                     object : itemObj,
                     selected : itemSelected,

--- a/src/aria/widgets/form/list/templates/LCTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/LCTemplate.tpl
@@ -23,7 +23,7 @@
         {var className = _getClassForItem(item)/}
         {var entry = item.object.entry/}
 
-        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option"{/if} href="javascript:void(0)" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option" {if item.ariaLabel != null}aria-label="${item.ariaLabel}"{/if}{/if} href="javascript:void(0)" class="${className}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {elseif item.value.multiWordMatch/}

--- a/src/aria/widgets/form/list/templates/ListTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/ListTemplate.tpl
@@ -44,7 +44,7 @@
 
     {macro renderItem(item, itemIdx)}
         {var a = _getClassForItem(item)/}
-        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option"{/if} href="javascript:void(0)" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
+        <a {if data.waiAria}{id data.listItemDomIdPrefix + itemIdx/} role="option" {if item.ariaLabel != null}aria-label="${item.ariaLabel}"{/if}{/if} href="javascript:void(0)" class="${a}" data-itemIdx="${itemIdx}" onclick="return false;">
             {if ! item.label}
                 &nbsp;
             {else/}

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -23,5 +23,8 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
 
         this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
+
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
+        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
     }
 });

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
@@ -60,22 +60,11 @@ module.exports = Aria.classDefinition({
         checkAccessibilityEnabled : function (widget) {
             var inputElt = widget.getTextInputField();
 
-            var role = inputElt.getAttribute("role");
-            this.assertEquals(role, "combobox", "wrong input role value (%1)");
-
-            var ariaAutocomplete = inputElt.getAttribute("aria-autocomplete");
-            this.assertEquals(ariaAutocomplete, "list", "wrong input aria-autocomplete value (%1)");
-
-            var ariaExpanded = inputElt.getAttribute("aria-expanded");
-            this.assertTrue(ariaExpanded === "true" || ariaExpanded === "false", "wrong input aria-expanded value");
-            var ariaExpandedBool = (ariaExpanded === "true");
-            this.assertEquals(ariaExpandedBool, !! widget._dropdownPopup, "aria-expanded (%1) does not match the state of widget._dropdownPopup (%2)");
-            var listWidget = widget.controller.getListWidget();
-            this.assertEquals(ariaExpandedBool, !! listWidget, "aria-expanded (%1) does not match the state of widget.controller.getListWidget() (%2)");
-
             var ariaOwns = inputElt.getAttribute("aria-owns");
             var ariaOwnsElt;
-            this.assertEquals(!! ariaOwns, ariaExpandedBool, "aria-owns should be present (%1) if and only if aria-expanded is true (%2)");
+            this.assertEquals(!! ariaOwns, !! widget._dropdownPopup, "aria-owns (%1) does not match the state of widget._dropdownPopup (%2)");
+            var listWidget = widget.controller.getListWidget();
+            this.assertEquals(!! ariaOwns, !! listWidget, "aria-owns (%1) does not match the state of widget.controller.getListWidget() (%2)");
             var listBoxElt;
             var optionsElt = [];
             if (ariaOwns) {
@@ -108,7 +97,6 @@ module.exports = Aria.classDefinition({
             var ariaActiveDescendant = inputElt.getAttribute("aria-activedescendant");
             var ariaActiveDescendantElt;
             if (ariaActiveDescendant) {
-                this.assertTrue(ariaExpandedBool, "aria-activedescendant is defined but aria-expanded is false");
                 ariaActiveDescendantElt = this.testDocument.getElementById(ariaActiveDescendant);
                 this.assertTruthy(ariaActiveDescendantElt, "the id specified in aria-activedescendant was not found in the document");
                 this.assertEquals(ariaActiveDescendantElt.getAttribute("role"), "option", "the aria-activedescendant element does not have the option role");

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteJawsTest1.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteJawsTest1.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.autoComplete.AutoCompleteTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("inputBeforeAutoComplete")],
+                ["pause", 1000],
+                ["type", null, "[down][down][down]"],
+                ["pause", 1000],
+                ["type", null, "p"],
+                ["pause", 1000],
+                ["type", null, "a"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[enter]"],
+                ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals("Edit\nType in text.\nWith accessibility enabled:\nCity 2\nEdit\nThere are 8 suggestions, use up and down arrow keys to navigate and enter to validate.\nThere are 2 suggestions, use up and down arrow keys to navigate and enter to validate.\nList view Pau 1 of 2\nParis 2 of 2\nCity 2 Edit\nParis\nType in text.", this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteJawsTest2.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteJawsTest2.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.autoComplete.AutoCompleteTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("inputBeforeAutoComplete")],
+                ["pause", 1000],
+                ["type", null, "[down][down][down]"],
+                ["pause", 1000],
+                ["type", null, "p"],
+                ["pause", 1000],
+                ["type", null, "l"],
+                ["pause", 1000],
+                ["type", null, "u"],
+                ["pause", 1000],
+                ["type", null, "s"],
+                ["pause", 1000],
+                ["type", null, "\b"],
+                ["pause", 1000],
+                ["type", null, "\b"],
+                ["pause", 1000],
+                ["type", null, "\b"],
+                ["pause", 1000],
+                ["type", null, "\b"],
+                ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals("Edit\nType in text.\nWith accessibility enabled:\nCity 2\nEdit\nThere are 8 suggestions, use up and down arrow keys to navigate and enter to validate.\nThere is one suggestion, use up and down arrow keys to navigate and enter to validate.\nThere is no suggestion.\ns\nu\nThere is one suggestion, use up and down arrow keys to navigate and enter to validate.\nl\nThere are 8 suggestions, use up and down arrow keys to navigate and enter to validate.\np\nThere is no suggestion.", this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteTpl.tpl
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteTpl.tpl
@@ -29,6 +29,7 @@
                 autoFill : false,
                 resourcesHandler : this.acHandler
             }/} <br><br>
+            <input {id "inputBeforeAutoComplete"/}><br><br>
             With accessibility enabled: <br>
             {@aria:AutoComplete {
                 id : "city2",
@@ -36,7 +37,9 @@
                 label : "City 2",
                 labelWidth: 100,
                 autoFill : false,
-                resourcesHandler : this.acHandler
+                resourcesHandler : this.acHandler,
+                waiSuggestionsStatusGetter: this.waiSuggestionsStatusGetter,
+                waiSuggestionAriaLabelGetter: this.waiSuggestionAriaLabelGetter
             }/} <br><br>
             With accessibility disabled: <br>
             {@aria:AutoComplete {

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteTplScript.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteTplScript.js
@@ -49,5 +49,18 @@ module.exports = Aria.tplScriptDefinition({
     $destructor : function () {
         this.acHandler.$dispose();
         this.acHandler = null;
+    },
+    $prototype: {
+        waiSuggestionsStatusGetter : function (number) {
+           if (number === 0) {
+               return "There is no suggestion.";
+           } else {
+               return (number == 1 ? "There is one suggestion" : "There are " + number + " suggestions") + ", use up and down arrow keys to navigate and enter to validate.";
+           }
+       },
+
+       waiSuggestionAriaLabelGetter : function (object) {
+           return object.value.label + " " + (object.index + 1) + " of " + object.total;
+       }
     }
 });


### PR DESCRIPTION
The compatibility of the aria:AutoComplete widget with JAWS on IE 11 is improved: it is now possible to specify a message to be read when the number of displayed suggestions changes and to change the message which is read for each suggestion.