### PR TITLE
In aria.DomEvent, on Edge, isGecko was incorrectly true

### DIFF
--- a/src/aria/DomEvent.js
+++ b/src/aria/DomEvent.js
@@ -88,7 +88,7 @@ var ariaCoreBrowser = require("./core/Browser");
         $onload : function () {
             // Browser shortcuts are done in the $onload which is executed only once
             isIE8orLess = (ariaCoreBrowser.isIE7 || ariaCoreBrowser.isIE8);
-            isGecko = !(ariaCoreBrowser.isIE || ariaCoreBrowser.isOpera || ariaCoreBrowser.isChrome || ariaCoreBrowser.isSafari || ariaCoreBrowser.isPhantomJS);
+            isGecko = ariaCoreBrowser.isGecko;
         },
         /**
          * DomEvent constructor. It is advised to use the getWrapper static method instead of the constructor,


### PR DESCRIPTION
This PR changes the value of the `isGecko` variable in `aria.DomEvent`, which was incorrectly true on Edge. This fixes several regressions introduced on Edge after changing `isSpecialKey` in commit e631660e271afe9352ddc36aa2c53873dc372a98.