### PR TITLE
fix #1596 fixed the "Modal Dialog" test on IE 8 and made a few more robust

### DIFF
--- a/test/EnhancedRobotTestCase.js
+++ b/test/EnhancedRobotTestCase.js
@@ -253,6 +253,12 @@ var prototype = {
     // Robot: User actions
     ////////////////////////////////////////////////////////////////////////////
 
+    // mouse -------------------------------------------------------------------
+
+    _click : function (callback, element) {
+        this.synEvent.click(element, callback);
+    },
+
     // keyboard ----------------------------------------------------------------
 
     _type : function (callback, sequence) {
@@ -287,8 +293,11 @@ var prototype = {
 
     _focusElement : function (callback, id) {
         var element = this.getElementById(id);
-        element.focus();
-        this._waitForElementFocus(callback, id);
+
+        this._localAsyncSequence(function (add) {
+            add('_click', element);
+            add('_waitForElementFocus', id);
+        }, callback);
     },
 
     _focusElementBefore : function (callback, id) {

--- a/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTpl.tpl
+++ b/test/aria/templates/keyboardNavigation/actionWidgets/ActionWidgetsTestTpl.tpl
@@ -18,7 +18,7 @@
     $hasScript: true
 }}
     {macro main()}
-        <a href='#' {id 'before_button' /}>First element</a>
+        <a tabindex='0' {id 'before_button' /}>First element</a>
 
         {call playground() /}
         {call debug() /}

--- a/test/aria/templates/keyboardNavigation/dialog/escape/Base.js
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/Base.js
@@ -150,6 +150,7 @@ module.exports = Aria.classDefinition({
                 add('_openDropdown', id);
 
                 add('_pressEscape');
+                add('_delay'); // both in order to wait for the widget's dropdown to close but also to check that in the end it doesn't trigger the closing of the dialog
                 add(isOpened.waitForTrue);
 
                 add('_pressEscape');

--- a/test/aria/templates/keyboardNavigation/dialog/escape/Tpl.tpl
+++ b/test/aria/templates/keyboardNavigation/dialog/escape/Tpl.tpl
@@ -14,12 +14,12 @@
  */
 
 {Template {
-    $classpath : 'test.aria.templates.keyboardNavigation.dialog.escape.Tpl',
-    $hasScript : true
+    $classpath: 'test.aria.templates.keyboardNavigation.dialog.escape.Tpl',
+    $hasScript: true
 }}
 
     {macro main()}
-        <a href='#' {id 'before_' + this.data.openDialogButtonId /}>Before AutoComplete</a>
+        <a tabindex='0' {id 'before_' + this.data.openDialogButtonId /}>Before AutoComplete</a>
 
         {@aria:Button {
             id: this.data.openDialogButtonId,
@@ -51,27 +51,27 @@
         {var configurations = this.data.widgetsConfigurations /}
 
         <div>
-            <a href='#' {id 'before_autoComplete' /}>Before AutoComplete</a>
+            <a tabindex='0' {id 'before_autoComplete' /}>Before AutoComplete</a>
             {@aria:AutoComplete configurations.autoComplete /}
         </div>
         <div>
-            <a href='#' {id 'before_datePicker' /}>Before DatePicker</a>
+            <a tabindex='0' {id 'before_datePicker' /}>Before DatePicker</a>
             {@aria:DatePicker configurations.datePicker /}
         </div>
         <div>
-            <a href='#' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
+            <a tabindex='0' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
             {@aria:MultiAutoComplete configurations.multiAutoComplete /}
         </div>
         <div>
-            <a href='#' {id 'before_multiSelect' /}>Before MultiSelect</a>
+            <a tabindex='0' {id 'before_multiSelect' /}>Before MultiSelect</a>
             {@aria:MultiSelect configurations.multiSelect /}
         </div>
         <div>
-            <a href='#' {id 'before_select' /}>Before Select</a>
+            <a tabindex='0' {id 'before_select' /}>Before Select</a>
             {@aria:Select configurations.select /}
         </div>
         <div>
-            <a href='#' {id 'before_selectBox' /}>Before SelectBox</a>
+            <a tabindex='0' {id 'before_selectBox' /}>Before SelectBox</a>
             {@aria:SelectBox configurations.selectBox /}
         </div>
     {/macro}

--- a/test/aria/widgets/form/multiselect/escapeKey/MultiSelectTpl.tpl
+++ b/test/aria/widgets/form/multiselect/escapeKey/MultiSelectTpl.tpl
@@ -19,7 +19,7 @@
 }}
     {macro main()}
         <div>
-            <a href='#' {id 'before_' + this.data.id /}>Element before</a>
+            <a tabindex='0' {id 'before_' + this.data.id /}>Element before</a>
             {@aria:MultiSelect {
                 id: this.data.id,
 

--- a/test/aria/widgets/wai/dropdown/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/Tpl.tpl
@@ -22,48 +22,48 @@
         {var widgets = this.data.widgets /}
 
         <div>
-            <a href='#' {id 'before_autoComplete' /}>Before AutoComplete</a>
+            <a tabindex='0' {id 'before_autoComplete' /}>Before AutoComplete</a>
             {@aria:AutoComplete widgets.autoComplete.configuration /}
         </div>
 
         <div>
-            <a href='#' {id 'before_expandableAutoComplete' /}>Before expandable AutoComplete</a>
+            <a tabindex='0' {id 'before_expandableAutoComplete' /}>Before expandable AutoComplete</a>
             {@aria:AutoComplete widgets.expandableAutoComplete.configuration /}
         </div>
 
 
 
         <div>
-            <a href='#' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
+            <a tabindex='0' {id 'before_multiAutoComplete' /}>Before MultiAutoComplete</a>
             {@aria:MultiAutoComplete widgets.multiAutoComplete.configuration /}
         </div>
 
         <div>
-            <a href='#' {id 'before_expandableMultiAutoComplete' /}>Before expandable MultiAutoComplete</a>
+            <a tabindex='0' {id 'before_expandableMultiAutoComplete' /}>Before expandable MultiAutoComplete</a>
             {@aria:MultiAutoComplete widgets.expandableMultiAutoComplete.configuration /}
         </div>
 
 
 
         <div>
-            <a href='#' {id 'before_datePicker' /}>Before DatePicker</a>
+            <a tabindex='0' {id 'before_datePicker' /}>Before DatePicker</a>
             {@aria:DatePicker widgets.datePicker.configuration /}
         </div>
 
 
 
         <div>
-            <a href='#' {id 'before_multiSelect' /}>Before MultiSelect</a>
+            <a tabindex='0' {id 'before_multiSelect' /}>Before MultiSelect</a>
             {@aria:MultiSelect widgets.multiSelect.configuration /}
         </div>
 
         <div>
-            <a href='#' {id 'before_select' /}>Before Select</a>
+            <a tabindex='0' {id 'before_select' /}>Before Select</a>
             {@aria:Select widgets.select.configuration /}
         </div>
 
         <div>
-            <a href='#' {id 'before_selectBox' /}>Before SelectBox</a>
+            <a tabindex='0' {id 'before_selectBox' /}>Before SelectBox</a>
             {@aria:SelectBox widgets.selectBox.configuration /}
         </div>
     {/macro}

--- a/test/aria/widgets/wai/icon/IconTestTpl.tpl
+++ b/test/aria/widgets/wai/icon/IconTestTpl.tpl
@@ -14,7 +14,7 @@
  */
 
 {Template {
-    $classpath : 'test.aria.widgets.wai.icon.IconTestTpl',
+    $classpath: 'test.aria.widgets.wai.icon.IconTestTpl',
     $hasScript: true,
     $css: ['test.aria.widgets.wai.icon.IconTestTplCSS']
 }}
@@ -41,7 +41,7 @@
     {macro widget(icon)}
         {var id = icon.id /}
 
-        <a href='#' {id 'before_' + id /}>Element before</a>
+        <a tabindex='0' {id 'before_' + id /}>Element before</a>
 
         {@aria:Icon icon.configuration /}
     {/macro}

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTest.js
@@ -125,6 +125,10 @@ module.exports = Aria.classDefinition({
                     );
 
                     var actual = labelElement.textContent;
+                    if (actual == null) {
+                        actual = labelElement.innerText;
+                    }
+
                     var expected = title;
 
                     this.assertTrue(

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestTpl.tpl
@@ -14,8 +14,8 @@
  */
 
 {Template {
-    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
-    $hasScript : true
+    $classpath: 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
+    $hasScript: true
 }}
 
     {macro main()}
@@ -24,13 +24,13 @@
         {/foreach}
 
         <div id='container' style='position: absolute; width: 550px; height: 450px; outline: solid black 1px;'>
-            <a href='#'>Focusable</a>
+            <a tabindex='0'>Focusable</a>
         </div>
     {/macro}
 
     {macro displayDialog(dialog)}
         <div>
-            <a href='#' {id dialog.elementBeforeId /}>Element before</a>
+            <a tabindex='0' {id dialog.elementBeforeId /}>Element before</a>
 
             {@aria:Button {
                 id: dialog.buttonId,


### PR DESCRIPTION
- now links are focused by clicking on them instead of using the programmatic way `.focus`
- all links used to get focus have now a `tabindex` property and no `href`, in order to avoid unwanted navigation or else
- made the "Dialog escape test" more robust
- fixed the "Modal Dialog" test on IE 8 by using the proper element's property