### PR TITLE
Adding the autoFocus property on the aria:Dialog widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1988,6 +1988,10 @@ module.exports = Aria.beanDefinitions({
                     $description : "If true, the dialog is always centered in the browser window. Takes priority over xpos and ypos. However, if the dialog box is movable and the user manually moves it, the centered behavior will be switched off.",
                     $default : true
                 },
+                "autoFocus" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the first element in the dialog is automatically focused when the dialog is displayed. By default, it is true for modal dialogs and false for other dialogs."
+                },
                 "xpos" : {
                     $type : "json:Integer",
                     $description : "x position of the top left corner of the dialog box.",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -201,6 +201,9 @@ module.exports = Aria.classDefinition({
             if (!("movableProxy" in cfg)) {
                 cfg.movableProxy = appEnvDialogSettings.movableProxy;
             }
+            if (cfg.autoFocus == null) {
+                cfg.autoFocus = cfg.modal;
+            }
         },
 
         /**
@@ -609,8 +612,10 @@ module.exports = Aria.classDefinition({
 
             this._calculatePosition();
 
-            if (cfg.modal) {
+            if (cfg.autoFocus) {
                 ariaTemplatesNavigationManager.focusFirst(this._domElt);
+            } else if (cfg.modal) {
+                Aria.$window.document.activeElement.blur();
             }
 
             ariaCoreTimer.addCallback({

--- a/test/aria/widgets/container/dialog/DialogTestSuite.js
+++ b/test/aria/widgets/container/dialog/DialogTestSuite.js
@@ -31,6 +31,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.container.dialog.scroll.SetScrollTestCase");
         this.addTests("test.aria.widgets.container.dialog.scroll.OnScrollTestCase");
         this.addTests("test.aria.widgets.container.dialog.focus.FocusInsideModalDialog");
+        this.addTests("test.aria.widgets.container.dialog.autoFocus.AutoFocusTest");
 
         this.addTests("test.aria.widgets.container.dialog.checkStyle.DialogTestCase");
         this.addTests("test.aria.widgets.container.dialog.escKey.DialogTemplateTestCase");

--- a/test/aria/widgets/container/dialog/autoFocus/AutoFocusTest.js
+++ b/test/aria/widgets/container/dialog/autoFocus/AutoFocusTest.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.autoFocus.AutoFocusTest",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            dialogVisible : false,
+            modal : true,
+            autoFocus : null
+        };
+        this.setTestEnv({
+            data : this.data
+        });
+    },
+    $prototype : {
+        waitForMyDialog : function (visible, cb) {
+            this.waitFor({
+                condition: function () {
+                    var dialogInstance = this.getWidgetInstance("myDialog");
+                    var dialogOpen = !! (dialogInstance._popup && dialogInstance._popup.isOpen);
+                    return dialogOpen === visible;
+                },
+                callback: cb
+            });
+        },
+
+        assertFocusInDialog : function () {
+            var fieldInDialog = this.getElementById("fieldInDialog");
+            this.assertTrue(Aria.$window.document.activeElement === fieldInDialog, "The focus should be in the dialog.");
+        },
+
+        assertFocusOutsideDialog : function () {
+            var fieldOutsideDialog = this.getElementById("fieldOutsideDialog");
+            this.assertTrue(Aria.$window.document.activeElement === fieldOutsideDialog, "The focus should be outside the dialog.");
+        },
+
+        assertNothingFocused : function () {
+            var document = Aria.$window.document;
+            var activeElement = document.activeElement;
+            this.assertTrue(activeElement == null || activeElement === document.body, "There should be no element focused.");
+        },
+
+        setPropertiesAndReopenDialog : function (modal, autoFocus, cb) {
+            aria.utils.Json.setValue(this.data, "dialogVisible", false);
+            aria.utils.Json.setValue(this.data, "modal", modal);
+            aria.utils.Json.setValue(this.data, "autoFocus", autoFocus);
+            this.templateCtxt.$refresh();
+            this.waitForMyDialog(false, function () {
+                var fieldOutsideDialog = this.getElementById("fieldOutsideDialog");
+                fieldOutsideDialog.focus();
+                this.waitForDomEltFocus(fieldOutsideDialog, function () {
+                    this.openDialog(cb);
+                });
+            });
+        },
+
+        openDialog : function (cb) {
+            aria.utils.Json.setValue(this.data, "dialogVisible", true);
+            this.waitForMyDialog(true, cb);
+        },
+
+        runTemplateTest : function () {
+            var self = this;
+
+            function step0() {
+                self.assertFocusInDialog();
+                self.setPropertiesAndReopenDialog(true, false, step1);
+            }
+
+            function step1() {
+                self.assertNothingFocused();
+                self.setPropertiesAndReopenDialog(true, true, step2);
+            }
+
+            function step2() {
+                self.assertFocusInDialog();
+                self.setPropertiesAndReopenDialog(false, null, step3);
+            }
+
+            function step3() {
+                self.assertFocusOutsideDialog();
+                self.setPropertiesAndReopenDialog(false, false, step4);
+            }
+
+            function step4() {
+                self.assertFocusOutsideDialog();
+                self.setPropertiesAndReopenDialog(false, true, step5);
+            }
+
+            function step5() {
+                self.assertFocusInDialog();
+                self.end();
+            }
+
+            self.openDialog(step0);
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/autoFocus/AutoFocusTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/autoFocus/AutoFocusTestTpl.tpl
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.autoFocus.AutoFocusTestTpl"
+}}
+	{macro main()}
+        <input {id "fieldOutsideDialog" /} />
+		{@aria:Dialog {
+			id : "myDialog",
+			macro : "dialogContent",
+			modal : data.modal,
+            autoFocus : data.autoFocus,
+			bind : {
+				visible : {
+					to : "dialogVisible",
+					inside : data
+				}
+			}
+		}/}
+	{/macro}
+
+	{macro dialogContent()}
+        <input {id "fieldInDialog" /} />
+	{/macro}
+{/Template}


### PR DESCRIPTION
The new `autoFocus` property allows to control whether the first element in the dialog is automatically focused when the dialog is displayed.
By default, it is true for modal dialogs and false for other dialogs.

(cf #1577)