### PR TITLE
feat WAI-ARIA - Modal dialog

### DIFF
--- a/src/aria/popups/Beans.js
+++ b/src/aria/popups/Beans.js
@@ -148,6 +148,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "The role attribute to add to the container, if wai is activated"
                 },
+                "labelId" : {
+                    $type : "json:String",
+                    $description : "The id of the element to use as a label for accessibility. Used only if wai is activated."
+                },
                 "waiAria" : {
                     $type : "json:Boolean",
                     $description : "If true, accessibility-related DOM attributes are enabled on this container, adding the role attribute if defined."

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1354,6 +1354,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "common:Callback",
                     $description : "Function to be called when the user clicks on the icon."
                 },
+                "label" : {
+                    $type : "json:String",
+                    $description : "The label to use for the icon (used for accessibility only)."
+                },
                 "sourceImage" : {
                     $type : "json:Object",
                     $description : "Configuration for custom image",
@@ -1374,6 +1378,11 @@ module.exports = Aria.beanDefinitions({
                             $default : 16
                         }
                     }
+                },
+                "role" : {
+                    $type : "json:String",
+                    $description : "The role (attribute) to give to the widget (only used when waiAria is true).",
+                    $default : null
                 }
             }
         },
@@ -1973,10 +1982,18 @@ module.exports = Aria.beanDefinitions({
                     $description : "Whether the dialog has a close button in its title bar.",
                     $default : true
                 },
+                "closeLabel" : {
+                    $type : "json:String",
+                    $description : "The label to use for the close icon (can be used in various ways such as for tooltip or accessibility)."
+                },
                 "maximizable" : {
                     $type : "json:Boolean",
                     $description : "Whether the dialog has a maximize button in its title bar. Note that you can set this to false and programatically maximize the Dialog to achieve a fullscreen-only Dialog solution.",
                     $default : false
+                },
+                "maximizeLabel" : {
+                    $type : "json:String",
+                    $description : "The label to use for the maximize icon (can be used in various ways such as for tooltip or accessibility)."
                 },
                 "closeOnMouseClick" : {
                     $type : "json:Boolean",

--- a/src/aria/widgets/GlobalStyle.tpl.css
+++ b/src/aria/widgets/GlobalStyle.tpl.css
@@ -118,7 +118,7 @@
 
 {if aria.core.Browser.isSafari || aria.core.Browser.isChrome || aria.core.Browser.isOpera}
 *:focus {
-    outline: 0;
+    outline-width: 0;
 }
 {/if}
 

--- a/src/aria/widgets/Icon.js
+++ b/src/aria/widgets/Icon.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 var Aria = require("../Aria");
+var ariaUtilsString = require("../utils/String");
 var ariaWidgetsIconStyle = require("./IconStyle.tpl.css");
 var ariaWidgetsWidget = require("./Widget");
 var ariaCoreTplClassLoader = require("../core/TplClassLoader");
@@ -67,7 +68,6 @@ module.exports = Aria.classDefinition({
         ICON_NOT_FOUND : "%1Icon was not found: %2"
     },
     $prototype : {
-
         /**
          * Override widget _widgetMarkup method.
          * @protected
@@ -75,35 +75,95 @@ module.exports = Aria.classDefinition({
          * @param {aria.templates.MarkupWriter} out the html output writer
          */
         _widgetMarkup : function (out) {
-            var cfg = this._cfg;
-            var id = this._domId;
-            var tooltip = cfg.tooltip;
-            var iconInfo = this._iconInfo;
+            // --------------------------------------------------- destructuring
 
-            if (tooltip != null && tooltip !== '') {
-                tooltip = 'title="' + tooltip + '" ';
-            } else {
-                tooltip = '';
+            var cfg = this._cfg;
+            var icon = cfg.icon;
+            var tooltip = cfg.tooltip;
+            var tabIndex = cfg.tabIndex;
+            var waiAria = cfg.waiAria;
+            var label = cfg.label;
+            var role = cfg.role;
+
+            var id = this._domId;
+            var iconInfo = this._iconInfo;
+            var extraAttributes = this.extraAttributes;
+
+            // ------------------------------------------------------ processing
+
+            var attributes = [];
+
+            function addAttribute(key, value) {
+                value = '' + value;
+                value = ariaUtilsString.escapeForHTML(value, {attr: true});
+                attributes.push(key + '="' + value + '"');
             }
 
-            var delegationMarkup = "";
+            // delegationMarkup ------------------------------------------------
+
             var delegateManager = aria.utils.Delegate;
-            if (!this._delegateId) {
-                this._delegateId = delegateManager.add({
+            var delegateId = this._delegateId;
+
+            if (!delegateId) {
+                delegateId = delegateManager.add({
                     fn : this.delegate,
                     scope : this
                 });
+                this._delegateId = delegateId;
             }
-            delegationMarkup = delegateManager.getMarkup(this._delegateId) + " ";
 
-            if (!iconInfo.spriteURL && cfg.icon) {
-                var classes = aria.widgets.AriaSkinInterface.getSkinObject("Icon", cfg.icon.split(":")[0], true).content[cfg.icon.split(":")[1]];
-                out.write(['<span id="', id, '" class="xWidget ', classes, '" ', this.extraAttributes, '></span>'].join(''));
+            var delegationMarkup = delegateManager.getMarkup(delegateId);
+
+            // icon ------------------------------------------------------------
+
+            addAttribute('id', id);
+
+
+            var style = null;
+
+            if (!iconInfo.spriteURL && icon) {
+                var parts = icon.split(":");
+                var skinclass = parts[0];
+                var contentKey = parts[1];
+
+                var classes = aria.widgets.AriaSkinInterface.getSkinObject("Icon", skinclass, true).content[contentKey];
+
+                addAttribute('class', ['xWidget'].concat(classes).join(' '));
             } else {
-                out.write(['<span id="', id, '" class="', this._getIconClasses(iconInfo), '" ', tooltip,
-                        delegationMarkup, 'style="', this._getIconStyle(iconInfo), '" ', this.extraAttributes,
-                        '></span>'].join(''));
+                addAttribute('class', this._getIconClasses(iconInfo));
+                if (tooltip != null && tooltip !== '') {
+                    tooltip = addAttribute('title', tooltip);
+                }
+                attributes.push(delegationMarkup);
+
+                style = this._getIconStyle(iconInfo);
             }
+
+            if (tabIndex != null) {
+                tabIndex = this._calculateTabIndex();
+                addAttribute('tabindex', tabIndex);
+            }
+
+            if (waiAria && label) {
+                addAttribute('aria-label', label);
+            }
+
+            if (waiAria && role) {
+                addAttribute('role', role);
+            }
+
+            if (style) {
+                addAttribute('style', style);
+            }
+
+            attributes.push(extraAttributes);
+
+            attributes = attributes.join(' ');
+            var markup = '<span ' + attributes + '></span>';
+
+            // ---------------------------------------------------------- output
+
+            out.write(markup);
         },
 
         /**
@@ -200,6 +260,16 @@ module.exports = Aria.classDefinition({
                 cssClasses += " xBlock";
             }
             return cssClasses;
+        },
+
+        _dom_onkeydown : function (domEvent) {
+            var keyCode = domEvent.keyCode;
+
+            if (keyCode == domEvent.KC_ENTER || keyCode == domEvent.KC_SPACE) {
+                return this._dom_onclick(domEvent);
+            }
+
+            return true;
         },
 
         /**

--- a/src/aria/widgets/IconStyle.tpl.css
+++ b/src/aria/widgets/IconStyle.tpl.css
@@ -25,6 +25,10 @@
 
         /* Icon class: ${info.skinClassName} */
         {if info.skinClass.spriteURL}
+            .xICN${info.skinClassName}:focus {
+                outline-width: initial;
+            }
+
             .xICN${info.skinClassName} {
                 {if !widgetSettings.middleAlignment}vertical-align:top;{/if}
                 font-size:1px;

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -350,14 +350,11 @@ module.exports = Aria.classDefinition({
          * @private
          */
         _dom_onclick : (ariaCoreBrowser.isChrome || ariaCoreBrowser.isOpera || ariaCoreBrowser.isSafari) ? function (domEvent) {
-            this._keyPressed = false;
-            return; // we don't catch onclick's for buttons on chrome & safari. we catch mouseup's instead
+            // we don't catch onclick's for buttons on chrome & safari. we catch mouseup's instead
         } : function (domEvent) {
-            if (this._keyPressed) {
-                this._keyPressed = false;
-                return;
+            if (!this._keyPressed) {
+                this._performAction(domEvent);
             }
-            this._performAction(domEvent);
         },
 
         /**
@@ -367,14 +364,15 @@ module.exports = Aria.classDefinition({
          */
         _dom_onkeyup : function (domEvt) {
             if (domEvt.keyCode == ariaDomEvent.KC_SPACE || domEvt.keyCode == ariaDomEvent.KC_ENTER) {
-                this._keyPressed = false;
-                this._updateState();
+                if (this._keyPressed) {
+                    this._keyPressed = false;
+                    this._updateState();
 
-                if (!this._performAction(domEvt)) {
-                    domEvt.stopPropagation();
-                    return false;
+                    if (!this._performAction(domEvt)) {
+                        domEvt.stopPropagation();
+                        return false;
+                    }
                 }
-                return true;
             }
             return true;
         },
@@ -394,6 +392,7 @@ module.exports = Aria.classDefinition({
          */
         _dom_onblur : function (domEvt) {
             this._focused = false;
+            this._keyPressed = false;
             this._updateState();
         }
     }

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -104,7 +104,6 @@ module.exports = Aria.classDefinition({
             // Otherwise we will leave the application
             domEvent.preventDefault();
             if (this._keyPressed) {
-                this._keyPressed = false;
                 return false;
             } else {
                 return this.$ActionWidget._dom_onclick.apply(this, arguments);
@@ -118,14 +117,19 @@ module.exports = Aria.classDefinition({
          */
         _dom_onkeyup : function (domEvt) {
             if (domEvt.keyCode == aria.DomEvent.KC_ENTER) {
-
-                if (!this._performAction(domEvt)) {
-                    domEvt.stopPropagation();
-                    return false;
+                if (this._keyPressed) {
+                    this._keyPressed = false;
+                    if (!this._performAction(domEvt)) {
+                        domEvt.stopPropagation();
+                        return false;
+                    }
                 }
-                return true;
             }
             return true;
+        },
+
+        _dom_onblur : function (domEvent) {
+            this._keyPressed = false;
         },
 
         /**

--- a/src/aria/widgets/controllers/DatePickerController.js
+++ b/src/aria/widgets/controllers/DatePickerController.js
@@ -107,6 +107,7 @@ module.exports = Aria.classDefinition({
                         report.displayDropDown = false;
                         report.caretPosStart = 0;
                         report.caretPosEnd = currentValue.length;
+                        report.cancelKeyStroke = true;
                     } else {
                         // transmit the key to the calendar
                         // and cancel the key stroke if the calendar used it

--- a/src/aria/widgets/controllers/DropDownListController.js
+++ b/src/aria/widgets/controllers/DropDownListController.js
@@ -154,6 +154,7 @@ module.exports = Aria.classDefinition({
                     report.text = dataModel.initialInput;
                     // data Model value reset on escape to retain error no escape PTR 05163905
                     report.value = report.text;
+                    report.cancelKeyStroke = true;
                     dataModel.value = null;
                     return report;
 
@@ -203,7 +204,7 @@ module.exports = Aria.classDefinition({
                 // domEvent.KC_ESCAPE for issue#697 on FF
                 if (report && keyCode != domEvent.KC_TAB && keyCode != domEvent.KC_ARROW_DOWN) {
                     // domEvent.KC_ESCAPE for issue#697 on FF
-                    report.cancelKeyStroke = (keyCode == domEvent.KC_ESCAPE);
+                    report.cancelKeyStrokeDefaultBehavior = (keyCode == domEvent.KC_ESCAPE);
                 }
                 return report;
             }

--- a/src/aria/widgets/controllers/MultiSelectController.js
+++ b/src/aria/widgets/controllers/MultiSelectController.js
@@ -301,7 +301,7 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Check for the case when the displayedValue will change This has to be overriden to handle list update on key
+         * Check for the case when the displayedValue will change This has to be overridden to handle list update on key
          * stroke
          * @param {Integer} charCode
          * @param {Integer} keyCode

--- a/src/aria/widgets/controllers/reports/ControllerReport.js
+++ b/src/aria/widgets/controllers/reports/ControllerReport.js
@@ -36,6 +36,12 @@ module.exports = Aria.classDefinition({
         this.cancelKeyStroke = false;
 
         /**
+         * Controller specifies if the keystroke's default behavior has to be canceled
+         * @type Boolean
+         */
+        this.cancelKeyStrokeDefaultBehavior = false;
+
+        /**
          * true if the displayed value matches the begining of a correct value
          * @type Boolean
          */

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -131,8 +131,12 @@ module.exports = Aria.classDefinition({
                 var report = controller.checkKeyStroke(event.charCode, event.keyCode, this.getTextInputField().value, cp.start, cp.end, event);
                 // event may not always be a DomEvent object, that's why we check for the existence of
                 // preventDefault on it
-                if (report && report.cancelKeyStroke && event.preventDefault) {
-                    event.preventDefault(true);
+                if (report && event.preventDefault) {
+                    if (report.cancelKeyStroke) {
+                        event.preventDefault(true);
+                    } else if (report.cancelKeyStrokeDefaultBehavior) {
+                        event.preventDefault(false);
+                    }
                 }
                 this._reactToControllerReport(report, {
                     hasFocus : true

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -147,6 +147,13 @@ module.exports = Aria.classDefinition({
                 return true;
             }
 
+            if (event.keyCode == ariaDomEvent.KC_ESCAPE) {
+                if (this._dropDownOpen) {
+                    this._toggleDropdown();
+                    return true;
+                }
+            }
+
             return false;
         },
 

--- a/test/aria/templates/keyboardNavigation/DialogNavTestCaseTplScript.js
+++ b/test/aria/templates/keyboardNavigation/DialogNavTestCaseTplScript.js
@@ -12,8 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 Aria.tplScriptDefinition({
     $classpath : "test.aria.templates.keyboardNavigation.DialogNavTestCaseTplScript",
+
     $constructor : function () {
         aria.templates.NavigationManager.addGlobalKeyMap({
             key : "ESCAPE",
@@ -25,15 +27,17 @@ Aria.tplScriptDefinition({
             }
         });
     },
+
     $destructor : function () {
         aria.templates.NavigationManager.removeGlobalKeyMap({
             key : "ESCAPE"
         });
     },
+
     $prototype : {
         clickHandler : function () {
-            var holder = this.data.dialog;
-            var propName = "visible";
+            var holder = this.data;
+            var propName = "dialogOpen";
 
             this.$json.setValue(holder, propName, !holder[propName]);
         }

--- a/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
+++ b/test/aria/templates/keyboardNavigation/NavigationTestSuite.js
@@ -21,8 +21,10 @@ Aria.classDefinition({
 
         this.addTests("test.aria.templates.keyboardNavigation.TableNavTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.KeyMapTestCase");
+        this.addTests("test.aria.templates.keyboardNavigation.actionWidgets.ActionWidgetsTest");
         this.addTests("test.aria.templates.keyboardNavigation.enter.EnterTestCase");
-        this.addTests("test.aria.templates.keyboardNavigation.DialogNavTestCase");
         this.addTests("test.aria.templates.keyboardNavigation.bingCompatibility.KeyMapBingCompatibility");
+        this.addTests("test.aria.templates.keyboardNavigation.DialogNavTestCase");
+        this.addTests("test.aria.templates.keyboardNavigation.dialog.Suite");
     }
 });

--- a/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTest.js
+++ b/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTest.js
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsString = require('ariatemplates/utils/String');
+var ariaUtilsJson = require('ariatemplates/utils/Json');
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.actionWidgets.ActionWidgetsTest',
+
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        var data = {
+            countersIds: [
+                'button',
+                'link'
+            ],
+            counters: {
+                button: 0,
+                link: 0
+            },
+            logs: []
+        };
+
+        this.setTestEnv({
+            data: data
+        });
+    },
+
+    $prototype : {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            this._localAsyncSequence(function (add) {
+                // -------------------------------------------------------------
+
+                add('_focusWidget', 'button');
+
+                add('_pushEnter');
+                add('_goToLink');
+                add('_releaseEnter');
+                add('_checkCounters', {
+                    button: 0,
+                    link: 0
+                });
+
+                add('_actionWidget');
+                add('_checkCounters', {
+                    button: 0,
+                    link: 1
+                });
+
+                // -------------------------------------------------------------
+
+                // focus link: done already
+
+                add('_pushEnter');
+                add('_goToButton');
+                add('_releaseEnter');
+                add('_checkCounters', {
+                    button: 0,
+                    link: 0
+                });
+
+                add('_actionWidget');
+                add('_checkCounters', {
+                    button: 1,
+                    link: 0
+                });
+
+                // -------------------------------------------------------------
+
+                // focus button: done already
+
+                add('_pushEnter');
+                add('_goToLink');
+                add('_goToButton');
+                add('_releaseEnter');
+                add('_checkCounters', {
+                    button: 0,
+                    link: 0
+                });
+
+                // -------------------------------------------------------------
+
+                add('_goToLink');
+
+                add('_pushEnter');
+                add('_goToButton');
+                add('_goToLink');
+                add('_releaseEnter');
+                add('_checkCounters', {
+                    button: 0,
+                    link: 0
+                });
+            }, this.end);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Local library
+        ////////////////////////////////////////////////////////////////////////
+
+        _waitForAction : function (callback) {
+            var data = this._getData();
+
+            this._localAsyncSequence(function (add) {
+                add(function (next) {
+                    this.waitFor({
+                        scope: this,
+                        condition: function () {
+                            return data.actionDone;
+                        },
+                        callback: next
+                    });
+                });
+                add(this._createAsyncWrapper(function () {
+                    ariaUtilsJson.setValue(data, 'actionDone', false);
+                }));
+            }, callback);
+        },
+
+        _actionWidget : function (callback) {
+            this._localAsyncSequence(function (add) {
+                add('_pressEnter');
+                add('_waitForAction');
+            }, callback);
+        },
+
+        _goToButton : function (callback) {
+            this._goToActionWidget(callback, 'button', true);
+        },
+
+        _goToLink : function (callback) {
+            this._goToActionWidget(callback, 'link');
+        },
+
+        _goToActionWidget : function (callback, id, reverseDirection) {
+            // -------------------------------------- input arguments processing
+
+            if (reverseDirection == null) {
+                reverseDirection = false;
+            }
+
+            // ------------------------------------------------------ processing
+
+            this._localAsyncSequence(function (add) {
+                if (reverseDirection) {
+                    add('_pressShiftTab');
+                } else {
+                    add('_pressTab');
+                }
+
+                add('_waitForWidgetFocus', id);
+            }, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Assertions
+        ////////////////////////////////////////////////////////////////////////
+
+        _checkCounters : function (callback, expectedCounts) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var countersIds = data.countersIds;
+
+            // ------------------------------------------------------ processing
+
+            ariaUtilsArray.forEach(countersIds, function (id) {
+                var expectedCount = expectedCounts[id];
+
+                this._checkCounter(id, expectedCount);
+            }, this);
+
+            this._resetCounters();
+
+            // ---------------------------------------------------------- return
+
+            callback();
+        },
+
+        _checkCounter : function (id, expected) {
+            var count = this._getData().counters[id];
+
+            var condition = count === expected;
+
+            var message = ariaUtilsString.substitute(
+                'Widget "%1" has not be actioned the expected number of times: %2 instead of %3',
+                [id, count, expected]
+            );
+
+            this.assertTrue(condition, message);
+        },
+
+        _resetCounters : function () {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+
+            var counters = data.counters;
+            var countersIds = data.countersIds;
+
+            // ------------------------------------------------------ processing
+
+            ariaUtilsArray.forEach(countersIds, function (id) {
+                ariaUtilsJson.setValue(counters, id, 0);
+            });
+        }
+   }
+});

--- a/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTpl.tpl
+++ b/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTpl.tpl
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: 'test.aria.templates.keyboardNavigation.actionWidgets.ActionWidgetsTestTpl',
+    $hasScript: true
+}}
+    {macro main()}
+        <a href='#' {id 'before_button' /}>First element</a>
+
+        {call playground() /}
+        {call debug() /}
+    {/macro}
+
+    {macro playground()}
+        {@aria:Button {
+            id: 'button',
+            label: 'Button',
+
+            onclick: {
+                scope: this,
+                fn: this.onButtonAction
+            }
+        }/}
+
+        {@aria:Link {
+            id: 'link',
+            label: 'Link',
+
+            onclick: {
+                scope: this,
+                fn: this.onLinkAction
+            }
+        }/}
+    {/macro}
+
+    {macro debug()}
+        <div>{call counters() /}</div>
+        <div>{call logs() /}</div>
+    {/macro}
+
+    {macro counters()}
+        <ul>
+        {foreach id inArray this.data.countersIds}
+            <li>{call counter(id) /}</li>
+        {/foreach}
+        </ul>
+    {/macro}
+
+    {macro counter(id)}
+        {var counters = this.data.counters /}
+
+        {section {
+            id: 'counter_' + id,
+            macro: {
+                name: 'displayCounter',
+                args: [id]
+            },
+            bindRefreshTo: [{inside: counters, to: id}]
+        } /}
+    {/macro}
+
+    {macro displayCounter(id)}
+        {var counters = this.data.counters /}
+
+        ${id}: ${counters[id]}
+    {/macro}
+
+    {macro logs()}
+        {var logs = this.data.logs /}
+
+        {repeater {
+            id: 'logs',
+            content: logs,
+            loopType: 'array',
+            type: 'ul',
+
+            childSections : {
+                id: 'logEntry',
+                macro: {
+                    name: 'logEntry'
+                },
+
+                type: 'li'
+            }
+        } /}
+    {/macro}
+
+    {macro logEntry(args)}
+        ${args.item}
+    {/macro}
+{/Template}

--- a/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTplScript.js
+++ b/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTplScript.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.actionWidgets.ActionWidgetsTestTplScript',
+
+    $prototype : {
+        onButtonAction : function () {
+            this._onAction('button');
+        },
+
+        onLinkAction : function () {
+            this._onAction('link');
+        },
+
+        _onAction : function (id, logEntry) {
+            // -------------------------------------- input arguments processing
+
+            if (logEntry == null) {
+                logEntry = id;
+            }
+
+            // --------------------------------------------------- destructuring
+
+            var data = this.data;
+            var counters = data.counters;
+            var logs = data.logs;
+
+            // ------------------------------------------------------ processing
+
+            var counter = counters[id];
+            this.$json.setValue(counters, id, counter + 1);
+
+            this.$json.add(logs, logEntry);
+
+            this.$json.setValue(data, 'actionDone', true);
+        }
+    }
+});

--- a/test/aria/templates/keyboardNavigation/dialog/Suite.js
+++ b/test/aria/templates/keyboardNavigation/dialog/Suite.js
@@ -13,20 +13,17 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.Suite',
+    $extends : require('ariatemplates/jsunit/TestSuite'),
+
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
-
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
-
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.Suite');
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/Base.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/Base.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaResourcesHandlersLCResourcesHandler = require('ariatemplates/resources/handlers/LCResourcesHandler');
+var ariaResourcesHandlersLCRangeResourceHandler = require('ariatemplates/resources/handlers/LCRangeResourceHandler');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.Base',
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        // ------------------------------------------------------ initialization
+
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        // ---------------------------------------------------------- processing
+
+        var disposableObjects = this._disposableObjects;
+
+        function createResourcesHandler(cls) {
+            var handler = new cls();
+            var suggestions = [
+                {label: 'zero', code: '0'},
+                {label: 'one', code: '1'}
+            ];
+
+            handler.setSuggestions(suggestions);
+            disposableObjects.push(handler);
+
+            return handler;
+        }
+
+        function createSelectOptions() {
+            return [
+                {value: '0', label: '0'},
+                {value: '1', label: '1'}
+            ];
+        }
+
+        var data = {
+            dialogId: 'dialog',
+            openDialogButtonId: 'openDialog',
+
+            widgetsIds: [
+                'autoComplete',
+                'datePicker',
+                'multiAutoComplete',
+                'multiSelect',
+                'select',
+                'selectBox'
+            ],
+
+            widgetsConfigurations: {
+                autoComplete: {
+                    id: 'autoComplete',
+                    label: 'AutoComplete: ',
+                    expandButton: true,
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCResourcesHandler)
+                },
+
+                datePicker: {
+                    id: 'datePicker',
+                    label: 'DatePicker: '
+                },
+
+                multiAutoComplete: {
+                    id: 'multiAutoComplete',
+                    label: 'MultiAutoComplete: ',
+                    expandButton: true,
+                    resourcesHandler: createResourcesHandler(ariaResourcesHandlersLCRangeResourceHandler)
+                },
+
+                multiSelect: {
+                    id: 'multiSelect',
+                    label: 'MultiSelect: ',
+
+                    fieldDisplay: 'label',
+                    fieldSeparator: '/',
+                    displayOptions: {},
+
+                    items: createSelectOptions()
+                },
+
+                select: {
+                    id: 'select',
+                    label: 'Select: ',
+                    options: createSelectOptions()
+                },
+
+                selectBox: {
+                    id: 'selectBox',
+                    label: 'SelectBox: ',
+                    options: createSelectOptions()
+                }
+            }
+        };
+
+        this.setTestEnv({
+            data: data,
+            template: 'test.aria.templates.keyboardNavigation.dialog.escape.Tpl'
+        });
+    },
+
+    $prototype : {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            // --------------------------------------------------- destructuring
+
+            var idOfWidgetToTest = this.idOfWidgetToTest;
+            var widgetsIds = this._getData().widgetsIds;
+
+            // ------------------------------------------------------ processing
+
+            var ids;
+            if (idOfWidgetToTest != null) {
+                ids = [idOfWidgetToTest];
+            } else {
+                ids = widgetsIds;
+            }
+
+            this._asyncIterate(ids, this._testWidget, this.end);
+        },
+
+        _testWidget : function (callback, id) {
+            var dialogId = this._getData().dialogId;
+
+            var isOpened = this._createIsDialogOpenedPredicate(dialogId);
+
+            this._localAsyncSequence(function (add) {
+                add('_openDialog');
+                add('_openDropdown', id);
+
+                add('_pressEscape');
+                add(isOpened.waitForTrue);
+
+                add('_pressEscape');
+                add(isOpened.waitForFalse);
+            }, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Local library: dialog
+        ////////////////////////////////////////////////////////////////////////
+
+        _openDialog : function (callback) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+
+            var dialogId = data.dialogId;
+            var openDialogButtonId = data.openDialogButtonId;
+
+            // ------------------------------------------------------ processing
+
+            var isOpened = this._createIsDialogOpenedPredicate(dialogId);
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', openDialogButtonId);
+                add('_pressEnter');
+                add(isOpened.waitForTrue);
+            }, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Local library: dropdown
+        ////////////////////////////////////////////////////////////////////////
+
+        _openDropdown : function (callback, id) {
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', id);
+                add('_pressShiftF10');
+                add(function wait(next) {
+                    this.waitForDropDownPopup(id, next);
+                });
+            }, callback);
+        }
+    }
+});

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeAutoComplete.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeAutoComplete.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeAutoComplete',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'autoComplete'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeDatePicker.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeDatePicker.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeDatePicker',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'datePicker'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeMultiAutoComplete.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeMultiAutoComplete.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeMultiAutoComplete',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'multiAutoComplete'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeMultiSelect.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeMultiSelect.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeMultiSelect',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'multiSelect'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeSelect.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeSelect.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeSelect',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'select'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeSelectBox.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/DialogEscapeSelectBox.js
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+var Aria = require('ariatemplates/Aria');
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
 
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeSelectBox',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        idOfWidgetToTest: 'selectBox'
     }
 });

--- a/test/aria/templates/keyboardNavigation/dialog/escape/Suite.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/Suite.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.Suite',
+    $extends : require('ariatemplates/jsunit/TestSuite'),
+
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeAutoComplete');
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeDatePicker');
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeMultiAutoComplete');
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeMultiSelect');
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeSelect');
+        this.addTests('test.aria.templates.keyboardNavigation.dialog.escape.DialogEscapeSelectBox');
+    }
+});

--- a/test/aria/templates/keyboardNavigation/dialog/escape/Tpl.tpl
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/Tpl.tpl
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.Tpl',
+    $hasScript : true
+}}
+
+    {macro main()}
+        <a href='#' {id 'before_' + this.data.openDialogButtonId /}>Before AutoComplete</a>
+
+        {@aria:Button {
+            id: this.data.openDialogButtonId,
+            label: 'Open dialog',
+            onclick: {
+                scope: this,
+                fn: this.openDialog
+            }
+        }/}
+
+        {@aria:Dialog {
+            id : this.data.dialogId,
+            title : 'Dialog',
+            width : 500,
+            maxHeight : 500,
+            modal : true,
+            visible : false,
+            macro : 'dialogContent',
+            bind : {
+                'visible' : {
+                    inside : this.data,
+                    to : 'dialogOpen'
+                }
+            }
+        }/}
+    {/macro}
+
+    {macro dialogContent()}
+        {var configurations = this.data.widgetsConfigurations /}
+
+        <div>
+            <a href='#' {id 'before_autoComplete' /}>Before AutoComplete</a>
+            {@aria:AutoComplete configurations.autoComplete /}
+        </div>
+        <div>
+            <a href='#' {id 'before_datePicker' /}>Before DatePicker</a>
+            {@aria:DatePicker configurations.datePicker /}
+        </div>
+        <div>
+            <a href='#' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
+            {@aria:MultiAutoComplete configurations.multiAutoComplete /}
+        </div>
+        <div>
+            <a href='#' {id 'before_multiSelect' /}>Before MultiSelect</a>
+            {@aria:MultiSelect configurations.multiSelect /}
+        </div>
+        <div>
+            <a href='#' {id 'before_select' /}>Before Select</a>
+            {@aria:Select configurations.select /}
+        </div>
+        <div>
+            <a href='#' {id 'before_selectBox' /}>Before SelectBox</a>
+            {@aria:SelectBox configurations.selectBox /}
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/templates/keyboardNavigation/dialog/escape/TplScript.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/TplScript.js
@@ -13,20 +13,12 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.TplScript',
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
-
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
-
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+    $prototype : {
+        openDialog : function () {
+            this.$json.setValue(this.data, 'dialogOpen', true);
+        }
     }
 });

--- a/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
+++ b/test/aria/widgets/form/multiselect/MultiselectTestSuite.js
@@ -19,25 +19,28 @@ Aria.classDefinition({
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
 
-        this._tests = ["test.aria.widgets.form.multiselect.checkFeatures.MultiSelect",
-                "test.aria.widgets.form.multiselect.emptyMultiSelect.MultiSelect",
-                "test.aria.widgets.form.multiselect.deleteFieldValue.test1.MultiSelect",
-                "test.aria.widgets.form.multiselect.deleteFieldValue.test2.MultiSelect",
-                "test.aria.widgets.form.multiselect.downArrowKey.MultiSelect",
-                "test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey",
-                "test.aria.widgets.form.multiselect.instantbind.InstantBindTestCase",
-                "test.aria.widgets.form.multiselect.invalidcontent.MultiSelect",
-                "test.aria.widgets.form.multiselect.issue223.MultiSelect",
-                "test.aria.widgets.form.multiselect.issue312.Issue312TestSuite",
-                "test.aria.widgets.form.multiselect.issue470.MultiSelect",
-                "test.aria.widgets.form.multiselect.longlist.test1.MsLongList",
-                "test.aria.widgets.form.multiselect.longlist.test2.MsLongList",
-                "test.aria.widgets.form.multiselect.onblur.MultiSelect",
-                "test.aria.widgets.form.multiselect.toggleMultiSelect.MultiSelect",
-                "test.aria.widgets.form.multiselect.upArrowKey.test1.MultiSelect",
-                "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect",
-                "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim",
-                "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase",
-                "test.aria.widgets.form.multiselect.popupReposition.MultiSelect"];
+        this._tests = [
+            "test.aria.widgets.form.multiselect.checkFeatures.MultiSelect",
+            "test.aria.widgets.form.multiselect.emptyMultiSelect.MultiSelect",
+            "test.aria.widgets.form.multiselect.deleteFieldValue.test1.MultiSelect",
+            "test.aria.widgets.form.multiselect.deleteFieldValue.test2.MultiSelect",
+            "test.aria.widgets.form.multiselect.downArrowKey.MultiSelect",
+            "test.aria.widgets.form.multiselect.downArrowKeyPreventDef.MSDownArrowKey",
+            "test.aria.widgets.form.multiselect.instantbind.InstantBindTestCase",
+            "test.aria.widgets.form.multiselect.invalidcontent.MultiSelect",
+            "test.aria.widgets.form.multiselect.issue223.MultiSelect",
+            "test.aria.widgets.form.multiselect.issue312.Issue312TestSuite",
+            "test.aria.widgets.form.multiselect.issue470.MultiSelect",
+            "test.aria.widgets.form.multiselect.longlist.test1.MsLongList",
+            "test.aria.widgets.form.multiselect.longlist.test2.MsLongList",
+            "test.aria.widgets.form.multiselect.onblur.MultiSelect",
+            "test.aria.widgets.form.multiselect.toggleMultiSelect.MultiSelect",
+            "test.aria.widgets.form.multiselect.upArrowKey.test1.MultiSelect",
+            "test.aria.widgets.form.multiselect.upArrowKey.test2.MultiSelect",
+            "test.aria.widgets.form.multiselect.labelsToTrim.LabelsToTrim",
+            "test.aria.widgets.form.multiselect.focusMove.Issue968TestCase",
+            "test.aria.widgets.form.multiselect.popupReposition.MultiSelect",
+            "test.aria.widgets.form.multiselect.escapeKey.MultiSelect"
+        ];
     }
 });

--- a/test/aria/widgets/form/multiselect/escapeKey/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/escapeKey/MultiSelect.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsString = require('ariatemplates/utils/String');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.form.multiselect.escapeKey.MultiSelect',
+
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        this.setTestEnv({
+            data: {
+                id: 'multiSelect'
+            }
+        });
+    },
+
+    $prototype: {
+        runTemplateTest : function () {
+            var id = this._getData().id;
+
+            var isOpen = this._createPredicate(function () {
+                return this.isWidgetDropDownPopupOpened(id);
+            }, function (shouldBeTrue) {
+                return ariaUtilsString.substitute(
+                    'Widget "%1" should have its dropdown %2',
+                    [id, shouldBeTrue ? 'open' : 'closed']
+                );
+            }, this);
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', id);
+
+                add('_pressShiftF10');
+                add(isOpen.waitForTrue);
+
+                add('_pressEscape');
+                add(isOpen.waitForFalse);
+            }, this.end);
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/escapeKey/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/escapeKey/MultiSelectTpl.tpl
@@ -13,20 +13,21 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+{Template {
+    $classpath: 'test.aria.widgets.form.multiselect.escapeKey.MultiSelectTpl',
+    $hasScript: false
+}}
+    {macro main()}
+        <div>
+            <a href='#' {id 'before_' + this.data.id /}>Element before</a>
+            {@aria:MultiSelect {
+                id: this.data.id,
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
-
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
-
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
-    }
-});
+                items: [
+                    {value: '0', label: '0'}
+                ],
+                value: '0'
+            }/}
+        </div>
+    {/macro}
+{/Template}

--- a/test/aria/widgets/wai/WaiTestSuite.js
+++ b/test/aria/widgets/wai/WaiTestSuite.js
@@ -26,6 +26,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.WaiInputTestSuite");
         this.addTests("test.aria.widgets.wai.popup.WaiPopupTestSuite");
         this.addTests("test.aria.widgets.wai.errorlist.ListErrorTestCase");
+        this.addTests("test.aria.widgets.wai.icon.IconTest");
 
     }
 });

