### PR TITLE
Random failures of test.aria.core.environment.Customizations

### DIFF
--- a/test/aria/core/environment/Customizations.js
+++ b/test/aria/core/environment/Customizations.js
@@ -17,11 +17,8 @@ Aria.classDefinition({
     $classpath : "test.aria.core.environment.Customizations",
     $extends : "aria.jsunit.TestCase",
     $dependencies : ["aria.core.environment.Customizations"],
-    $constructor : function () {
-        this.$TestCase.constructor.call(this);
-    },
     $prototype : {
-        testAsyncDescriptorLoaded : function () {
+        testAsyncDescriptorLoadedMissing : function () {
             // Customization descriptor does not exist
             aria.core.environment.Customizations.$onOnce({
                 "descriptorLoaded" : {
@@ -31,7 +28,16 @@ Aria.classDefinition({
             });
             aria.core.environment.Customizations.setCustomizations(Aria.rootFolderPath
                     + "ExternalCustomizationsFile.json");
+        },
 
+        _loadErrorFile : function () {
+            this.assertTrue(aria.core.environment.Customizations.descriptorLoaded());
+            this.assertErrorInLogs(aria.core.environment.Customizations.DESCRIPTOR_NOT_LOADED);
+            aria.core.environment.Customizations.setCustomizations({}); // remove any customization
+            this.notifyTestEnd('testAsyncDescriptorLoadedMissing');
+        },
+
+        testAsyncDescriptorLoaded : function () {
             // Customization descriptor ok
             aria.core.environment.Customizations.$onOnce({
                 "descriptorLoaded" : {
@@ -41,12 +47,6 @@ Aria.classDefinition({
             });
             aria.core.environment.Customizations.setCustomizations(Aria.rootFolderPath
                     + "test/aria/core/test/ExternalCustomizationsFile.json");
-        },
-
-        _loadErrorFile : function () {
-            this.assertTrue(aria.core.environment.Customizations.descriptorLoaded());
-            this.assertErrorInLogs(aria.core.environment.Customizations.DESCRIPTOR_NOT_LOADED);
-            aria.core.environment.Customizations.setCustomizations({}); // remove any customization
         },
 
         _afterExternalCustomFile : function () {


### PR DESCRIPTION
This PR fixes random failures of `test.aria.core.environment.Customizations`, by waiting for the load of the first customization descriptor to be finished before loading another one.

To be sure that this PR fixes the issue, I have run several times in a loop a short campaign containing `test.aria.core.environment.Customizations` on travis-ci until the campaign fails.
- Without this fix, there is a failing campaign in less than 5 min, after 41 iterations in [this travis build](https://travis-ci.org/divdavem/ariatemplates/builds/109917850)
- With this fix, there is no failing campaign after more than 30 min and 600 iterations in [this travis build](https://travis-ci.org/divdavem/ariatemplates/builds/109920542)