### PR TITLE
feat - WAI-ARIA - Dropdowns visibility toggling

### DIFF
--- a/src/aria/DomEvent.js
+++ b/src/aria/DomEvent.js
@@ -457,6 +457,10 @@ var ariaCoreBrowser = require("./core/Browser");
                 if (specials.altKey && kc != this.KC_ALT) {
                     return true;
                 }
+                if (kc >= 112 && kc <= 123) {
+                    // F1 .. F12
+                    return true;
+                }
 
                 return false;
             },

--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -206,6 +206,15 @@ module.exports = Aria.classDefinition({
 
         },
 
+        _dom_onkeydown : function (event) {
+            // On Shift+F10, when AutoComplete has no expand button enabled, we don't open the dropdown, we only close it
+            if (this._isShiftF10Pressed(event) && !this._cfg.expandButton && this._dropdownPopup == null) {
+                return;
+            }
+
+            this.$DropDownTextInput._dom_onkeydown.apply(this, arguments);
+        },
+
         /**
          * Handle events raised by the frame
          * @param {Object} evt

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -292,6 +292,10 @@ module.exports = Aria.classDefinition({
             if (domEvtWrapper.keyCode === 32) {
                 domEvtWrapper.charCode = 32;
             }
+            if (this._isShiftF10Pressed(domEvtWrapper)) {
+                this._toggleDropdown();
+                return;
+            }
             this._handleKey(domEvtWrapper);
         },
 

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 var Aria = require("../../Aria");
+var DomEvent = require("../../DomEvent");
 var ariaWidgetsFormDropDownTrait = require("./DropDownTrait");
 var ariaWidgetsFormTextInput = require("./TextInput");
 var ariaCoreBrowser = require("../../core/Browser");
@@ -120,6 +121,10 @@ module.exports = Aria.classDefinition({
          * keyCode properties). This object may be or may not be an instance of aria.DomEvent.
          */
         _checkKeyStroke : function (event) {
+            if (this._cfg.waiAria && !this._dropdownPopup && event.keyCode === DomEvent.KC_DOWN) {
+                // disable arrow down key when waiAria is enabled and the popup is closed
+                return;
+            }
             var controller = this.controller;
             var cp = this.getCaretPosition();
             if (cp) {

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 var Aria = require("../../Aria");
+var DomEvent = require("../../DomEvent");
 var ariaPopupsPopup = require("../../popups/Popup");
 var ariaUtilsJson = require("../../utils/Json");
 
@@ -223,6 +224,16 @@ module.exports = Aria.classDefinition({
          */
         _handleKey : function (event) {},
 
+        _isShiftF10Pressed : function (event) {
+            if (event.shiftKey && event.keyCode === DomEvent.KC_F10) {
+                if (event.preventDefault) {
+                    event.preventDefault(true);
+                }
+                return true;
+            }
+            return false;
+        },
+
         /**
          * Internal method to handle the keydown event
          * @protected
@@ -230,6 +241,12 @@ module.exports = Aria.classDefinition({
          */
         _dom_onkeydown : function (event) {
             if (event.isSpecialKey) {
+                if (this._isShiftF10Pressed(event)) {
+                    this._toggleDropdown();
+
+                    return;
+                }
+
                 this._handleKey(event);
             }
         },

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -22,7 +22,6 @@ var ariaWidgetsContainerDivStyle = require("../container/DivStyle.tpl.css");
 var ariaWidgetsFormCheckBoxStyle = require("./CheckBoxStyle.tpl.css");
 var ariaWidgetsFormDropDownTextInput = require("./DropDownTextInput");
 
-
 /**
  * Multi-select widget which is a list of checkboxes and labels passed in an array of predefined values
  * @extends aria.widgets.form.DropDownTextInput
@@ -129,16 +128,25 @@ module.exports = Aria.classDefinition({
 
         /**
          * Handle key event not handled by the list, in this case arrow up to close the dropdown
+         *
          * @protected
-         * @param {aria.DomEvent} evt Click event
+         *
+         * @param {Object} information Information about the key event.
+         *
          * @return {Boolean}
          */
-        _keyPressed : function (evt) {
-            if ((evt.keyCode == ariaDomEvent.KC_ARROW_UP) && this._checkCloseItem(evt)) {
+        _keyPressed : function (information) {
+            var event = information.event;
+
+            var isShiftF10Pressed = this._isShiftF10Pressed(event);
+            var isArrowUp = event.keyCode == ariaDomEvent.KC_ARROW_UP;
+
+            if (isShiftF10Pressed || (isArrowUp && this._checkCloseItem(information))) {
                 this.focus();
                 this._toggleDropdown();
                 return true;
             }
+
             return false;
         },
 

--- a/test/aria/widgets/wai/WaiTestSuite.js
+++ b/test/aria/widgets/wai/WaiTestSuite.js
@@ -19,6 +19,7 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
+        this.addTests("test.aria.widgets.wai.dropdown.DropdownTestSuite");
         this.addTests("test.aria.widgets.wai.autoComplete.WaiAutoCompleteTestSuite");
         this.addTests("test.aria.widgets.wai.datePicker.DatePickerTest");
         this.addTests("test.aria.widgets.wai.textInputBased.WaiTextInputBasedTestSuite");

--- a/test/aria/widgets/wai/dropdown/AutoCompleteDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/AutoCompleteDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.AutoCompleteDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'autoComplete'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/Base.js
+++ b/test/aria/widgets/wai/dropdown/Base.js
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsString = require('ariatemplates/utils/String');
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+var ariaResourcesHandlersLCResourcesHandler = require('ariatemplates/resources/handlers/LCResourcesHandler');
+var ariaResourcesHandlersLCRangeResourceHandler = require('ariatemplates/resources/handlers/LCRangeResourceHandler');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.Base',
+
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        // ------------------------------------------------------ initialization
+
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        // ------------------------------------------------- internal attributes
+
+        this._waiAria = null;
+
+        // ---------------------------------------------------------- processing
+
+        var disposableObjects = this._disposableObjects;
+
+        function createResourcesHandler(cls) {
+            var handler = new cls();
+            var suggestions = [
+                {label: 'zero', code: '0'},
+                {label: 'one', code: '1'}
+            ];
+
+            handler.setSuggestions(suggestions);
+            disposableObjects.push(handler);
+
+            return handler;
+        }
+
+        function createSelectOptions() {
+            return [
+                {value: '0', label: '0'},
+                {value: '1', label: '1'}
+            ];
+        }
+
+        var widgetsIds = [
+            'autoComplete',
+            'expandableAutoComplete',
+
+            'multiAutoComplete',
+            'expandableMultiAutoComplete',
+
+            'datePicker',
+
+            'multiSelect',
+            'select',
+            'selectBox'
+        ];
+
+        var widgets = {
+            autoComplete: {
+                configuration: {
+                    id: 'autoComplete',
+                    label: 'AutoComplete: ',
+                    expandButton: false,
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCResourcesHandler)
+                },
+                expectations: {
+                    canBeOpened: false
+                }
+            },
+
+            expandableAutoComplete: {
+                configuration: {
+                    id: 'expandableAutoComplete',
+                    label: 'Expandable AutoComplete: ',
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCResourcesHandler),
+                    expandButton: true
+                }
+            },
+
+
+
+            multiAutoComplete: {
+                configuration: {
+                    id: 'multiAutoComplete',
+                    label: 'MultiAutoComplete: ',
+                    expandButton: false,
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCRangeResourceHandler)
+                },
+                expectations: {
+                    canBeOpened: false
+                }
+            },
+
+            expandableMultiAutoComplete: {
+                configuration: {
+                    id: 'expandableMultiAutoComplete',
+                    label: 'Expandable MultiAutoComplete: ',
+                    expandButton: true,
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCRangeResourceHandler)
+                }
+            },
+
+
+
+            datePicker: {
+                configuration: {
+                    id: 'datePicker',
+                    label: 'DatePicker: '
+                }
+            },
+
+
+
+            multiSelect: {
+                configuration: {
+                    id: 'multiSelect',
+                    label: 'MultiSelect: ',
+
+                    fieldDisplay: 'label',
+                    fieldSeparator: '/',
+                    displayOptions: {},
+
+                    items: createSelectOptions()
+                }
+            },
+
+            select: {
+                configuration: {
+                    id: 'select',
+                    label: 'Select: ',
+                    options: createSelectOptions()
+                },
+                expectations: {
+                    canBeOpenedOnDownArrow: false
+                }
+            },
+
+            selectBox: {
+                configuration: {
+                    id: 'selectBox',
+                    label: 'SelectBox: ',
+                    options: createSelectOptions()
+                }
+            }
+        };
+
+        ariaUtilsArray.forEach(widgetsIds, function (id) {
+            var widget = widgets[id];
+
+            var expectations = widget.expectations;
+            if (expectations == null) {
+                expectations = {};
+            }
+            widget.expectations = expectations;
+
+            var canBeOpened = expectations.canBeOpened;
+            if (canBeOpened == null) {
+                canBeOpened = true;
+            }
+            expectations.canBeOpened = canBeOpened;
+
+            var canBeOpenedOnDownArrow = expectations.canBeOpenedOnDownArrow;
+            if (canBeOpenedOnDownArrow == null) {
+                canBeOpenedOnDownArrow = true;
+            }
+            expectations.canBeOpenedOnDownArrow = canBeOpenedOnDownArrow;
+        });
+
+        var data = {
+            widgetsIds: widgetsIds,
+
+            widgets: widgets
+        };
+
+        this.setTestEnv({
+            data: data,
+            template: 'test.aria.widgets.wai.dropdown.Tpl'
+        });
+    },
+
+    $prototype : {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            // --------------------------------------------------- destructuring
+
+            var idOfWidgetToTest = this.idOfWidgetToTest;
+            var widgetsIds = this._getData().widgetsIds;
+
+            // ------------------------------------------------------ processing
+
+            var ids;
+            if (idOfWidgetToTest != null) {
+                ids = [idOfWidgetToTest];
+            } else {
+                ids = widgetsIds;
+            }
+
+            this._waiAria = false;
+
+            this._localAsyncSequence(function (add) {
+                add(testWidgets);
+                add(testWaiAriaWidgets);
+
+                add(this._createAsyncWrapper(turnWaiAriaOn));
+                add('_refresh');
+
+                add(testWaiAriaWidgets);
+            }, this.end);
+
+            // ------------------------------------------------- local functions
+
+            function _testWidgets(next, testFunction) {
+                this._asyncIterate(
+                    ids,
+                    function (next, id) {
+                        testFunction.call(this, next, id);
+                    },
+                    next,
+                    this
+                );
+            }
+
+            function testWidgets(next) {
+                _testWidgets.call(this, next, this._testWidget);
+            }
+
+            function testWaiAriaWidgets(next) {
+                _testWidgets.call(this, next, this._testWaiAriaWidget);
+            }
+
+            function turnWaiAriaOn() {
+                this._waiAria = true;
+
+                var widgets = this._getData().widgets;
+                ariaUtilsArray.forEach(ids, function (id) {
+                    widgets[id].configuration.waiAria = true;
+                });
+            }
+        },
+
+        _testWaiAriaWidget : function (callback, id) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var waiAria = this._waiAria;
+
+            var expectations = data.widgets[id].expectations;
+            var canBeOpened = expectations.canBeOpened;
+            var canBeOpenedOnDownArrow = expectations.canBeOpenedOnDownArrow;
+
+            // ------------------------------------------------------ processing
+
+            var shouldBeOpenOnDownArrow = !waiAria && canBeOpened && canBeOpenedOnDownArrow;
+
+            var isOpen = this._createIsOpenPredicate(id);
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', id);
+
+                add('_pressDown');
+                if (shouldBeOpenOnDownArrow) {
+                    add(isOpen.waitForTrue);
+                    add('_pressShiftF10');
+                }
+                add(isOpen.waitForFalse);
+            }, callback);
+        },
+
+        _testWidget : function (callback, id) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var waiAria = this._waiAria;
+
+            var expectations = data.widgets[id].expectations;
+            var canBeOpened = expectations.canBeOpened;
+
+            // ------------------------------------------------------ processing
+
+            var isOpen = this._createIsOpenPredicate(id);
+
+            var shouldBeOpenedOnShiftF10 = canBeOpened; // actually only applies to AutoComplete based widgets
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', id);
+
+                add('_pressShiftF10');
+
+                if (shouldBeOpenedOnShiftF10) {
+                    add(isOpen.waitForTrue);
+                    add('_pressShiftF10');
+                } else {
+                    add('_delay');
+                    add(isOpen.assertFalse);
+                    add('_type', 'o'); // to display the suggestion 'one' in order to open the dropdown anyway; moreover, 'o' doesn't change from QWERTY to AZERTY, so there is less risks the tests fails depending on the current input method
+                    add(isOpen.waitForTrue);
+                    add('_pressShiftF10');
+                }
+
+                add(isOpen.waitForFalse);
+
+                if (!shouldBeOpenedOnShiftF10) {
+                    add('_pressBackspace'); // to erase the previously entered character and reset a proper state for testing
+                }
+            }, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Library: dropdown
+        ////////////////////////////////////////////////////////////////////////
+
+        _createIsOpenPredicate : function (id) {
+            return this._createPredicate(function () {
+                return this.isWidgetDropDownPopupOpened(id);
+            }, function (shouldBeTrue) {
+                return ariaUtilsString.substitute(
+                    'Widget "%1" should have its dropdown %2',
+                    [id, shouldBeTrue ? 'open' : 'closed']
+                );
+            }, this);
+        }
+   }
+});

