### PR TITLE
Allowing to use attesterLauncher with "npm run attest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "src/aria/node.js",
   "config": {
     "port": "8080",
-    "phantomjsInstances": 2
+    "phantomjsInstances": 2,
+    "attesterLauncherConfig": ""
   },
   "scripts": {
     "start": "node scripts/server.js",
@@ -40,7 +41,7 @@
     "noder-js": "1.6.2"
   },
   "devDependencies": {
-    "attester": "2.4.0",
+    "attester": "2.4.1",
     "express": "3.4.8",
     "grunt": "0.4.2",
     "grunt-contrib-jshint": "0.8.0",

--- a/scripts/attest.js
+++ b/scripts/attest.js
@@ -20,23 +20,20 @@ middleware.forEach(function (fn) {
     attester.server.use(fn);
 });
 
-var options = {
-    "phantomjs-instances": 0
-};
-var browser = "phantomjs";
+var optionRegExp = /^--([^=]+)=(.*)$/;
+var commandLineOptions = {};
 var testsToExecute = process.argv.slice(2).filter(function (arg) {
-    if (/^--browser=/.test(arg)) {
-        browser = arg.substr(10);
+    var match = optionRegExp.exec(arg);
+    if (match) {
+        commandLineOptions[match[1]] = match[2];
         return false;
     }
     return true;
 });
 
-if (browser == "phantomjs") {
-    options["phantomjs-instances"] = 1;
-} else if (browser != "none") {
-    options["robot-browser"] = browser;
-}
+var attesterOptions = {
+    "phantomjs-instances": 0
+};
 
 var campaign = {
     resources : {
@@ -54,6 +51,20 @@ var campaign = {
     }
 };
 
+var browsers = commandLineOptions.browsers;
+var browser = commandLineOptions.browser;
+if (browsers) {
+    campaign.browsers = browsers.trim().split(/\s*,\s*/);
+    var launcherConfig = commandLineOptions["launcher-config"] || process.env.npm_package_config_attesterLauncherConfig;
+    if (launcherConfig) {
+        attesterOptions["launcher-config"] = launcherConfig;
+    }
+} else if (browser == "phantomjs" || browser == null) {
+    attesterOptions["phantomjs-instances"] = commandLineOptions["phantomjs-instances"] || 1;
+} else if (browser != "none") {
+    attesterOptions["robot-browser"] = browser;
+}
+
 // Called when the campaign completes successfully
 attester.event.once("attester.core.idle", function () {
     attester.dispose().then(function () {
@@ -68,7 +79,9 @@ attester.event.once("attester.core.fail", function () {
     });
 });
 
-attester.config.set(options);
+console.log("Using the following options:");
+console.log(JSON.stringify(attesterOptions, null, " "));
+attester.config.set(attesterOptions);
 attester.campaign.create(campaign, {}, 1);
 
 attester.start();


### PR DESCRIPTION
This PR allows to use the `attesterLauncherConfig` npm configuration parameter to specify an attester-launcher configuration file to be used with the `npm run attest` command, when the `--browsers=...` switch is used.

Here is a sample command showing how to configure the `attesterLauncherConfig` parameter:

```
npm config set ariatemplates:attesterLauncherConfig 'c:\\attesterLauncherConfig.yml'
```

Then, if that configuration file contains entries for the `Chrome` and `Firefox` browsers, it is possible to run `test.aria.AriaTest` on those 2 browsers with:

```
npm run attest -- --browsers=Chrome,Firefox test.aria.AriaTest
```
