### PR TITLE
fix/test ClosePopupScrollTest on IE 9

### DIFF
--- a/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTestTpl.tpl
+++ b/test/aria/widgets/container/dialog/closePopupScroll/ClosePopupScrollTestTpl.tpl
@@ -23,7 +23,8 @@
             width: 300,
             height: 400,
             visible: true,
-            modal: true
+            modal: true,
+            autoFocus: false
         }/}
     {/macro}
 


### PR DESCRIPTION
This PR fixes `test.aria.widgets.container.dialog.closePopupScroll.ClosePopupScrollTest`
on IE9. It seems that auto-focusing the first element in the dialog prevents the following `scrollIntoView` on IE 9 (only).