### PR TITLE
fix test.aria.utils.dragdrop.fixedElements.FixedElementTest on IE 8

### DIFF
--- a/test/aria/utils/dragdrop/fixedElements/FixedElementTestTemplate.tpl
+++ b/test/aria/utils/dragdrop/fixedElements/FixedElementTestTemplate.tpl
@@ -21,11 +21,11 @@
   {macro main ( )}
 
     <div id="draggable-fixed" class="modal fixed">
-        <div class="title-bar">Fixed</div>
+        <div class="title-bar" unselectable="on">Fixed</div>
         Cannot move :(
     </div>
     <div id="draggable-absolute" class="modal absolute" style="right:50px;">
-        <div class="title-bar">Absolute</div>
+        <div class="title-bar" unselectable="on">Absolute</div>
         Will move just fine
     </div>
 


### PR DESCRIPTION
This PR fixes `test.aria.utils.dragdrop.fixedElements.FixedElementTest` on IE 8, when run with [vbox-robot](https://github.com/attester/vbox-robot).

On IE 8, the following strange behavior happens: when the user starts to drag and drop a selected area (with a physical mouse, such as the one simulated by [vbox-robot](https://github.com/attester/vbox-robot), not the [robot-server](https://github.com/attester/robot-server)), the execution of script tags is temporarily delayed until the mouse is released.
As we wait for the execution of the JSON-P request from [vbox-robot](https://github.com/attester/vbox-robot) before sending the command to release the mouse, the test never ends successfully.

In this test, it is a mistake to have something selected, so, adding the unselectable attribute fixes the issue.