### PR TITLE
Template parser and class generator improvements for tools

### DIFF
--- a/src/aria/core/loaders/TplBasePreprocessor.js
+++ b/src/aria/core/loaders/TplBasePreprocessor.js
@@ -19,7 +19,14 @@ var Promise = require('noder-js/promise.js');
 module.exports = function (classGenerator) {
     return function (content, fileName) {
         return new Promise(function (resolve, reject) {
-            classGenerator.parseTemplate(content, false, function (res) {
+            classGenerator.parseTemplate(content, {
+                allDependencies: false,
+                errorContext: {
+                    "file_classpath" : fileName
+                },
+                debug: false,
+                skipLogError: true
+            }, function (res) {
                 if (res.classDef) {
                     var logicalPath = res.logicalPath;
                     if (logicalPath === fileName || require.resolve(logicalPath) === fileName) {
@@ -47,9 +54,7 @@ module.exports = function (classGenerator) {
                             + errorDetails);
                     reject(error);
                 }
-            }, {
-                "file_classpath" : fileName
-            }, false, true);
+            });
         });
     };
 };

--- a/src/aria/templates/CfgBeans.js
+++ b/src/aria/templates/CfgBeans.js
@@ -27,6 +27,36 @@ module.exports = Aria.beanDefinitions({
         "coreBeans" : ariaCoreCfgBeans
     },
     $beans : {
+        "ClassGeneratorCfg" : {
+            $type : "json:Object",
+            $description : "Options for the class generator.",
+            $properties : {
+                "parseOnly" : {
+                    $type : "json:Boolean",
+                    $description : "If true, the class will not be generated, but the template will be fully parsed, including all statement properties."
+                },
+                "dontLoadWidgetLibs" : {
+                    $type : "json:Boolean",
+                    $description : "If true, widget libraries referenced in the template will not be loaded during the class generation process, which is convenient if they are not available at that time. However, as a result, there will probably be missing dependencies in the generated class."
+                },
+                "allDependencies" : {
+                    $type : "json:Boolean",
+                    $description : "If true, all dependencies should be included in the generated class, otherwise only classes which are not currently loaded are added as dependencies of the generated class."
+                },
+                "debug" : {
+                    $type : "json:Boolean",
+                    $description : "If true, extra code is added in the generated class to help debugging."
+                },
+                "errorContext" : {
+                    $type : "json:ObjectRef",
+                    $description : "Context object passed with the errors to help debugging."
+                },
+                "skipLogError": {
+                    $type : "json:Boolean",
+                    $description : "If true, passes the errors to the callback instead of logging them with $logError."
+                }
+            }
+        },
         "BaseTemplateCfg" : {
             $type : "json:Object",
             $description : "Base configuration for all types of templates.",

--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -23,6 +23,17 @@ var ariaUtilsJson = require("../utils/Json");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
 var ariaCoreEnvironmentEnvironment = require("../core/environment/Environment");
 
+var normalizeOptions = function (optionsOrAllDeps, context, debug, skipLogError) {
+    var options = (typeof optionsOrAllDeps == "object") ? optionsOrAllDeps : {
+        allDependencies: optionsOrAllDeps,
+        errorContext: context,
+        debug: debug,
+        skipLogError: skipLogError
+    };
+    ariaCoreJsonValidator.check(options, "aria.templates.CfgBeans.ClassGeneratorCfg");
+    return options;
+};
+
 /**
  * The class generator is used to generate the class corresponding to a template. This class uses the tree from the
  * template parser, and generates a string containing the corresponding class definition. This is an abstract class and
@@ -117,12 +128,7 @@ module.exports = Aria.classDefinition({
          * @param {aria.core.CfgBeans:Callback} callback the callback description
          */
         parseTemplate : function (template, optionsOrAllDeps, callback, context, debug, skipLogError) {
-            var options = (typeof optionsOrAllDeps == "object") ? optionsOrAllDeps : {
-                allDependencies: optionsOrAllDeps,
-                errorContext: context,
-                debug: debug,
-                skipLogError: skipLogError
-            };
+            var options = normalizeOptions(optionsOrAllDeps, context, debug, skipLogError);
             var tree, errors;
             try {
                 tree = this._parser.parseTemplate(template, options.errorContext, this.STATEMENTS, options.skipLogError);
@@ -144,16 +150,9 @@ module.exports = Aria.classDefinition({
          * @param {aria.templates.TreeBeans:Root} tree tree returned by the parser.
          * @param {aria.templates.CfgBeans:ClassGeneratorCfg} options Options for class generation.
          * @param {aria.core.CfgBeans:Callback} callback callback the callback description
-         * @param {Object} context - passes template context information to improve debugging
-         * @param {Boolean} debug debug mode
          */
         parseTemplateFromTree : function (tree, optionsOrAllDeps, callback, context, debug, skipLogError) {
-            var options = (typeof optionsOrAllDeps == "object") ? optionsOrAllDeps : {
-                allDependencies: optionsOrAllDeps,
-                errorContext: context,
-                debug: debug,
-                skipLogError: skipLogError
-            };
+            var options = normalizeOptions(optionsOrAllDeps, context, debug, skipLogError);
             this.__buildClass(tree, options, callback);
         },
 
@@ -186,7 +185,6 @@ module.exports = Aria.classDefinition({
          * @param {aria.core.CfgBeans:Callback} callback the callback description
          */
         __buildClass : function (tree, options, callback) {
-            ariaCoreJsonValidator.check(options, "aria.templates.CfgBeans.ClassGeneratorCfg");
             ariaCoreJsonValidator.check(tree, "aria.templates.TreeBeans.Root");
             var out = new ariaTemplatesClassWriter({
                 fn : this.__processStatement,

--- a/src/aria/templates/ClassGenerator.js
+++ b/src/aria/templates/ClassGenerator.js
@@ -116,7 +116,13 @@ module.exports = Aria.classDefinition({
          * @param {aria.templates.CfgBeans:ClassGeneratorCfg} options Options for the class generation.
          * @param {aria.core.CfgBeans:Callback} callback the callback description
          */
-        parseTemplate : function (template, options, callback) {
+        parseTemplate : function (template, optionsOrAllDeps, callback, context, debug, skipLogError) {
+            var options = (typeof optionsOrAllDeps == "object") ? optionsOrAllDeps : {
+                allDependencies: optionsOrAllDeps,
+                errorContext: context,
+                debug: debug,
+                skipLogError: skipLogError
+            };
             var tree, errors;
             try {
                 tree = this._parser.parseTemplate(template, options.errorContext, this.STATEMENTS, options.skipLogError);
@@ -141,7 +147,13 @@ module.exports = Aria.classDefinition({
          * @param {Object} context - passes template context information to improve debugging
          * @param {Boolean} debug debug mode
          */
-        parseTemplateFromTree : function (tree, options, callback) {
+        parseTemplateFromTree : function (tree, optionsOrAllDeps, callback, context, debug, skipLogError) {
+            var options = (typeof optionsOrAllDeps == "object") ? optionsOrAllDeps : {
+                allDependencies: optionsOrAllDeps,
+                errorContext: context,
+                debug: debug,
+                skipLogError: skipLogError
+            };
             this.__buildClass(tree, options, callback);
         },
 

--- a/src/aria/templates/ClassWriter.js
+++ b/src/aria/templates/ClassWriter.js
@@ -515,7 +515,13 @@ module.exports = Aria.classDefinition({
         enableParseOnly : function () {
             this.parseOnly = true;
             // disables functions which are only useful to generate code:
-            this.writeDependencies = this.newVarName = this.writeln = this.write = this.wrapExpression = this.trackLine = Aria.empty;
+            var empty = Aria.empty;
+            this.writeDependencies = empty;
+            this.newVarName = empty;
+            this.writeln = empty;
+            this.write = empty;
+            this.wrapExpression = empty;
+            this.trackLine = empty;
         }
 
     }

--- a/src/aria/templates/ClassWriter.js
+++ b/src/aria/templates/ClassWriter.js
@@ -189,11 +189,10 @@ module.exports = Aria.classDefinition({
         this._stack = [];
 
         /**
-         * List of dependencies found for the class to be generated
-         * @type Array
+         * Map of dependencies found for the class to be generated
          * @protected
          */
-        this._dependencies = [];
+        this._dependencies = {};
 
         /**
          * Contains information about errors which occured during the generation process. If the processErrors callback
@@ -215,6 +214,17 @@ module.exports = Aria.classDefinition({
          */
         this.tree = null;
 
+        /**
+         * If set to true, code generation is disabled, only parsing matters.
+         * @type Boolean
+         */
+        this.parseOnly = false;
+
+        /**
+         * If set to true, widget libraries will not be loaded during class generation.
+         * @type Boolean
+         */
+        this.dontLoadWidgetLibs = false;
     },
     $prototype : {
         /**
@@ -273,7 +283,9 @@ module.exports = Aria.classDefinition({
         getView : function (viewBaseName) {
             var res = this.views[viewBaseName];
             if (res == null) {
-                res = {};
+                res = {
+                    baseName: viewBaseName
+                };
                 this.views[viewBaseName] = res;
             }
             return res;
@@ -495,6 +507,15 @@ module.exports = Aria.classDefinition({
             if (this._curblock) {
                 this.writeln("this['" + Aria.FRAMEWORK_PREFIX + "currentLineNumber'] = " + lineNumber + ";");
             }
+        },
+
+        /**
+         * Set the parseOnly flag to true and disables functions which are only useful for class generation.
+         */
+        enableParseOnly : function () {
+            this.parseOnly = true;
+            // disables functions which are only useful to generate code:
+            this.writeDependencies = this.newVarName = this.writeln = this.write = this.wrapExpression = this.trackLine = Aria.empty;
         }
 
     }

--- a/src/aria/templates/Parser.js
+++ b/src/aria/templates/Parser.js
@@ -299,7 +299,8 @@ module.exports = Aria.classDefinition({
                 paramBlock : "",
                 parent : null,
                 content : curContainer,
-                lineNumber : 0
+                lineNumber : 0,
+                source: tpl
             }, stack = [res]; // stack of content containers
             while (index != -1) {
                 dollar = (tpl.charAt(index - 1) == "$" && !utilString.isEscaped(tpl, index - 1));

--- a/src/aria/templates/Statements.js
+++ b/src/aria/templates/Statements.js
@@ -142,6 +142,7 @@ module.exports = Aria.classDefinition({
                     parts.push(param);
 
                     // Automatic escape ----------------------------------------
+
                     var autoEscape = false;
                     if (ariaCoreEnvironmentEnvironment.hasEscapeHtmlByDefault()) {
 
@@ -169,6 +170,7 @@ module.exports = Aria.classDefinition({
                     }
 
                     // end of: automatic escape --------------------------------
+
                     var modifiersList = [];
                     var beginexpr = [], endexpr = [];
                     var expr;

--- a/src/aria/templates/TplClassGenerator.js
+++ b/src/aria/templates/TplClassGenerator.js
@@ -94,7 +94,11 @@ module.exports = Aria.classDefinition({
                     classes.push(wlibs[i]);
                 }
             }
-
+            if (out.dontLoadWidgetLibs) {
+                // skip the load of widget libraries
+                this.$ClassGenerator._processTemplateContent.call(this, args);
+                return;
+            }
             Aria.load({
                 classes : classes,
                 oncomplete : {

--- a/src/aria/templates/TreeBeans.js
+++ b/src/aria/templates/TreeBeans.js
@@ -43,6 +43,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "Statement.parent",
                     $description : "Parent element: is null for the root statement.",
                     $mandatory : false
+                },
+                "source" : {
+                    $type : "json:String",
+                    $description : "Processed template source. It differs from the original template passed to parseTemplate, as there is some preprocessing (to remove comments, ...). Positions in the template tree are inside this string, and not the original one."
                 }
             }
         },
@@ -91,6 +95,11 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "Statement parameter, with new lines at the begining and end removed.",
                     $mandatory : true
+                },
+                "properties" : {
+                    $type : "json:ObjectRef",
+                    $description : "Statement properties, after being parsed from paramBlock and/or other parameters. This object is filled during template class generation (it is not yet present after only executing the parser). The properties it contains depend on the name of the statement.",
+                    $mandatory : false
                 },
                 "firstCharParamIndex" : {
                     $type : "json:Integer",

--- a/test/aria/templates/ClassGeneratorTest.js
+++ b/test/aria/templates/ClassGeneratorTest.js
@@ -210,7 +210,9 @@ Aria.classDefinition({
 
         _taskParseTemplateError : function (task, args) {
             var cg = aria.templates.TplClassGenerator;
-            cg.parseTemplate(args.tpl, true, {
+            cg.parseTemplate(args.tpl, {
+                allDependencies: true
+            }, {
                 fn : this._parseTemplateResponse,
                 scope : this,
                 args : {
@@ -263,7 +265,9 @@ Aria.classDefinition({
                 var dm = aria.core.DownloadMgr;
                 var cg = aria.templates.TplClassGenerator;
                 var tpl = dm.getFileContent("test/aria/templates/test/TemplateOK.tpl");
-                cg.parseTemplate(tpl, true, {
+                cg.parseTemplate(tpl, {
+                    allDependencies: true
+                }, {
                     fn : this._onReceivingTemplateOKGenerated,
                     scope : this
                 });
@@ -305,10 +309,14 @@ Aria.classDefinition({
                 var dm = aria.core.DownloadMgr;
                 var cg = aria.templates.TplClassGenerator;
                 var tpl = dm.getFileContent("test/aria/templates/test/TemplateKO_Runtime.tpl");
-                cg.parseTemplate(tpl, true, {
+                cg.parseTemplate(tpl, {
+                    allDependencies: true,
+                    errorContext: {},
+                    debug: true
+                }, {
                     fn : this._onReceivingTemplateKO_RuntimeGenerated,
                     scope : this
-                }, {}, true);
+                });
             } catch (e) {
                 this.handleAsyncTestError(e);
             }

--- a/test/aria/templates/TemplatesTestSuite.js
+++ b/test/aria/templates/TemplatesTestSuite.js
@@ -46,6 +46,7 @@ Aria.classDefinition({
         this.addTests("test.aria.templates.TemplateTest");
 
         this.addTests("test.aria.templates.TplClassGeneratorTest");
+        this.addTests("test.aria.templates.TplClassGeneratorParseOnlyTest");
         this.addTests("test.aria.templates.TxtClassGeneratorTest");
         this.addTests("test.aria.templates.TxtTemplateTest");
         this.addTests("test.aria.templates.ViewTest");

--- a/test/aria/templates/TplClassGeneratorParseOnlyTest.js
+++ b/test/aria/templates/TplClassGeneratorParseOnlyTest.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.templates.TplClassGeneratorParseOnlyTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.templates.TplClassGenerator"],
+    $prototype : {
+        testParseTemplate : function () {
+            var result;
+            aria.templates.TplClassGenerator.parseTemplate([
+                '{Template {',
+                '   $classpath: "x.y.Z",',
+                '   $extends: "x.y.Y",',
+                '   $wlibs: {',
+                '      myLib: "x.y.MyWidgetsLibThatDoesNotExistButShouldNotBeChecked"',
+                '   }',
+                '}}',
+                '   {macro main()}',
+                '      {call test(null, "value", "data")/}',
+                '      {call $Y.main()/}',
+                '   {/macro}',
+                '   {macro test(  a ,   bb , c   )}Date:${a|empty:new Date()|dateformat:"dd/MM/yyyy"}',
+                '      {@myLib:MyWidget {',
+                '         something: b',
+                '      }/}',
+                '   {/macro}',
+                '{/Template}'
+            ].join("\n"), {
+                parseOnly: true,
+                dontLoadWidgetLibs: true
+            }, function (res) {
+                result = res;
+            });
+
+            this.assertEquals(result.tree.content[0].properties.$classpath, "x.y.Z");
+            this.assertEquals(result.tree.content[0].properties.$extends, "x.y.Y");
+
+            var mainMacroStatement = result.tree.properties.macros.main.definition;
+            this.assertEquals(mainMacroStatement.name, "macro");
+            this.assertEquals(mainMacroStatement.paramBlock, "main()");
+            this.assertEquals(result.tree.source.substring(mainMacroStatement.firstCharParamIndex, mainMacroStatement.lastCharParamIndex), "main()");
+            this.assertEquals(mainMacroStatement.properties.name, "main");
+            this.assertJsonEquals(mainMacroStatement.properties.args, []);
+
+            var callTestStatement = mainMacroStatement.content[0];
+            this.assertEquals(callTestStatement.name, "call");
+            this.assertEquals(callTestStatement.properties.name, "test");
+            this.assertEquals(callTestStatement.properties.container, undefined);
+            this.assertEquals(callTestStatement.properties.args, 'null, "value", "data"');
+
+            var callMainStatement = mainMacroStatement.content[1];
+            this.assertEquals(callMainStatement.name, "call");
+            this.assertEquals(callMainStatement.properties.name, "main");
+            this.assertEquals(callMainStatement.properties.container, "$Y");
+            this.assertEquals(callMainStatement.properties.args, "");
+
+            var testMacroStatement = result.tree.properties.macros.test.definition;
+            this.assertEquals(testMacroStatement.name, "macro");
+            this.assertEquals(testMacroStatement.paramBlock, "test(  a ,   bb , c   )");
+            this.assertEquals(testMacroStatement.properties.name, "test");
+            this.assertJsonEquals(testMacroStatement.properties.args, ["a", "bb", "c"]);
+
+            var textStatement = testMacroStatement.content[0];
+            this.assertEquals(textStatement.name, "#TEXT#");
+            this.assertEquals(textStatement.paramBlock, "Date:");
+
+            var exprStatement = testMacroStatement.content[1];
+            this.assertEquals(exprStatement.name, "#EXPRESSION#");
+            this.assertEquals(exprStatement.paramBlock, 'a|empty:new Date()|dateformat:"dd/MM/yyyy"');
+            this.assertEquals(exprStatement.properties.expression, 'a');
+            this.assertJsonEquals(exprStatement.properties.modifiers, [{
+                "name": "empty",
+                "args": 'new Date()'
+            }, {
+                "name": "dateformat",
+                "args": '"dd/MM/yyyy"'
+            }]);
+
+            var widgetStatement = testMacroStatement.content[2];
+            this.assertEquals(widgetStatement.name, "@myLib:MyWidget");
+            this.assertEquals(widgetStatement.properties.libName, "myLib");
+            this.assertEquals(widgetStatement.properties.libClasspath, "x.y.MyWidgetsLibThatDoesNotExistButShouldNotBeChecked");
+            this.assertEquals(widgetStatement.properties.widgetName, "MyWidget");
+
+            this.assertTruthy(result, "The callback should have been called synchronously.");
+        }
+    }
+});

--- a/test/aria/templates/TplClassGeneratorParseOnlyTest.js
+++ b/test/aria/templates/TplClassGeneratorParseOnlyTest.js
@@ -45,6 +45,7 @@ Aria.classDefinition({
                 result = res;
             });
 
+            this.assertTruthy(result, "The callback should have been called synchronously.");
             this.assertEquals(result.tree.content[0].properties.$classpath, "x.y.Z");
             this.assertEquals(result.tree.content[0].properties.$extends, "x.y.Y");
 
@@ -95,7 +96,6 @@ Aria.classDefinition({
             this.assertEquals(widgetStatement.properties.libClasspath, "x.y.MyWidgetsLibThatDoesNotExistButShouldNotBeChecked");
             this.assertEquals(widgetStatement.properties.widgetName, "MyWidget");
 
-            this.assertTruthy(result, "The callback should have been called synchronously.");
         }
     }
 });

--- a/test/aria/templates/TxtClassGeneratorTest.js
+++ b/test/aria/templates/TxtClassGeneratorTest.js
@@ -121,7 +121,9 @@ Aria.classDefinition({
 
         _taskParseTemplateError : function (task, args) {
             var cg = aria.templates.TxtClassGenerator;
-            cg.parseTemplate(args.tpl, true, {
+            cg.parseTemplate(args.tpl, {
+                allDependencies: true
+            }, {
                 fn : this._parseTemplateResponse,
                 scope : this,
                 args : {

--- a/test/aria/templates/statements/StatementParserTest.js
+++ b/test/aria/templates/statements/StatementParserTest.js
@@ -52,7 +52,9 @@ Aria.classDefinition({
 
         _taskParseTemplate : function (task, args) {
             var cg = aria.templates.TplClassGenerator;
-            cg.parseTemplate(args.tpl, true, {
+            cg.parseTemplate(args.tpl, {
+                allDependencies: true
+            }, {
                 fn : this._parseTemplateResponse,
                 scope : this,
                 args : {


### PR DESCRIPTION
This PR improves the template parser and class generator in the following ways:
- the template tree now includes the processed source (which is the reference string for positions provided in the template tree)
- during class generation, most statements now add a "properties" property on their corresponding template tree node, to contain the parsed version of their parameters, so that it is possible to avoid code duplication with tools which analyse templates and need those pieces of information too
- the signature of the parseTemplate method in class generators was simplified so that it is easier to add options. The following options were added:
  - parseOnly: if true, the resulting class will not be generated, but the template is still fully parsed, including all statement properties
  - dontLoadWidgetLibs: If true, widget libraries referenced in the template will not be loaded during the class generation process, which is convenient if they are not available at that time. However, as a result, there will probably be missing dependencies in the generated class (but that is especially not a problem when parseOnly is true).