--- a/test/aria/widgets/wai/icon/IconTest.js
+++ b/test/aria/widgets/wai/icon/IconTest.js
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsString = require('ariatemplates/utils/String');
+var ariaUtilsJson = require('ariatemplates/utils/Json');
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Model: Icon
+////////////////////////////////////////////////////////////////////////////////
+
+function Icon(id, waiAria, label) {
+    // -------------------------------------------------------------- properties
+
+    this.id = id;
+    this.waiAria = waiAria;
+    this.label = label;
+
+    // -------------------------------------------------------------- attributes
+
+    var configuration = {
+        id: id,
+        waiAria: waiAria,
+
+        icon: 'std:info',
+        onclick: 'incrementCalledCounter',
+
+        label: label
+    };
+
+    if (waiAria) {
+        configuration.role = 'button';
+        configuration.tabIndex = 0;
+    }
+
+    this.configuration = configuration;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.icon.IconTest',
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        // ------------------------------------------------------ initialization
+
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        // ---------------------------------------------------------- processing
+
+        var label = 'waiLabel';
+
+        var icons = [];
+        var iconsIndex = {};
+        function addIcon(id, waiAria) {
+            var icon = new Icon(id, waiAria, label);
+
+            icons.push(icon);
+            iconsIndex[id] = icon;
+        }
+
+        addIcon('waiEnabled', true);
+        addIcon('waiDisabled', false);
+
+        this.setTestEnv({
+            data: {
+                icons: icons,
+                iconsIndex: iconsIndex,
+                calledCounter: 0,
+                label: label
+            }
+        });
+    },
+
+    $prototype: {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            this._asyncIterate(
+                this._getData().icons,
+                this._testIcon,
+                this.end
+            );
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Tests: specific
+        ////////////////////////////////////////////////////////////////////////
+
+        _testIcon : function (callback, icon) {
+            this._localAsyncSequence(function (add) {
+                add('_testLabel', icon);
+                add('_testRole', icon);
+
+                add('_testTabFocus', icon);
+                if (icon.waiAria) {
+                    add('_testActionOnKeyDown', icon);
+                }
+            }, callback);
+        },
+
+        _testLabel : function (callback, icon) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var waiAria = icon.waiAria;
+            var widgetDom = this._getWidgetDom(icon.id);
+
+            // ------------------------------------------------------ processing
+
+            var condition;
+            var message;
+
+            var attributeValue = widgetDom.getAttribute('aria-label');
+            if (waiAria) {
+                var expectedValue = data.label;
+
+                condition = attributeValue === expectedValue;
+                message = ariaUtilsString.substitute(
+                    'The icon should have a label with value "%1", instead it has the value "%2"',
+                    [expectedValue, attributeValue]
+                );
+            } else {
+                condition = !attributeValue;
+                message = ariaUtilsString.substitute(
+                    'The icon should not have a label value, instead it has the value "%1"',
+                    [attributeValue]
+                );
+            }
+
+            this.assertTrue(condition, message);
+
+            // ---------------------------------------------------------- return
+
+            callback();
+        },
+
+        _testRole : function (callback, icon) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var waiAria = icon.waiAria;
+            var widgetDom = this._getWidgetDom(icon.id);
+
+            // ------------------------------------------------------ processing
+
+            var condition;
+            var message;
+
+            var attributeValue = widgetDom.getAttribute('role');
+            if (waiAria) {
+                var expectedValue = 'button';
+
+                condition = attributeValue === expectedValue;
+                message = ariaUtilsString.substitute(
+                    'The icon should have a role with value "%1", instead it has the value "%2"',
+                    [expectedValue, attributeValue]
+                );
+            } else {
+                condition = !attributeValue;
+                message = ariaUtilsString.substitute(
+                    'The icon should not have a role, instead it has the value "%1"',
+                    [attributeValue]
+                );
+            }
+
+            this.assertTrue(condition, message);
+
+            // ---------------------------------------------------------- return
+
+            callback();
+        },
+
+        _testTabFocus : function (callback, icon) {
+            // --------------------------------------------------- destructuring
+
+            var id = icon.id;
+            var waiAria = icon.waiAria;
+
+            // ------------------------------------------------------ processing
+
+            var isIconFocused = this._createPredicate(function () {
+                return this._isWidgetFocused(id);
+            }, function (shouldBeTrue) {
+                return ariaUtilsString.substitute('Icon should%1be focused.', [
+                    shouldBeTrue ? ' ' : ' not '
+                ]);
+            });
+
+            this._localAsyncSequence(function (add) {
+                add('_focusElementBefore', id);
+                add('_pressTab');
+                add('_waitForFocusChange');
+
+                if (waiAria) {
+                    add(isIconFocused.assertTrue);
+                } else {
+                    add(isIconFocused.assertFalse);
+                }
+            }, callback);
+        },
+
+        _testActionOnKeyDown : function (callback, icon) {
+            // --------------------------------------------------- destructuring
+
+            var data = this._getData();
+            var id = icon.id;
+
+            // ------------------------------------------------------ processing
+
+            function check(next) {
+                this.assertTrue(
+                    data.calledCounter === 1,
+                    'Icon action was not properly triggered when pressing action key while focused.'
+                );
+
+                ariaUtilsJson.setValue(data, 'calledCounter', 0);
+            }
+            this._createAsyncWrapper(check);
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', id);
+
+                add('_pressEnter');
+                add(check);
+
+                add('_pressSpace');
+                add(check);
+            }, callback);
+        }
+    }
+});

