### PR TITLE
feat New parameter added to load a test template without running the test

### DIFF
--- a/test/testLauncher.js
+++ b/test/testLauncher.js
@@ -143,7 +143,15 @@ Aria.load({
                     ts.demoMode = true;
                 }
 
-                aria.jsunit.TestRunner.run(ts, skipTests);
+                if (qs.getKeyValue("norun") == "true") {
+                    if (ts.$TemplateTestCase) {
+                        ts.$TemplateTestCase._loadTestTemplate.call(ts);
+                    } else {
+                        console.error("This is not a template test case, nothing is shown with the 'norun' parameter");
+                    }
+                } else {
+                    aria.jsunit.TestRunner.run(ts, skipTests);
+                }
 
             }
         });


### PR DESCRIPTION
`norun="true"` can be now added to the test url.
Useful feature to debug or code on a template test case without having the full test to run, or the robot activated.