--- a/test/aria/widgets/wai/dropdown/DatePickerDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/DatePickerDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.DatePickerDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'datePicker'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/DropdownTestSuite.js
+++ b/test/aria/widgets/wai/dropdown/DropdownTestSuite.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.DropdownTestSuite',
+    $extends : require('ariatemplates/jsunit/TestSuite'),
+
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests('test.aria.widgets.wai.dropdown.AutoCompleteDropdownTogglingTest');
+        this.addTests('test.aria.widgets.wai.dropdown.DatePickerDropdownTogglingTest');
+        this.addTests('test.aria.widgets.wai.dropdown.MultiAutoCompleteDropdownTogglingTest');
+        this.addTests('test.aria.widgets.wai.dropdown.MultiSelectDropdownTogglingTest');
+        this.addTests('test.aria.widgets.wai.dropdown.SelectDropdownTogglingTest');
+        this.addTests('test.aria.widgets.wai.dropdown.SelectBoxDropdownTogglingTest');
+    }
+});

--- a/test/aria/widgets/wai/dropdown/MultiAutoCompleteDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/MultiAutoCompleteDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.MultiAutoCompleteDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'multiAutoComplete'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/MultiSelectDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/MultiSelectDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.MultiSelectDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'multiSelect'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/SelectBoxDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/SelectBoxDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.SelectBoxDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'selectBox'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/SelectDropdownTogglingTest.js
+++ b/test/aria/widgets/wai/dropdown/SelectDropdownTogglingTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.dropdown.SelectDropdownTogglingTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'select'
+    }
+});