--- a/test/aria/widgets/wai/icon/IconTestTpl.tpl
+++ b/test/aria/widgets/wai/icon/IconTestTpl.tpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : 'test.aria.widgets.wai.icon.IconTestTpl',
+    $hasScript: true,
+    $css: ['test.aria.widgets.wai.icon.IconTestTplCSS']
+}}
+    {macro main()}
+        <p>
+            With accessibility enabled: <br/>
+            {call widget(this.data.iconsIndex.waiEnabled) /}
+        </p>
+
+        <p>
+            With accessibility disabled: <br/>
+            {call widget(this.data.iconsIndex.waiDisabled) /}
+        </p>
+
+        <p>
+            {section {
+                id: 'sectionCalledCounter',
+                macro: 'displayCalledCounter',
+                bindRefreshTo: [{inside: this.data, to: 'calledCounter'}]
+            }/}
+        </p>
+    {/macro}
+
+    {macro widget(icon)}
+        {var id = icon.id /}
+
+        <a href='#' {id 'before_' + id /}>Element before</a>
+
+        {@aria:Icon icon.configuration /}
+    {/macro}
+
+    {macro displayCalledCounter()}
+        {var counter = this.data.calledCounter /}
+        Action called: ${counter} time(s)
+    {/macro}
+{/Template}

