### PR TITLE
Enabling travis-ci cache for node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - 4.2
 sudo: false
+cache:
+  directories:
+    - node_modules
 before_install:
 # Settings needed for graphic output in Firefox
   - export DISPLAY=:99.0


### PR DESCRIPTION
This commit enables caching on Travis for the node_modules directory,
cf https://docs.travis-ci.com/user/caching/#Caching-directories-%28Bundler%2C-dependencies%29

For example, from [this build](https://travis-ci.org/divdavem/ariatemplates/builds/109921779) (which had no cache available) to [this one](https://travis-ci.org/divdavem/ariatemplates/builds/109928305) (which could reuse the cache), there was a gain of 57s (= 146 - 89) for the `npm install` phase, and downloading the cache took less than 3s.