### PR TITLE
Fixing DatePickerJawsTest1 with Jaws 16

### DIFF
--- a/test/aria/widgets/wai/datePicker/DatePickerJawsTest1.js
+++ b/test/aria/widgets/wai/datePicker/DatePickerJawsTest1.js
@@ -42,7 +42,7 @@ Aria.classDefinition({
                 ["pause", 1000]
             ], {
                 fn: function () {
-                    this.assertJawsHistoryEquals("Next field Edit\nType in text.\nNext field\nDisplay calendar button menu collapsed\nEntering Application Region\nCalendar table. Use arrow keys to navigate and space to validate.\nFriday 1 January 2016\nFriday 8 January 2016\nFriday 15 January 2016\nLeaving Application Region\nTravel date Edit\n15/1/16\nType in text.", this.end);
+                    this.assertJawsHistoryEquals("Next field Edit\nType in text.\nNext field\nDisplay calendar button menu collapsed\nCalendar table. Use arrow keys to navigate and space to validate.\nFriday 1 January 2016\nFriday 8 January 2016\nFriday 15 January 2016\nTravel date Edit\n15/1/16\nType in text.", this.end);
                 },
                 scope: this
             });


### PR DESCRIPTION
It seems that Jaws 16 no longer say "entering application region" nor "leaving application region" in this test.