--- a/test/aria/widgets/wai/dropdown/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/Tpl.tpl
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: 'test.aria.widgets.wai.dropdown.Tpl',
+    $hasScript: false
+}}
+
+    {macro main()}
+        {var widgets = this.data.widgets /}
+
+        <div>
+            <a href='#' {id 'before_autoComplete' /}>Before AutoComplete</a>
+            {@aria:AutoComplete widgets.autoComplete.configuration /}
+        </div>
+
+        <div>
+            <a href='#' {id 'before_expandableAutoComplete' /}>Before expandable AutoComplete</a>
+            {@aria:AutoComplete widgets.expandableAutoComplete.configuration /}
+        </div>
+
+
+
+        <div>
+            <a href='#' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
+            {@aria:MultiAutoComplete widgets.multiAutoComplete.configuration /}
+        </div>
+
+        <div>
+            <a href='#' {id 'before_expandableMultiAutoComplete' /}>Before expandable MultiAutoComplete</a>
+            {@aria:MultiAutoComplete widgets.expandableMultiAutoComplete.configuration /}
+        </div>
+
+
+
+        <div>
+            <a href='#' {id 'before_datePicker' /}>Before DatePicker</a>
+            {@aria:DatePicker widgets.datePicker.configuration /}
+        </div>
+
+
+
+        <div>
+            <a href='#' {id 'before_multiSelect' /}>Before MultiSelect</a>
+            {@aria:MultiSelect widgets.multiSelect.configuration /}
+        </div>
+
+        <div>
+            <a href='#' {id 'before_select' /}>Before Select</a>
+            {@aria:Select widgets.select.configuration /}
+        </div>
+
+        <div>
+            <a href='#' {id 'before_selectBox' /}>Before SelectBox</a>
+            {@aria:SelectBox widgets.selectBox.configuration /}
+        </div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
Now dropdowns can be opened and closed by using the keyboard accelerator <kbd>shift+F10</kbd>.

This disables the down arrow key for opening the dropdowns when `waiAria` is activated.

Also, `AutoComplete` based widgets won't have their dropdown opened if they don't have the expand button enabled (however the keys combination will work for closing the dropdown).

This required a little fix: now the full event object is passed to some event handlers functions. This enables giving more information about the event, which is sometimes needed. The API has been kept backward compatible.