### PR TITLE
document.activeElement can be null on some browsers

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -782,7 +782,11 @@ module.exports = Aria.classDefinition({
             if (cfg.autoFocus) {
                 ariaTemplatesNavigationManager.focusFirst(this._domElt);
             } else if (cfg.modal) {
-                Aria.$window.document.activeElement.blur();
+                var document = Aria.$window.document;
+                var activeElement = document.activeElement;
+                if (activeElement && activeElement !== document.body) {
+                    activeElement.blur();
+                }
             }
 
             ariaCoreTimer.addCallback({


### PR DESCRIPTION
This PR fixes an issue with commit ba8b45d (#1591): as `document.activeElement` can be null on some browsers, it is better to check whether it is non-null before using it.