--- a/test/aria/widgets/wai/icon/IconTestTplCSS.tpl.css
+++ b/test/aria/widgets/wai/icon/IconTestTplCSS.tpl.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+  $classpath : 'test.aria.widgets.wai.icon.IconTestTplCSS'
+}}
+    {macro main()}
+        *:focus {
+            outline: solid red 1px;
+        }
+    {/macro}
+{/CSSTemplate}

--- a/test/aria/widgets/wai/icon/IconTestTplScript.js
+++ b/test/aria/widgets/wai/icon/IconTestTplScript.js
@@ -13,20 +13,14 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.wai.icon.IconTestTplScript',
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
+    $dependencies : ['aria.utils.Json'],
 
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
-
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+    $prototype : {
+        incrementCalledCounter : function(){
+            aria.utils.Json.setValue(this.data, 'calledCounter', this.data.calledCounter + 1);
+        }
     }
 });

--- a/test/aria/widgets/wai/popup/WaiPopupTestSuite.js
+++ b/test/aria/widgets/wai/popup/WaiPopupTestSuite.js
@@ -20,6 +20,7 @@ Aria.classDefinition({
         this.$TestSuite.constructor.call(this);
         this.addTests("test.aria.widgets.wai.popup.dialog.DialogTestCase");
         this.addTests("test.aria.widgets.wai.popup.dialog.WaiDialogTestCase");
+        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogTest");
         this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipTestCase");
         this.addTests("test.aria.widgets.wai.popup.errortooltip.WaiErrorTooltipTestCase");
     }

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var EnhancedRobotTestCase = require('test/EnhancedRobotTestCase');
+var ariaJsunitJawsTestCase = require('ariatemplates/jsunit/JawsTestCase');
+
+var Model = require('./Model');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest',
+    $extends : ariaJsunitJawsTestCase,
+
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+
+        this._history = [];
+
+        this.setTestEnv({
+            template : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
+            data : Model.data
+        });
+    },
+
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    $prototype : {
+        $init : function (prototype) {
+            var source = EnhancedRobotTestCase.prototype;
+
+            for (var key in source) {
+                if (source.hasOwnProperty(key) && !prototype.hasOwnProperty(key)) {
+                    prototype[key] = source[key];
+                }
+            }
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            this._localAsyncSequence(function (add) {
+                add('_testDialogs');
+                add('_checkHistory');
+            }, this.end);
+        },
+
+        _checkHistory : function (callback) {
+            var history = this._history;
+
+            history = history.join('\n');
+
+            this.assertJawsHistoryEquals(history, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        _testDialogs : function (callback) {
+            this._asyncIterate(
+                this._getData().dialogs,
+                this._testDialog,
+                callback,
+                this
+            );
+        },
+
+        _testDialog : function (callback, dialog) {
+            // ----------------------------------------------- early termination
+
+            if (!dialog.wai) {
+                callback();
+                return;
+            }
+
+            // ------------------------------------------------------ processing
+
+            this._executeStepsAndWriteHistory(callback, function (step, entry) {
+                step(['click', this.getElementById(dialog.elementBeforeId)]);
+                entry('Element before Link');
+
+                step(['type', null, '[tab]']);
+                entry(dialog.buttonLabel, 'Button');
+
+                step(['type', null, '[enter]']);
+
+                if (!dialog.fullyEmpty) {
+                    entry(dialog.title, 'dialog');
+                    entry(dialog.closeLabel, 'Button');
+
+                    step(['type', null, '[tab]']);
+                    entry(dialog.maximizeLabel, 'Button');
+                }
+
+                step(['type', null, '[escape]']);
+                if (!dialog.fullyEmpty) {
+                    entry(dialog.buttonLabel, 'Button');
+                }
+            });
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Local library
+        ////////////////////////////////////////////////////////////////////////
+
+        _executeStepsAndWriteHistory : function (callback, builder, thisArg) {
+            // -------------------------------------- input arguments processing
+
+            if (thisArg === undefined) {
+                thisArg = this;
+            }
+
+            // --------------------------------------------------- local globals
+
+            var history = this._history;
+            var steps = [];
+
+            function addStep(item) {
+                steps.push(item);
+                steps.push(['pause', 1000]);
+            }
+
+            function addToHistory(item, role) {
+                if (role != null) {
+                    item += ' ' + role;
+                }
+
+                history.push(item);
+            }
+
+            // ------------------------------------------------------ processing
+
+            builder.call(thisArg, addStep, addToHistory, steps, history);
+
+            this.synEvent.execute(steps, {
+                scope: this,
+                fn: callback
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTest.js
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaCoreBrowser = require('ariatemplates/core/Browser');
+var ariaUtilsString = require('ariatemplates/utils/String');
+var ariaUtilsDom = require('ariatemplates/utils/Dom');
+
+var ariaPopupsPopupManager = require('ariatemplates/popups/PopupManager');
+
+var Model = require('./Model');
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Model: Test
+////////////////////////////////////////////////////////////////////////////////
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTest',
+    $extends : require('test/EnhancedRobotTestCase'),
+
+    $constructor : function () {
+        this.$EnhancedRobotTestCase.constructor.call(this);
+
+        if (ariaCoreBrowser.isPhantomJS) {
+            this.defaultTestTimeout = 60000;
+        }
+
+        this.setTestEnv({
+            data: Model.data
+        });
+    },
+
+    $prototype : {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            this._asyncIterate(
+                this._getData().dialogs,
+                this._testDialog,
+                this.end,
+                this
+            );
+        },
+
+        _testDialog : function (callback, dialog) {
+            this._localAsyncSequence(function (add) {
+                // attributes --------------------------------------------------
+
+                add('_testLabel', dialog);
+                add('_testElementsHiding', dialog);
+
+                // behavior ----------------------------------------------------
+
+                add('_testFocusRestoration', dialog);
+                add('_testFocusCycling', dialog);
+
+                add('_testIcons', dialog);
+            }, callback);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Tests: attributes
+        ////////////////////////////////////////////////////////////////////////
+
+        _testLabel : function (callback, dialog) {
+            // --------------------------------------------------- configuration
+
+            var attributeName = 'aria-labelledby';
+
+            // --------------------------------------------------- destructuring
+
+            var wai = dialog.wai;
+            var id = dialog.id;
+            var title = dialog.title;
+
+            // ------------------------------------------------------ processing
+
+            this._localAsyncSequence(function (add) {
+                add('_openDialog', dialog);
+                add(this._createAsyncWrapper(check));
+                add('_closeDialog', dialog);
+            }, callback);
+
+            // ------------------------------------------------- local functions
+
+            function check() {
+                var dialogInstance = this.getWidgetInstance(id);
+                var dialogContainer = dialogInstance._popup.domElement;
+
+                var labelId = dialogContainer.getAttribute(attributeName);
+
+                if (!wai) {
+                    this.assertTrue(
+                        labelId == null,
+                        'Dialog should not have a label.'
+                    );
+                } else {
+                    var labelElement = ariaUtilsDom.getElementById(labelId);
+
+                    this.assertTrue(
+                        labelElement != null,
+                        ariaUtilsString.substitute(
+                            'Label element should exist, id: %1', [
+                            labelId
+                        ])
+                    );
+
+                    var actual = labelElement.textContent;
+                    var expected = title;
+
+                    this.assertTrue(
+                        actual === expected,
+                        ariaUtilsString.substitute(
+                            'Label content is not the expected one: "%1" instead of "%2"', [
+                            actual,
+                            expected
+                        ])
+                    );
+                }
+            }
+        },
+
+        _testElementsHiding : function (callback, dialog) {
+            // --------------------------------------------------- configuration
+
+            var attributeName = 'aria-hidden';
+            var expectedValue = 'true';
+
+            // --------------------------------------------------- destructuring
+
+            var id = dialog.id;
+            var wai = dialog.wai;
+
+            // --------------------------------------------------- local globals
+
+            var widgetDom;
+            var children;
+
+            function getChildrenElements() {
+                widgetDom = this._getWidgetDom(id);
+
+                var parentElement = widgetDom.parentElement;
+                children = parentElement.children;
+            }
+
+            // ------------------------------------------------------ processing
+
+            this._localAsyncSequence(function (add) {
+                add('_openDialog', dialog);
+                add(this._createAsyncWrapper(getChildrenElements));
+                add(this._createAsyncWrapper(checkWhenOpen));
+
+                add('_closeDialog', dialog);
+                add(this._createAsyncWrapper(checkWhenClosed));
+            }, callback);
+
+            // ------------------------------------------------- local functions
+
+            function checkWhenOpen() {
+                checkChildren.call(this, function (element) {
+                    return wai && element !== widgetDom;
+                });
+            }
+
+            function checkWhenClosed() {
+                checkChildren.call(this, function (element) {
+                    return false;
+                });
+            }
+
+            function checkChildren(checkIfShouldBeHidden) {
+                for (var index = 0, length = children.length; index < length; index++) {
+                    var child = children[index];
+
+                    var shouldBeHidden = checkIfShouldBeHidden.call(this, child);
+                    checkElement.call(this, child, shouldBeHidden);
+                }
+            }
+
+            function checkElement(element, shouldBeHidden) {
+                if (shouldBeHidden == null) {
+                    shouldBeHidden = true;
+                }
+
+                var actualValue = element.getAttribute(attributeName);
+
+                var condition;
+                var message;
+
+                if (shouldBeHidden) {
+                    condition = actualValue === expectedValue;
+                    message = 'Element should be hidden.';
+                } else {
+                    condition = !actualValue;
+                    message = 'Element should not be hidden.';
+                }
+
+                this.assertTrue(condition, message);
+            }
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Tests: behavior
+        ////////////////////////////////////////////////////////////////////////
+
+        _testIcons : function (callback, dialog) {
+            var wai = dialog.wai;
+            var fullyEmpty = dialog.fullyEmpty;
+
+            var isOpened = this._createIsDialogOpenedPredicate(dialog.id);
+
+            this._localAsyncSequence(function (add) {
+                if (wai) {
+                    if (!fullyEmpty) {
+                        add('_testMaximizeIcon', dialog);
+                        add('_testCloseIcon', dialog);
+                    } else {
+                        add('_openDialog', dialog);
+                        add('_closeDialog', dialog);
+                        add(isOpened.waitForFalse);
+                    }
+                } else {
+                    add('_openDialog', dialog);
+
+                    add('_pressEnter');
+                    add(isOpened.waitForTrue);
+
+                    add('_closeDialog', dialog);
+                }
+            }, callback);
+        },
+
+        _testMaximizeIcon : function (callback, dialog) {
+            var isMaximized = this._createPredicate(function () {
+                var dialogInstance = this.getWidgetInstance(dialog.id);
+                return dialogInstance._cfg.maximized;
+            }, function (shouldBeTrue) {
+                return ariaUtilsString.substitute('Dialog with id "%1" should%2be maximized.', [
+                    dialog.id,
+                    shouldBeTrue ? ' ' : ' not '
+                ]);
+            });
+
+            this._localAsyncSequence(function (add) {
+                add('_openDialog', dialog);
+                add('_navigateForward');
+
+                add('_pressEnter');
+                add(isMaximized.waitForTrue);
+
+                add('_pressEnter');
+                add(isMaximized.waitForFalse);
+
+                add('_closeDialog', dialog);
+            }, callback);
+        },
+
+        _testCloseIcon : function (callback, dialog) {
+            var isOpened = this._createIsDialogOpenedPredicate(dialog.id);
+
+            this._localAsyncSequence(function (add) {
+                add('_openDialog', dialog);
+
+                add('_pressEnter');
+                add(isOpened.waitForFalse);
+            }, callback);
+        },
+
+        _testFocusRestoration : function (callback, dialog) {
+            // --------------------------------------------------- local globals
+
+            var openingElement;
+
+            function getOpeningElement(next) {
+                this._localAsyncSequence(function (add) {
+                    add('_focusWidget', dialog.buttonId);
+                    add(this._createAsyncWrapper(function () {
+                        openingElement = this._getActiveElement();
+                    }));
+                }, next);
+            }
+
+            // ------------------------------------------------------ processing
+
+            var isOpeningElementFocused = this._createPredicate(function () {
+                return this._getActiveElement() === openingElement;
+            }, function () {
+                return 'Focus was not restored properly on the button after closing the dialog.';
+            });
+
+            this._localAsyncSequence(function (add) {
+                add(getOpeningElement);
+
+                add('_openDialog', dialog);
+                add('_closeDialog', dialog);
+
+                add(isOpeningElementFocused.waitForTrue);
+            }, callback);
+
+        },
+
+        _testFocusCycling : function (callback, dialog) {
+            callback();
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Local library: dialog management
+        ////////////////////////////////////////////////////////////////////////
+
+        _openDialog : function (callback, dialog) {
+            var isOpened = this._createIsDialogOpenedPredicate(dialog.id);
+
+            this._localAsyncSequence(function (add) {
+                add('_focusWidget', dialog.buttonId);
+                add('_pressEnter');
+                add(isOpened.waitForTrue);
+            }, callback);
+        },
+
+        _closeDialog : function (callback, dialog) {
+            var isOpened = this._createIsDialogOpenedPredicate(dialog.id);
+
+            this._localAsyncSequence(function (add) {
+                add('_pressEscape');
+                add(isOpened.waitForFalse);
+            }, callback);
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTpl.tpl
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
+    $hasScript : true
+}}
+
+    {macro main()}
+        {foreach dialog inArray this.data.dialogs}
+            {call displayDialog(dialog) /}
+        {/foreach}
+
+        <div id='container' style='position: absolute; width: 550px; height: 450px; outline: solid black 1px;'>
+            <a href='#'>Focusable</a>
+        </div>
+    {/macro}
+
+    {macro displayDialog(dialog)}
+        <div>
+            <a href='#' {id dialog.elementBeforeId /}>Element before</a>
+
+            {@aria:Button {
+                id: dialog.buttonId,
+
+                label: dialog.buttonLabel,
+                onclick: {
+                    scope: dialog,
+                    fn: dialog.open
+                }
+            }/}
+            </div>
+
+        {@aria:Dialog dialog.configuration /}
+    {/macro}
+
+    {macro dialogContent()}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTplScript.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTplScript.js
@@ -13,20 +13,12 @@
  * limitations under the License.
  */
 
-/**
- * Test suite grouping all tests to be run with Jaws enabled
- */
-Aria.classDefinition({
-    $classpath : "test.JawsTestSuite",
-    $extends : "aria.jsunit.TestSuite",
-    $constructor : function () {
-        this.$TestSuite.constructor.call(this);
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTplScript',
 
-        this.addTests("test.aria.widgets.wai.datePicker.DatePickerJawsTest1");
-
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
-        this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
-
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
+    $prototype : {
+        openDialog : function () {
+            this.$json.setValue(this.data, 'dialogOpen', true);
+        }
     }
 });

--- a/test/aria/widgets/wai/popup/dialog/modal/Model.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/Model.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ariaUtilsJson = require('ariatemplates/utils/Json');
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Model: Dialog
+////////////////////////////////////////////////////////////////////////////////
+
+function Dialog(options) {
+    // -------------------------------------------------------------- properties
+
+    if (options == null) {
+        options = {};
+    }
+
+    var wai = options.wai;
+    if (wai == null) {
+        wai = false;
+    }
+    this.wai = wai;
+
+    var fullyEmpty = options.fullyEmpty;
+    if (fullyEmpty == null) {
+        fullyEmpty = false;
+    }
+    this.fullyEmpty = fullyEmpty;
+
+    var displayInContainer = options.displayInContainer;
+    if (displayInContainer == null) {
+        displayInContainer = false;
+    }
+    this.displayInContainer = displayInContainer;
+
+    var titlePart = '';
+    if (wai) {
+        titlePart += ' (wai)';
+    }
+    if (fullyEmpty) {
+        titlePart += ' (fully empty)';
+    }
+    if (displayInContainer) {
+        titlePart += ' (in container)';
+    }
+
+    var buttonLabel = options.buttonLabel;
+    if (buttonLabel == null) {
+        buttonLabel = 'Open dialog' + titlePart;
+    }
+    this.buttonLabel = buttonLabel;
+
+    // -------------------------------------------------------------- attributes
+
+    var id = 'dialog';
+    if (wai) {
+        id += '_wai';
+    }
+    if (fullyEmpty) {
+        id += '_fullyEmpty';
+    }
+    if (displayInContainer) {
+        id += '_displayInContainer';
+    }
+    this.id = id;
+
+    var buttonId = id + '_button';
+    this.buttonId = buttonId;
+
+    var elementBeforeId = 'before_' + buttonId;
+    this.elementBeforeId = elementBeforeId;
+
+    var title = 'Dialog' + titlePart;
+    this.title = title;
+
+    var visible = false;
+    this.visible = visible;
+
+    var visibleBinding = {
+        inside: this,
+        to: 'visible'
+    };
+    this.visibleBinding = visibleBinding;
+
+    var maximizeLabel = 'maximize me';
+    this.maximizeLabel = maximizeLabel;
+
+    var closeLabel = 'close me';
+    this.closeLabel = closeLabel;
+
+    var configuration = {
+        id: id,
+        waiAria: wai,
+
+        closable: !fullyEmpty,
+        closeLabel: closeLabel,
+        maximizable: !fullyEmpty,
+        maximizeLabel: maximizeLabel,
+        modal: true,
+        width: 400,
+        maxHeight: 500,
+
+        title: title,
+
+        macro: 'dialogContent',
+
+        bind: {
+            'visible': visibleBinding
+        }
+    };
+    if (displayInContainer) {
+        configuration.container = 'container';
+    }
+    this.configuration = configuration;
+}
+
+Dialog.prototype.open = function () {
+    var visibleBinding = this.visibleBinding;
+    ariaUtilsJson.setValue(visibleBinding.inside, visibleBinding.to, true);
+};
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+////////////////////////////////////////////////////////////////////////////////
+
+var dialogs = [];
+dialogs.push(new Dialog({
+    wai: false
+}));
+
+dialogs.push(new Dialog({
+    wai: true
+}));
+dialogs.push(new Dialog({
+    wai: true,
+    fullyEmpty: true
+}));
+dialogs.push(new Dialog({
+    wai: true,
+    displayInContainer: true
+}));
+
+var data = {
+    dialogs: dialogs
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Exports
+////////////////////////////////////////////////////////////////////////////////
+
+exports.Dialog = Dialog;
+exports.data = data;


### PR DESCRIPTION
Mainly brings accessibility to modal dialogs.

# Dialog features

## Label (title)

Added the label information for the popup associated to the modal dialog. It is bound to the element containing the text of the latter's title.

## Accessible icons

Features:

- labels for icons can be specified: they will result in tooltips and aria labels
	- this implied opening a new property for icons allowing the specification of a label (the tooltip one was already existing)
- icons are accessible using tab
- icons react on "return" and "enter" keys, to trigger their action
- the outline is displayed around icons when they are focused

Issues:

- the "initial" outline width for Firefox is too big and does not correspond to the actual native outline we can see on focused elements
- JAWS can't read properly the label of the first inserted icon (first in the DOM)

Glitches:

- the tab order for icons is visually reversed, due to the floating positioning being contrary to the DOM insertion order

## Background elements hiding

Features:

- the elements of the body that visually resides behind the opened modal dialog are now ensured as hidden as long as the dialog is opened. These elements are restored to their previous state when the dialog is closed.

Glitches:

- this feature implementation is limited to a sequence of modal dialogs that are closed in the reverse order of their opening.

## Focus restoration

Features:

- the element that was focused just before opening the dialog is memorized and the focus is put back on it when closing the dialog

Issues:

- the icon reacts on the key down event: if the element on which the focus is put back opens the dialog upon the counterpart key up event (same key), it makes it impossible to close the dialog without having it opened again immediately afterwards

Glitches:

- a simple reference to the native DOM element is internally saved: if this element instance is not present in the DOM anymore, this won't work (usually the case upon AT refreshes)





# Side changes

## fix - Action widgets (Button & Link)

Ensure keyup is handled only if keydown happened.

## feat - WAI-ARIA - Icon

Features:

- icons accept a new property to specify their labels
- icons are accessible using tab
- icons react on "enter" and "space" keys, to trigger their action
- the outline is displayed around icons when they are focused

Issues:

- the "initial" outline width for Firefox is too big and does not correspond to the actual native outline we can see on focused elements

## feat - MultiSelect

The escape key now closes the dropdown.

## fix - Fixed the escape behavior for several widgets

That way widgets such as the dialog can be closed with this key.

Now their associated controllers properly stop the behavior of the events as needed.

I had to add an additional property to the controllers' report model so that they can tell to prevent the default behavior of the browsers without making the propagation stop. This is needed to keep a bug fix while enabling the new behavior on escape.