### PR TITLE
Using the robot instead of Syn to fix several tests on Edge

### DIFF
--- a/test/aria/widgets/form/multiselect/MultiSelectRobotTestCase.js
+++ b/test/aria/widgets/form/multiselect/MultiSelectRobotTestCase.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var MultiSelectTemplateTestCase = require("ariatemplates/jsunit/MultiSelectTemplateTestCase");
+
+module.exports = Aria.classDefinition({
+    $classpath: "test.aria.widgets.form.multiselect.MultiSelectRobotTestCase",
+    $extends: require("ariatemplates/jsunit/RobotTestCase"),
+    $prototype: {
+        $init : function (prototype) {
+            var source = MultiSelectTemplateTestCase.prototype;
+
+            for (var key in source) {
+                if (source.hasOwnProperty(key) && !prototype.hasOwnProperty(key)) {
+                    prototype[key] = source[key];
+                }
+            }
+        }
+    }
+});

--- a/test/aria/widgets/form/multiselect/downArrowKey/MultiSelect.js
+++ b/test/aria/widgets/form/multiselect/downArrowKey/MultiSelect.js
@@ -15,9 +15,9 @@
 
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.multiselect.downArrowKey.MultiSelect",
-    $extends : "aria.jsunit.MultiSelectTemplateTestCase",
+    $extends : "test.aria.widgets.form.multiselect.MultiSelectRobotTestCase",
     $constructor : function () {
-        this.$MultiSelectTemplateTestCase.constructor.call(this);
+        this.$MultiSelectRobotTestCase.constructor.call(this);
         this.inputField = null;
     },
     $prototype : {

--- a/test/aria/widgets/form/multiselect/longlist/test1/MsLongList.js
+++ b/test/aria/widgets/form/multiselect/longlist/test1/MsLongList.js
@@ -15,10 +15,10 @@
 
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.multiselect.longlist.test1.MsLongList",
-    $extends : "aria.jsunit.MultiSelectTemplateTestCase",
+    $extends : "test.aria.widgets.form.multiselect.MultiSelectRobotTestCase",
     $dependencies : ["aria.utils.FireDomEvent", "aria.DomEvent"],
     $constructor : function () {
-        this.$MultiSelectTemplateTestCase.constructor.call(this);
+        this.$MultiSelectRobotTestCase.constructor.call(this);
         this.inputField = null;
     },
     $prototype : {
@@ -52,17 +52,7 @@ Aria.classDefinition({
         },
 
         arrowDown2 : function () {
-            var cbs = this.tr.getElementsByTagName('input');
-            var domForAction = cbs[0].parentNode;
-            aria.utils.FireDomEvent.fireEvent('keydown', domForAction, {
-                keyCode : 40
-            });
-            var that = this;
-            setTimeout(function () {
-                that.checkFocus();
-            }, 200);
-            // Doesn't work for multiselect navigation
-            // this._MSType(domForAction, "[down]", this.checkFocus, this);
+            this._MSType(null, "[down]", this.checkFocus, this);
         },
 
         checkFocus : function () {

--- a/test/aria/widgets/form/multiselect/longlist/test2/MsLongList.js
+++ b/test/aria/widgets/form/multiselect/longlist/test2/MsLongList.js
@@ -15,9 +15,9 @@
 
 Aria.classDefinition({
     $classpath : "test.aria.widgets.form.multiselect.longlist.test2.MsLongList",
-    $extends : "aria.jsunit.MultiSelectTemplateTestCase",
+    $extends : "test.aria.widgets.form.multiselect.MultiSelectRobotTestCase",
     $constructor : function () {
-        this.$MultiSelectTemplateTestCase.constructor.call(this);
+        this.$MultiSelectRobotTestCase.constructor.call(this);
         this.inputField = null;
     },
     $prototype : {
@@ -45,8 +45,7 @@ Aria.classDefinition({
         },
 
         _closeMS : function () {
-            var checkBox = this.getWidgetInstance("listItem0").getDom();
-            this.synEvent.type(checkBox, "[space][up]", {
+            this.synEvent.type(null, "[space][up]", {
                 fn : this._onMsFocus,
                 scope : this
             });

--- a/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
+++ b/test/aria/widgets/wai/autoComplete/AutoCompleteBaseTest.js
@@ -19,9 +19,9 @@ var fnUtils = require("ariatemplates/utils/Function");
 
 module.exports = Aria.classDefinition({
     $classpath : "test.aria.widgets.wai.autoComplete.AutoCompleteBaseTest",
-    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $extends : require("ariatemplates/jsunit/RobotTestCase"),
     $constructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
+        this.$RobotTestCase.constructor.call(this);
 
         this.setTestEnv({
             template : this.myTemplate


### PR DESCRIPTION
`aria.utils.SynEvents` does not seem to correctly simulate key events on Edge, so this commit changes the following tests to use the robot, which fixes them:
- `test.aria.widgets.form.multiselect.longlist.test1.MsLongList`
- `test.aria.widgets.form.multiselect.longlist.test2.MsLongList`
- `test.aria.widgets.form.multiselect.downArrowKey.MultiSelect`
- `test.aria.widgets.wai.autoComplete.AutoCompleteWaiTestCase`
- `test.aria.widgets.wai.autoComplete.AutoCompleteGlobalNonWaiTestCase`
- `test.aria.widgets.wai.autoComplete.AutoCompleteGlobalWaiTestCase`
- `test.aria.widgets.wai.autoComplete.AutoCompleteNonWaiTestCase`