### PR TITLE
Fix a random error in robot tests which use the backspace key in PhantomJS

### DIFF
--- a/src/aria/jsunit/RobotPhantomJS.js
+++ b/src/aria/jsunit/RobotPhantomJS.js
@@ -80,6 +80,7 @@ module.exports = Aria.classDefinition({
             }
         }
         keys.VK_CTRL = robotKeys.Control;
+        keys.VK_BACK_SPACE = robotKeys.Backspace;
     },
     $statics : {
         MOUSEWHEEL_NOT_IMPLEMENTED : "mouseWheel is not implemented",
@@ -96,7 +97,6 @@ module.exports = Aria.classDefinition({
          */
         KEYS : {
             "VK_SPACE" : " ",
-            "VK_BACK_SPACE" : "\b",
             "VK_MULTIPLY" : "*",
             "VK_PLUS" : "+",
             "VK_MINUS" : "-",


### PR DESCRIPTION
The backspace key was not correctly sent to PhantomJS by `RobotPhantomJS` and this apparently triggered a navigation in the iframe to some previous test, resulting in a timeout.

Especially, for the Aria Templates test campaign, this commit fixes the random issue with `AdaptToContentWidthTest`, when it is run in the same
PhantomJS instance as `ExternalHashNavigationTest`.