### PR TITLE
Using Aria["eval"] instead of the eval statement in several places

### DIFF
--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -223,9 +223,7 @@ module.exports = Aria.classDefinition({
             var param;
             try {
                 // The parameter should be a JSON object
-                // TODO: think about error management and call aria.utils.Json.load(...)
-                // calling JsonUtils.load because it includes a sandbox
-                param = eval("(" + rootStatement.paramBlock + ")");
+                param = Aria["eval"]("return (" + rootStatement.paramBlock + ");");
             } catch (e) {
                 return out.logError(rootStatement, this.ERROR_IN_TEMPLATE_PARAMETER, [this._rootStatement], e);
             }

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -776,11 +776,10 @@ var ariaUtilsObject = require("./Object");
              * @return {Object}
              */
             load : function (str, ctxt, errMsg) {
-                // TODO setup complete sandbox variables - e.g. through closure
                 var res = null;
                 try {
                     str = ('' + str).replace(/^\s/, ''); // remove first spaces
-                    res = eval('(' + str + ')');
+                    res = Aria["eval"]('return (' + str + ');');
                 } catch (ex) {
                     res = null;
                     if (!errMsg) {

--- a/src/aria/utils/json/JsonSerializer.js
+++ b/src/aria/utils/json/JsonSerializer.js
@@ -606,7 +606,7 @@ module.exports = Aria.classDefinition({
                 // ',' or ':' or '{' or '}' or 'new Date(])'. If that is so, then the text is safe for eval.
                 if (/^((new Date\((\])?\))|([\],:{}\s]))*$/.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@').replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']').replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
                     // this might throw a SyntaxError
-                    return eval('(' + text + ')');
+                    return Aria["eval"]('return (' + text + ');');
                 } else {
                     throw new Error('aria.utils.json.JsonSerializer.parse');
                 }


### PR DESCRIPTION
This PR replaces the `eval` statement with the `Aria["eval"]` call so that the scope of the function calling `eval` is no longer exposed, and better minification can be achieved.