### PR TITLE
fix Fixed the TabsJawsTest (by filtering) and improved the JAWS test utilities

### DIFF
--- a/src/aria/jsunit/JawsTestCase.js
+++ b/src/aria/jsunit/JawsTestCase.js
@@ -132,12 +132,28 @@ module.exports = Aria.classDefinition({
         assertJawsHistoryEquals : function (expectedOutput, callback, filterFn) {
             this.retrieveJawsHistory({
                 fn: function (response) {
+                    var originalResponse = response;
 
                     if (filterFn) {
                         response = filterFn(response);
                     }
+                    var changed = response !== originalResponse;
 
-                    this.assertEquals(response, expectedOutput, "JAWS history: " + ariaUtilsJson.convertToJsonString(response));
+                    var message = [];
+                    if (changed) {
+                        message.push('History was filtered');
+                    } else {
+                        message.push('History was not filtered');
+                    }
+                    message.push("JAWS history" + (changed ? ' (filtered)' : '') + ": " + ariaUtilsJson.convertToJsonString(response));
+                    message.push("Expected history: " + ariaUtilsJson.convertToJsonString(expectedOutput));
+
+                    if (changed) {
+                        message.push("JAWS history (original): " + ariaUtilsJson.convertToJsonString(originalResponse));
+                    }
+                    message = message.join('.\n') + '.';
+
+                    this.assertEquals(response, expectedOutput, message);
                     this.$callback(callback);
                 },
                 scope: this

--- a/test/EnhancedJawsTestCase.js
+++ b/test/EnhancedJawsTestCase.js
@@ -28,6 +28,7 @@ module.exports = Aria.classDefinition({
         this.$JawsTestCase.constructor.call(this);
 
         this._history = [];
+        this._filter = null;
     },
 
 
@@ -54,11 +55,15 @@ module.exports = Aria.classDefinition({
         ////////////////////////////////////////////////////////////////////////
 
         _checkHistory : function (callback) {
+            // --------------------------------------------------- destructuring
+
             var history = this._history;
+            var filter = this._filter;
+
+            // ------------------------------------------------------ processing
 
             history = history.join('\n');
-
-            this.assertJawsHistoryEquals(history, callback);
+            this.assertJawsHistoryEquals(history, callback, filter);
         },
 
         _executeStepsAndWriteHistory : function (callback, builder, thisArg) {
@@ -78,17 +83,20 @@ module.exports = Aria.classDefinition({
                 steps.push(['pause', 1000]);
             }
 
-            function addToHistory(item, role) {
-                if (role != null) {
-                    item += ' ' + role;
-                }
-
+            function addToHistory(item) {
                 history.push(item);
             }
 
             // ------------------------------------------------------ processing
 
-            builder.call(thisArg, addStep, addToHistory, steps, history);
+            var api = {
+                addStep: addStep,
+                addToHistory: addToHistory,
+                steps: steps,
+                history: history
+            };
+
+            builder.call(thisArg, api);
 
             this.synEvent.execute(steps, {
                 scope: this,

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
@@ -77,26 +77,33 @@ module.exports = Aria.classDefinition({
 
             // ------------------------------------------------------ processing
 
-            this._executeStepsAndWriteHistory(callback, function (step, entry) {
+            this._executeStepsAndWriteHistory(callback, function (api) {
+                // ----------------------------------------------- destructuring
+
+                var step = api.addStep;
+                var entry = api.addToHistory;
+
+                // -------------------------------------------------- processing
+
                 step(['click', this.getElementById(dialog.elementBeforeId)]);
                 entry('Element before');
 
                 step(['type', null, '[tab]']);
-                entry(dialog.buttonLabel, 'Button');
+                entry(dialog.buttonLabel + ' Button');
 
                 step(['type', null, '[enter]']);
 
                 if (!dialog.fullyEmpty) {
-                    entry(dialog.title, 'dialog');
-                    entry(dialog.closeLabel, 'Button');
+                    entry(dialog.title + ' dialog');
+                    entry(dialog.closeLabel + ' Button');
 
                     step(['type', null, '[tab]']);
-                    entry(dialog.maximizeLabel, 'Button');
+                    entry(dialog.maximizeLabel + ' Button');
                 }
 
                 step(['type', null, '[escape]']);
                 if (!dialog.fullyEmpty) {
-                    entry(dialog.buttonLabel, 'Button');
+                    entry(dialog.buttonLabel + ' Button');
                 }
             });
         }

--- a/test/aria/widgets/wai/tabs/TabsJawsTest.js
+++ b/test/aria/widgets/wai/tabs/TabsJawsTest.js
@@ -53,6 +53,25 @@ module.exports = Aria.classDefinition({
         ////////////////////////////////////////////////////////////////////////
 
         runTemplateTest : function () {
+            this._filter = function (content) {
+                function createLineRegExp(content) {
+                    return new RegExp('^' + content + '\n?', 'gm');
+                }
+
+                var regexps = [];
+                regexps.push(createLineRegExp('Element before .*'));
+                regexps.push(createLineRegExp('separator'));
+                regexps.push(createLineRegExp('AT testsTab 0'));
+
+                for (var index = 0, length = regexps.length; index < length; index++) {
+                    var regexp = regexps[index];
+
+                    content = content.replace(regexp, '');
+                }
+
+                return content;
+            };
+
             this._localAsyncSequence(function (add) {
                 add('_testGroups');
                 add('_checkHistory');
@@ -84,14 +103,18 @@ module.exports = Aria.classDefinition({
 
             var tabs = group.tabs;
 
-            this._executeStepsAndWriteHistory(callback, function (step, entry) {
+            this._executeStepsAndWriteHistory(callback, function (api) {
+                // ----------------------------------------------- destructuring
+
+                var step = api.addStep;
+                var entry = api.addToHistory;
+
                 // --------------------------------------------- local functions
 
                 var self = this;
 
                 function selectStartPoint() {
                     step(['click', self.getElementById(group.elementBeforeId)]);
-                    entry('Element before ' + group.id + ' Link');
                 }
 
                 function getSelectedTabDescription(tab) {


### PR DESCRIPTION
- the `TabJawsTest` now ignores irrelevant content, especially the links that are clicked to have focus.
- the `EnhancedJawsTestCase` now supports the use of a filter
- the `JawsTestCase` now logs more information when there is an assert error