### PR TITLE
createATSyncContext method to use Aria Templates from node.js more easily

### DIFF
--- a/src/node/createATSyncContext.js
+++ b/src/node/createATSyncContext.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var vm = require('vm');
+var path = require('path');
+var fs = require('fs');
+
+function createXMLHttpRequest() {};
+var XMLHttpRequestProto = createXMLHttpRequest.prototype = {};
+
+XMLHttpRequestProto.UNSENT = 0;
+XMLHttpRequestProto.OPENED = 1;
+XMLHttpRequestProto.HEADERS_RECEIVED = 2;
+XMLHttpRequestProto.LOADING = 3;
+XMLHttpRequestProto.DONE = 4;
+
+XMLHttpRequestProto.abort = XMLHttpRequestProto.setRequestHeader = function () {};
+XMLHttpRequestProto.getResponseHeader = function () {
+    return null;
+};
+XMLHttpRequestProto.getAllResponseHeaders = function () {
+    return "";
+};
+XMLHttpRequestProto._changeReadyState = function (state) {
+    this.readyState = state;
+    if (this.onreadystatechange) {
+        this.onreadystatechange();
+    }
+};
+XMLHttpRequestProto.open = function (method, url, async) {
+    this.method = method;
+    this.url = url;
+    this.async = async;
+    this._changeReadyState(this.OPENED);
+};
+
+XMLHttpRequestProto.send = function () {
+    var responseText, status;
+    var self = this;
+    try {
+        responseText = self._readLogicalPathSync.call(null, self.url);
+        status = 200;
+    } catch (err) {
+        responseText = err + "";
+        status = 404;
+    }
+    var loadResult = function () {
+        self.status = status;
+        self.statusText = status === 200 ? "OK" : "NOT FOUND";
+        self.responseText = responseText;
+        self._changeReadyState(self.DONE);
+        self = responseText = loadResult = null;
+    };
+    if (this.async) {
+        this._setTimeout(loadResult, 0);
+    } else {
+        loadResult();
+    }
+};
+
+function defaultReadFileSync(fileName) {
+    return fs.readFileSync(path.resolve(__dirname, "..", fileName), "utf-8");
+}
+
+/**
+ * Creates a new node.js Javascript context to contain an instance of Aria Templates, and loads Aria Templates in it.
+ * In this context, timeouts are not executed automatically, but, instead, an execTimeouts method is provided on the
+ * returned context to allow executing timeouts synchronously when needed.
+ * @param {Object} options object which can contain the following properties:
+ * - bootstrapFile {String} name of the file containing the Aria Templates bootstrap (defaults to ./aria/bootstrap.js).
+ * - readFileSync {Function} synchronous function which will be used to read files on the disk (it is given
+ * the logical path to read as its only parameter, and it should return the content of the file as a string or throw an
+ * exception).
+ * - rootFolderPath {String} value to set in Aria.rootFolderPath before loading the framework (defaults to './')
+ * - debugMode {Boolean} whether to enable Aria Templates debug mode.
+ * - console {Object} object to be available as console in the context.
+ * @return {Object} node.js context, suitable to be used with vm.runInContext, and containing the execTimeouts method.
+ * If there was no error during the execution of this method, the context should contain the Aria and aria properties
+ * giving access to the embedded Aria Templates instance.
+ */
+module.exports = function (options) {
+    options = options || {};
+    var ariaBootstrapFileName = options.bootstrapFile || "./aria/bootstrap.js";
+    var readLogicalPathSync = options.readFileSync || defaultReadFileSync;
+    var console = options.console || global.console;
+
+    var timeouts = [];
+    var timeoutId = 0;
+
+    var setTimeout = function (fn, delay) {
+        timeoutId++;
+        var id = "" + timeoutId;
+        timeouts.push({
+            id : id,
+            fn : fn,
+            delay : delay
+        });
+        return id;
+    };
+    var clearTimeout = function (id) {
+        for (var i = 0, l = timeouts.length; i < l; i++) {
+            var item = timeouts[i];
+            if (item.id === id) {
+                timeouts.splice(i, 1);
+                return;
+            }
+        }
+    };
+    var document = {
+        currentScript : null
+    };
+
+    var XMLHttpRequest = function () {};
+    XMLHttpRequest.prototype = new createXMLHttpRequest();
+    XMLHttpRequest.prototype._readLogicalPathSync = readLogicalPathSync;
+    XMLHttpRequest.prototype._setTimeout = setTimeout;
+
+    var atContext = vm.createContext({
+        XMLHttpRequest : XMLHttpRequest,
+        console : console,
+        setTimeout : setTimeout,
+        clearTimeout : clearTimeout,
+        setInterval : setTimeout, // implements the setInterval method as a setTimeout (only call it once)
+        clearInterval : clearTimeout,
+        execTimeouts : function () {
+            var l = timeouts.length;
+            while (l > 0) {
+                var minIndex = 0;
+                for (var i = 1; i < l; i++) {
+                    if (timeouts[i].delay < timeouts[minIndex].delay) {
+                        minIndex = i;
+                    }
+                }
+                var minItem = timeouts[minIndex];
+                timeouts.splice(minIndex, 1);
+                minItem.fn.call(atContext);
+                // The function called at the previous line can add or remove items from timeouts, so it's necessary to
+                // check again the length:
+                l = timeouts.length;
+            }
+        },
+        load : function (filePath) {
+            var savedCurrentScript = document.currentScript;
+            try {
+                var fileContent = readLogicalPathSync(filePath);
+                document.currentScript = {
+                    src : filePath
+                };
+                vm.runInContext(fileContent, atContext, filePath);
+            } catch (err) {
+                console.error("Error while trying to execute " + filePath, err);
+            } finally {
+                document.currentScript = savedCurrentScript;
+            }
+        },
+        Aria : {
+            rootFolderPath : options.rootFolderPath == null ? './' : options.rootFolderPath,
+            debug : !!options.debugMode
+        },
+        document : document
+    });
+
+    atContext.load(ariaBootstrapFileName);
+
+    return atContext;
+};

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.createATSyncContext = require("./createATSyncContext");

