### PR TITLE
fix AutoFocusTest on IE 8 and IE 10

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -908,7 +908,11 @@ module.exports = Aria.classDefinition({
                     var previouslyFocusedElement = this._previouslyFocusedElement;
                     if (previouslyFocusedElement != null) {
                         setTimeout(function () {
-                            previouslyFocusedElement.focus();
+                            try {
+                                // On IE 7 and 8, focusing an element which is no longer in the DOM
+                                // throws the "Unexpected call to method or property access." exception
+                                previouslyFocusedElement.focus();
+                            } catch (e) {}
                         }, 0);
                         this._previouslyFocusedElement = null;
                     }

--- a/test/aria/widgets/container/dialog/autoFocus/AutoFocusTest.js
+++ b/test/aria/widgets/container/dialog/autoFocus/AutoFocusTest.js
@@ -16,7 +16,7 @@
 Aria.classDefinition({
     $classpath : "test.aria.widgets.container.dialog.autoFocus.AutoFocusTest",
     $extends : "aria.jsunit.TemplateTestCase",
-    $dependencies : ["aria.utils.Json"],
+    $dependencies : ["aria.utils.Json", "aria.core.Timer"],
     $constructor : function () {
         this.$TemplateTestCase.constructor.call(this);
         this.data = {
@@ -62,10 +62,16 @@ Aria.classDefinition({
             aria.utils.Json.setValue(this.data, "autoFocus", autoFocus);
             this.templateCtxt.$refresh();
             this.waitForMyDialog(false, function () {
-                var fieldOutsideDialog = this.getElementById("fieldOutsideDialog");
-                fieldOutsideDialog.focus();
-                this.waitForDomEltFocus(fieldOutsideDialog, function () {
-                    this.openDialog(cb);
+                aria.core.Timer.addCallback({
+                    fn: function () {
+                        var fieldOutsideDialog = this.getElementById("fieldOutsideDialog");
+                        fieldOutsideDialog.focus();
+                        this.waitForDomEltFocus(fieldOutsideDialog, function () {
+                            this.openDialog(cb);
+                        });
+                    },
+                    scope: this,
+                    delay: 20
                 });
             });
         },


### PR DESCRIPTION
This commit fixes `test.aria.widgets.container.dialog.autoFocus.AutoFocusTest` on IE 8 and IE 10.