### PR TITLE
fix #1601 fixed the wai Modal dialog (test & implementation) and made a few more robust

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -691,7 +691,8 @@ module.exports = Aria.classDefinition({
                 for (var index = 0, length = children.length; index < length; index++) {
                     var child = children[index];
 
-                    if (!child.hasAttribute(attributeName)) {
+                    var attributeNode = child.getAttributeNode(attributeName);
+                    if (attributeNode == null || attributeNode.nodeValue == null) {
                         child.setAttribute(attributeName, attributeValue);
                         hiddenElements.push(child);
                     }

--- a/test/EnhancedRobotTestCase.js
+++ b/test/EnhancedRobotTestCase.js
@@ -295,6 +295,7 @@ var prototype = {
         var element = this.getElementById(id);
 
         this._localAsyncSequence(function (add) {
+            add('_delay');
             add('_click', element);
             add('_waitForElementFocus', id);
         }, callback);

--- a/test/aria/widgets/wai/popup/dialog/modal/Base.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/Base.js
@@ -30,18 +30,15 @@ var Model = require('./Model');
 ////////////////////////////////////////////////////////////////////////////////
 
 module.exports = Aria.classDefinition({
-    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTest',
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.Base',
     $extends : require('test/EnhancedRobotTestCase'),
 
     $constructor : function () {
         this.$EnhancedRobotTestCase.constructor.call(this);
 
-        if (ariaCoreBrowser.isPhantomJS) {
-            this.defaultTestTimeout = 60000;
-        }
-
         this.setTestEnv({
-            data: Model.data
+            data: Model.buildData(this.indexOfWidgetToTest),
+            template: 'test.aria.widgets.wai.popup.dialog.modal.Tpl'
         });
     },
 
@@ -51,8 +48,10 @@ module.exports = Aria.classDefinition({
         ////////////////////////////////////////////////////////////////////////
 
         runTemplateTest : function () {
+            var dialogs = this._getData().dialogs;
+
             this._asyncIterate(
-                this._getData().dialogs,
+                dialogs,
                 this._testDialog,
                 this.end,
                 this
@@ -163,6 +162,9 @@ module.exports = Aria.classDefinition({
                 widgetDom = this._getWidgetDom(id);
 
                 var parentElement = widgetDom.parentElement;
+                if (parentElement == null) {
+                    parentElement = widgetDom.parentNode;
+                }
                 children = parentElement.children;
             }
 

--- a/test/aria/widgets/wai/popup/dialog/modal/FirstTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/FirstTest.js
@@ -13,12 +13,16 @@
  * limitations under the License.
  */
 
-Aria.tplScriptDefinition({
-    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTplScript',
+var Aria = require('ariatemplates/Aria');
 
-    $prototype : {
-        openDialog : function () {
-            this.$json.setValue(this.data, 'dialogOpen', true);
-        }
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.FirstTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        indexOfWidgetToTest: 0
     }
 });

--- a/test/aria/widgets/wai/popup/dialog/modal/FourthTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/FourthTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.FourthTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        indexOfWidgetToTest: 3
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
@@ -33,7 +33,7 @@ module.exports = Aria.classDefinition({
 
         this.setTestEnv({
             template : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
-            data : Model.data
+            data : Model.buildData()
         });
     },
 

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestSuite.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogTestSuite.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Amadeus s.a.s.
+ * Copyright 2016 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,15 +13,20 @@
  * limitations under the License.
  */
 
-Aria.classDefinition({
-    $classpath : "test.aria.widgets.wai.popup.WaiPopupTestSuite",
-    $extends : "aria.jsunit.TestSuite",
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestSuite',
+    $extends : require('ariatemplates/jsunit/TestSuite'),
+
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
-        this.addTests("test.aria.widgets.wai.popup.dialog.DialogTestCase");
-        this.addTests("test.aria.widgets.wai.popup.dialog.WaiDialogTestCase");
-        this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestSuite");
-        this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipTestCase");
-        this.addTests("test.aria.widgets.wai.popup.errortooltip.WaiErrorTooltipTestCase");
+
+        this.addTests('test.aria.widgets.wai.popup.dialog.modal.FirstTest');
+        this.addTests('test.aria.widgets.wai.popup.dialog.modal.SecondTest');
+        this.addTests('test.aria.widgets.wai.popup.dialog.modal.ThirdTest');
+        this.addTests('test.aria.widgets.wai.popup.dialog.modal.FourthTest');
     }
 });

--- a/test/aria/widgets/wai/popup/dialog/modal/Model.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/Model.js
@@ -139,26 +139,33 @@ Dialog.prototype.open = function () {
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-var dialogs = [];
-dialogs.push(new Dialog({
-    wai: false
-}));
+function buildData(index) {
+    var dialogs = [];
 
-dialogs.push(new Dialog({
-    wai: true
-}));
-dialogs.push(new Dialog({
-    wai: true,
-    fullyEmpty: true
-}));
-dialogs.push(new Dialog({
-    wai: true,
-    displayInContainer: true
-}));
+    dialogs.push(new Dialog({
+        wai: false
+    }));
 
-var data = {
-    dialogs: dialogs
-};
+    dialogs.push(new Dialog({
+        wai: true
+    }));
+    dialogs.push(new Dialog({
+        wai: true,
+        fullyEmpty: true
+    }));
+    dialogs.push(new Dialog({
+        wai: true,
+        displayInContainer: true
+    }));
+
+    if (index != null) {
+        dialogs = [dialogs[index]];
+    }
+
+    return {
+       dialogs: dialogs
+    };
+}
 
 
 
@@ -167,4 +174,4 @@ var data = {
 ////////////////////////////////////////////////////////////////////////////////
 
 exports.Dialog = Dialog;
-exports.data = data;
+exports.buildData = buildData;

--- a/test/aria/widgets/wai/popup/dialog/modal/SecondTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/SecondTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.SecondTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        indexOfWidgetToTest: 1
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/ThirdTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ThirdTest.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.ThirdTest',
+
+    $extends : require('./Base'),
+
+    $statics : {
+        indexOfWidgetToTest: 2
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/Tpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/modal/Tpl.tpl
@@ -14,7 +14,7 @@
  */
 
 {Template {
-    $classpath: 'test.aria.widgets.wai.popup.dialog.modal.ModalDialogTestTpl',
+    $classpath: 'test.aria.widgets.wai.popup.dialog.modal.Tpl',
     $hasScript: true
 }}
 

--- a/test/aria/widgets/wai/popup/dialog/modal/TplScript.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/TplScript.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.modal.TplScript',
+
+    $prototype : {
+        openDialog : function () {
+            this.$json.setValue(this.data, 'dialogOpen', true);
+        }
+    }
+});


### PR DESCRIPTION
- the biggest change is that I have split the wai Modal Dialog test to allow parallelization and avoid timeouts too (I therefore removed the timeout increase for PhantomJS)
- made some tests even more robust by adding a delay before clicks to avoid unwanted double-clicks
- fixed the Dialog implementation in IE7 (hiding elements): Element.hasAttribute doesn't exist
- fixed the wai Modal Dialog test in Firefox 3: Element.parentElement doesn't exist

closes #1601