--- a/test/node/createATSyncContext.js
+++ b/test/node/createATSyncContext.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var assert = require("assert");
+var atVersion = require("../../package.json").version;
+var createATSyncContext = require("../../src/node").createATSyncContext;
+
+// This test checks that Aria Templates can be used from node.js with createATSyncContext
+describe("Aria Templates with createATSyncContext in node.js", function () {
+    it("should work with no option", function () {
+        var context = createATSyncContext();
+        assert.equal(context.Aria.version, 'ARIA-SNAPSHOT');
+        context.Aria.load({
+           classes : ["aria.templates.TplClassGenerator"]
+        });
+        context.execTimeouts(); // executes any timeout synchronously
+        var classDef;
+        context.aria.templates.TplClassGenerator.parseTemplate("{Template {$classpath:'a.b.C'}} {macro main()}It works!{/macro}{/Template}", true, function(response) {
+            classDef = response.classDef;
+        });
+        context.execTimeouts(); // executes any timeout synchronously
+        assert.ok(classDef, "Expecting classDef to be defined.");
+        assert.ok(/It works!/.test(classDef), "Expecting classDef to contain 'It works!'.");
+    });
+
+    it("should work with bootstrapFile and rootFolderPath options", function () {
+        var context = createATSyncContext({
+            bootstrapFile: path.join(__dirname, "..", "..", "build/target/production/aria/ariatemplates-" + atVersion + ".js"),
+            rootFolderPath: path.join(__dirname, "..", "..", "build/target/production/")
+        });
+        var onCompleteCalled = false;
+        context.Aria.load({
+            classes : ["aria.templates.TplClassGenerator"],
+            oncomplete : function () {
+                onCompleteCalled = true;
+            }
+        });
+        assert.ok(!onCompleteCalled, "Expecting oncomplete not to have been called yet!");
+        context.execTimeouts();
+        assert.ok(onCompleteCalled, "Expecting oncomplete to have been called.");
+        assert.ok(context.aria.templates.TplClassGenerator, "Expecting aria.templates.TplClassGenerator to be defined.");
+        assert.equal(context.Aria.version, atVersion);
+    });
+
+    it("should work with bootstrapFile and readFileSync options", function () {
+        var context = createATSyncContext({
+            bootstrapFile: "aria/ariatemplates-" + atVersion + ".js",
+            readFileSync: function (fileName) {
+                return fs.readFileSync(path.join(__dirname, "..", "..", "build/target/production", fileName), "utf-8");
+            }
+        });
+        var onCompleteCalled = false;
+        context.Aria.load({
+            classes : ["aria.templates.TplClassGenerator"],
+            oncomplete : function () {
+                onCompleteCalled = true;
+            }
+        });
+        assert.ok(!onCompleteCalled, "Expecting oncomplete not to have been called yet!");
+        context.execTimeouts();
+        assert.ok(onCompleteCalled, "Expecting oncomplete to have been called.");
+        assert.ok(context.aria.templates.TplClassGenerator, "Expecting aria.templates.TplClassGenerator to be defined.");
+        assert.equal(context.Aria.version, atVersion);
+    });
+});


### PR DESCRIPTION
This PR adds the `createATSyncContext` method to the ariatemplates npm package.

Here is an example showing how it can be used (from node.js) to load the `aria.templates.TplClassGenerator` class and compile a template synchronously:

```js
var createATSyncContext = require("ariatemplates/src/node").createATSyncContext;
var context= createATSyncContext();
context.Aria.load({
    classes : ["aria.templates.TplClassGenerator"]
});
context.execTimeouts(); // executes any timeout synchronously
var classDef;
context.aria.templates.TplClassGenerator.parseTemplate("{Template {$classpath:'a.b.C'}} {macro main()}It works!{/macro}{/Template}", true, function(response) {
    classDef = response.classDef;
});
context.execTimeouts(); // executes any timeout synchronously
console.log(classDef); // here, classDef contains the generated class definition
```

An previous version of the `createATSyncContext` function is included in [atpackager](https://github.com/ariatemplates/atpackager/blob/v0.2.7/lib/ariatemplates.js), but it is probably better to share it in the Aria Templates package itself so that it can be used more easily by any project.