### PR TITLE
WAI-ARIA adds 4 new properties to manage aria label related attributes in the DOM

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -318,6 +318,23 @@ module.exports = Aria.beanDefinitions({
                     $description : "Indicates if the label must be displayed or not (if true the label is hidden)",
                     $default : false
                 },
+                "waiLabel" : {
+                    $type : "json:String",
+                    $description : "Sets aria-label on the input, value will be used as the attributes value"
+                },
+                "waiDescribedBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-describedby on the input, value will be used as the attributes value"
+                },
+                "waiLabelledBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-labelledby on the input, value will be used as the attributes value"
+                },
+                "waiLabelHidden" : {
+                    $type : "json:Boolean",
+                    $description : "Sets aria-hidden on the label when set to true",
+                    $default : false
+                },
                 "errorTipPosition" : {
                     $type : "json:String",
                     $description : "Possible values are: 'bottom left', 'bottom right', 'top left', 'top right'.",

--- a/src/aria/widgets/form/CheckBox.js
+++ b/src/aria/widgets/form/CheckBox.js
@@ -115,7 +115,7 @@ module.exports = Aria.classDefinition({
                     this._skinObj.simpleHTML ? ' style="display:inline-block"' : ' class="xSROnly"',
                     (Aria.testMode || cfg.waiAria) ? ' id="' + this._domId + '_input"' : '',
                     this._isChecked() ? ' checked' : '', ' type="', cfg._inputType, '"', name, ' value="',
-                    cfg.value, '" ', tabIndex, '/>'].join(''));
+                    cfg.value, '" ', tabIndex, this._getAriaLabelMarkup(), '/>'].join(''));
 
         },
 
@@ -163,6 +163,7 @@ module.exports = Aria.classDefinition({
             if (cfg.waiAria) {
                 out.write(' for="' + this._domId + '_input"');
             }
+            out.write(this._getAriaLabelHiddenMarkup());
             out.write('>');
             out.write(ariaUtilsString.escapeHTML(cfg.label));
 

--- a/src/aria/widgets/form/Input.js
+++ b/src/aria/widgets/form/Input.js
@@ -161,34 +161,26 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Updates the aria-label attribute on the DOM element if accessibility is enabled.
-         */
-        _updateAriaLabel : function () {
-            var element = this._getLabelledElement();
-            if (element) {
-                var ariaLabel = this._cfg.label;
-                if (ariaLabel != null) {
-                    element.setAttribute("aria-label", ariaLabel);
-                } else {
-                    element.removeAttribute("aria-label");
-                }
-            }
-        },
-
-        /**
-         * Returns the markup for aria-labelledby attribute on the DOM element if accessibility is enabled.
+         * Returns the markup for the aria-label related attributes on a DOM element if accessibility is enabled.
          * @protected
          */
         _getAriaLabelMarkup : function () {
+            var markup = [];
             if (this._cfg.waiAria) {
-                if (this._labelId) {
-                    return ' aria-labelledby="' + this._labelId + '" ';
-                } else {
-                    var ariaLabel = this._cfg.label;
-                    if (ariaLabel != null) {
-                        return ' aria-label="' + ariaUtilsString.encodeForQuotedHTMLAttribute(ariaLabel) + '" ';
-                    }
-                }
+              if (this._cfg.waiLabel) {markup.push(' aria-label="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiLabel) + '" ');}
+              if (this._cfg.waiLabelledBy) {markup.push(' aria-labelledby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiLabelledBy) + '" ');}
+              if (this._cfg.waiDescribedBy) {markup.push(' aria-describedby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiDescribedBy) + '" ');}
+            }
+            return markup.join('');
+        },
+
+        /**
+         * Returns the markup for the aria-hidden attribute on a DOM element if accessibility is enabled.
+         * @protected
+         */
+        _getAriaLabelHiddenMarkup : function () {
+            if (this._cfg.waiAria && this._cfg.waiLabelHidden) {
+              return ' aria-hidden="true"';
             }
             return '';
         },
@@ -349,7 +341,9 @@ module.exports = Aria.classDefinition({
             if (cfg.labelHeight > -1) {
                 out.write(';height:' + cfg.labelHeight + 'px');
             }
-            out.write(';text-align:' + cfg.labelAlign + ';">');
+            out.write(';text-align:' + cfg.labelAlign + ';"');
+            out.write(this._getAriaLabelHiddenMarkup());
+            out.write('>');
             out.write(ariaUtilsString.escapeHTML(cfg.label));
 
             out.write('</label>');
@@ -495,9 +489,6 @@ module.exports = Aria.classDefinition({
                 var label = this.getLabel();
                 if (label) {
                     label.innerHTML = ariaUtilsString.escapeHTML(newValue);
-                } else if (this._cfg.waiAria) {
-                    // check WAI flag for label attributes to be updated
-                    this._updateAriaLabel();
                 }
             }
             return this.$Widget._onBoundPropertyChange.apply(this, arguments);

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -33,6 +33,7 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonGroupJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.WaiInputLabelJawsTestSuite");
 
     }
 });

--- a/test/aria/widgets/wai/input/InputBaseTestCase.js
+++ b/test/aria/widgets/wai/input/InputBaseTestCase.js
@@ -37,84 +37,21 @@ module.exports = Aria.classDefinition({
             });
         },
 
-        checkAttributes : function () {
-            // get widgets to be tested
-            this.widgetDefaultWithLabel = this.getWidgetInstance("default - with label");
-            this.widgetDefaultNoLabel = this.getWidgetInstance("default - no label");
-            this.widgetEnabledWithLabelHidden = this.getWidgetInstance("enabled - with label hidden");
-            this.widgetEnabledWithBoundLabelHidden = this.getWidgetInstance("enabled - with bound label hidden");
-            this.widgetEnabledWithLabel = this.getWidgetInstance("enabled - with label");
-            this.widgetEnabledNoLabel = this.getWidgetInstance("enabled - no label");
-            this.widgetDisabledWithLabel = this.getWidgetInstance("disabled - with label");
-            this.widgetDisabledNoLabel = this.getWidgetInstance("disabled - no label");
-
-            // start test cases
-            this.checkAccessibilityUndefined();
-            this.checkAccessibilityEnabled();
-            this.checkAccessibilityDisabled();
-            this.notifyTemplateTestEnd();
-        },
-
-        checkAccessibility : function (widget) {
-            var widgetWithLabel = this[widget + "WithLabel"];
-            var inputWithLabel = widgetWithLabel.getTextInputField();
-            var inputNoLabel = this[widget + "NoLabel"].getTextInputField();
-
-            // if there is a label: aria-labelledby is not added to the input element
-            this.assertNull(inputWithLabel.getAttribute('aria-labelledby'), "If there is a label the attribute aria-labelledby is not added to the input element.");
-
-            // if there isn't a label: aria-label is not added to the input element
-            this.assertNull(inputNoLabel.getAttribute('aria-label'), "If there isn't a label the attribute aria-label is not added to the input element.");
-
-            // if there is a label then an id is not automatically added to the label element
-            this.assertFalsy(widgetWithLabel.getLabel().id, "There is no id generated for the label element.");
-        },
-
-        checkAccessibilityUndefined : function () {
-            this.checkAccessibility("widgetDefault");
-        },
-
-        checkAccessibilityDisabled : function () {
-            this.checkAccessibility("widgetDisabled");
-        },
-
-        checkAccessibilityEnabled : function () {
-            // No need to test label bindings, as a change in the value of the label doesn't impact the attributes set
-            var inputWithLabelHidden = this.widgetEnabledWithLabelHidden.getTextInputField();
-            var inputWithBoundLabelHidden = this.widgetEnabledWithBoundLabelHidden.getTextInputField();
-            var inputWithLabel = this.widgetEnabledWithLabel.getTextInputField();
-            var inputNoLabel = this.widgetEnabledNoLabel.getTextInputField();
-
-            // if there is a label then an id is automatically added to the label element
-            this.assertTruthy(this.widgetEnabledWithLabel.getLabel().id, "There is no id generated for the label element.");
-
-            // if there is a label: aria-labelledby is added to the input element
-            this.assertNotNull(inputWithLabel.getAttribute('aria-labelledby'), "checkAccessibilityEnabled: if there is a label the attribute aria-labelledby is added to the input element.");
-
-            // if there is a label: aria-labelledby is added to the input element, value is the id of the widget
-            this.assertEquals(this.widgetEnabledWithLabel.getLabel().id, inputWithLabel.getAttribute('aria-labelledby'), "checkAccessibilityEnabled: if there is a label the attribute aria-labelledby is added to the input element, value is the id of the widget.");
-
-            // if there isn't a label: aria-label is not added to the input element
-            this.assertNull(inputNoLabel.getAttribute('aria-label'));
-
-            // if there is a label defined but it is hidden using the hideLabel property: aria-label is added to the
-            // input element with the value of the label property
-            this.assertEquals(inputWithLabelHidden.getAttribute('aria-label'), "enabled - with label hidden");
-
-            // If there is a label defined but it is hidden using the hideLabel property and the value of the label
-            // property is updated through bidings: aria-label is added to the input element with the value of the label
-            // property, and then aria-label is changed to contain the new value updated through the label bindings
-            this.assertEquals(inputWithBoundLabelHidden.getAttribute('aria-label'), "enabled - with bound label hidden");
-
-            // update label value
-            aria.utils.Json.setValue(this.templateCtxt._tpl.data, "label", "enabled - with bound label hidden and updated value through bindings");
-
-            // test updated label value is now the new value of aria-label
-            this.assertEquals(inputWithBoundLabelHidden.getAttribute('aria-label'), "enabled - with bound label hidden and updated value through bindings");
+        checkAccessibility : function () {
+            var widget = this.getWidgetInstance("enabled");
+            var widgetWithLabelHidden = this.getWidgetInstance("enabled - with aria label hidden");
+            var input = widget.getTextInputField ? widget.getTextInputField() : widget._getFocusableElement();
+            var label = widgetWithLabelHidden.getLabel();
+            this.assertEquals(input.getAttribute('aria-labelledby'), 'waiLabelledBy', "If there is an ariaLabelledBy property defined the attribute aria-labelledby is added to the input element. %1 is not equal to %2.");
+            this.assertEquals(input.getAttribute('aria-describedby'), 'waiDescribedBy', "If there is an waiDescribedBy property defined the attribute aria-describedby is added to the input element. %1 is not equal to %2.");
+            this.assertEquals(input.getAttribute('aria-label'), 'waiLabel', "If there is an waiLabel property defined the attribute aria-label is added to the input element. %1 is not equal to %2.");
+            this.assertFalsy(input.getAttribute('aria-hidden'), "If there is an ariaLabelHidden property defined and set to false the attribute aria-hidden is not added to the label element.");
+            this.assertEquals(label.getAttribute('aria-hidden'), "true", "If there is an ariaLabelHidden property defined and set to true the attribute aria-hidden is added to the label element. %1 is not equal to %2.");
         },
 
         runTemplateTest : function () {
-            this.checkAttributes();
+            this.checkAccessibility();
+            this.notifyTemplateTestEnd();
         }
     }
 });

--- a/test/aria/widgets/wai/input/WaiInputTestSuite.js
+++ b/test/aria/widgets/wai/input/WaiInputTestSuite.js
@@ -18,15 +18,17 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TestSuite",
     $constructor : function () {
         this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxTestCase");
+        this.addTests("test.aria.widgets.wai.input.dateField.DateFieldTestCase");
+        this.addTests("test.aria.widgets.wai.input.datePicker.DatePickerTestCase");
+        this.addTests("test.aria.widgets.wai.input.multiSelect.MultiSelectTestCase");
+        this.addTests("test.aria.widgets.wai.input.numberField.NumberFieldTestCase");
+        this.addTests("test.aria.widgets.wai.input.passwordField.PasswordFieldTestCase");
+        this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonTestCase");
+        this.addTests("test.aria.widgets.wai.input.select.SelectTestCase");
+        this.addTests("test.aria.widgets.wai.input.selectBox.SelectBoxTestCase");
+        this.addTests("test.aria.widgets.wai.input.textArea.TextAreaTestCase");
         this.addTests("test.aria.widgets.wai.input.textField.TextFieldTestCase");
         this.addTests("test.aria.widgets.wai.input.timeField.TimeFieldTestCase");
-        this.addTests("test.aria.widgets.wai.input.textArea.TextAreaTestCase");
-        this.addTests("test.aria.widgets.wai.input.selectBox.SelectBoxTestCase");
-        this.addTests("test.aria.widgets.wai.input.select.SelectTestCase");
-        this.addTests("test.aria.widgets.wai.input.passwordField.PasswordFieldTestCase");
-        this.addTests("test.aria.widgets.wai.input.numberField.NumberFieldTestCase");
-        this.addTests("test.aria.widgets.wai.input.multiSelect.MultiSelectTestCase");
-        this.addTests("test.aria.widgets.wai.input.datePicker.DatePickerTestCase");
-        this.addTests("test.aria.widgets.wai.input.dateField.DateFieldTestCase");
     }
 });

--- a/test/aria/widgets/wai/input/checkbox/CheckboxLabelTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxLabelTestCaseTpl.tpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxLabelTestCaseTpl",
+    $hasScript : false
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        With accessibility enabled: <br>
+        {@aria:CheckBox {
+            id : "enabled",
+            waiAria : true,
+            label : "enabled",
+            labelWidth: 100,
+            waiLabel: "waiLabel",
+            waiDescribedBy: "waiDescribedBy",
+            waiLabelledBy: "waiLabelledBy",
+            waiLabelHidden: false
+        }/} <br><br>
+        With accessibility enabled - with aria label hidden: <br>
+        {@aria:CheckBox {
+            id : "enabled - with aria label hidden",
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiLabel: "waiLabel",
+            waiDescribedBy: "waiDescribedBy",
+            waiLabelledBy: "waiLabelledBy",
+            waiLabelHidden: true
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/checkbox/CheckboxTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxTestCase",
+    $extends : require("../InputBaseTestCase"),
+    $prototype : {
+        myTemplate : "test.aria.widgets.wai.input.checkbox.CheckboxLabelTestCaseTpl"
+    }
+});

--- a/test/aria/widgets/wai/input/dateField/DateFieldTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/dateField/DateFieldTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:DateField {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:DateField {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:DateField {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:DateField {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:DateField {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:DateField {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:DateField {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:DateField {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/datePicker/DatePickerTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/datePicker/DatePickerTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:DatePicker {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:DatePicker {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:DatePicker {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:DatePicker {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:DatePicker {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:DatePicker {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:DatePicker {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:DatePicker {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/label/CheckboxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/CheckboxJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.CheckboxJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "cbWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/DateFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/DateFieldJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.DateFieldJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "dfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/DatePickerJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/DatePickerJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.DatePickerJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "dpWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/LabelJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/LabelJawsTestCase.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.LabelJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.input.label.LabelJawsTestCaseTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this._testElement();
+        },
+        _testElement : function () {
+            var domElement = this.getElementById(this.elementsToTest);
+            this.synEvent.execute([["ensureVisible", domElement], ["click", domElement], ["pause", 1000],
+                    ["type", null, "[tab]"], ["pause", 1000], ["type", null, "[tab]"], ["pause", 1000]], {
+                fn : this._testValue,
+                scope : this
+            });
+        },
+        _testValue : function () {
+            this.assertJawsHistoryEquals(true, this._resetTest, function (response) {
+                if (!/waiLabel/.test(response) || !/aria label described by/.test(response)
+                        || !/aria label labelled by/.test(response)
+                        || /enabled - with aria label hidden/.test(response)) {
+                    return false;
+                }
+                return true;
+            });
+        },
+        _resetTest : function () {
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/label/LabelJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/label/LabelJawsTestCaseTpl.tpl
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.input.label.LabelJawsTestCaseTpl"
+}}
+    {macro main()}
+        <span id="label-for-described-by">aria label described by</span>
+        <span id="label-for-labelled-by">aria label labelled by</span>
+        <div style="margin:10px;font-size:+3;font-weight:bold;">Label accessibility sample</div>
+        <div style="margin:10px; overflow: auto; height: 600px;">
+            With accessibility enabled: <br><br>
+            {call checkBox("cbWaiEnabledStart") /}<br>
+            {call dateField("dfWaiEnabledStart") /}<br>
+            {call datePicker("dpWaiEnabledStart") /}<br>
+            {call multiSelect("msWaiEnabledStart") /}<br>
+            {call numberField("nfWaiEnabledStart") /}<br>
+            {call passwordField("pfWaiEnabledStart") /}<br>
+            {call radioButton("rbWaiEnabledStart") /}<br>
+            {call selectBox("sbWaiEnabledStart") /}<br>
+            {call textArea("taWaiEnabledStart") /}<br>
+            {call textField("tfWaiEnabledStart") /}<br>
+            {call timeField("tifWaiEnabledStart") /}<br>
+        </div>
+    {/macro}
+
+    {macro checkBox(id)}
+
+        <input type="text" {id id/}>
+        {@aria:CheckBox {
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiDescribedBy: "label-for-described-by",
+            waiLabelledBy: "label-for-labelled-by",
+            waiLabelHidden: true
+        }/} <br><br>
+        {@aria:CheckBox {
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiLabel: "waiLabel",
+            waiLabelHidden: true
+        }/} <br><br>
+    {/macro}
+
+    {macro dateField(id)}
+        <input type="text" {id id/}>
+        {@aria:DateField {
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiDescribedBy: "label-for-described-by",
+            waiLabelledBy: "label-for-labelled-by",
+            waiLabelHidden: true
+        }/} <br><br>
+        {@aria:DateField {
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiLabel: "waiLabel",
+            waiLabelHidden: true
+        }/} <br><br>
+    {/macro}
+
+    {macro datePicker(id)}
+        <input type="text" {id id/}>
+        {@aria:DatePicker {
+            label : "enabled - with aria label hidden",
+            iconTooltip: "Display calendar",
+            waiAria: true,
+            waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
+            waiAriaDateFormat: "EEEE d MMMM yyyy",
+            calendarShowShortcuts: false,
+            waiDescribedBy: "label-for-described-by",
+            waiLabelledBy: "label-for-labelled-by",
+            waiLabelHidden: true
+        }/}  <br><br>
+        {@aria:DatePicker {
+            label : "enabled - with aria label hidden",
+            iconTooltip: "Display calendar",
+            waiAria: true,
+            waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
+            waiAriaDateFormat: "EEEE d MMMM yyyy",
+            calendarShowShortcuts: false,
+            waiLabel: "waiLabel",
+            waiLabelHidden: true
+        }/}
+    {/macro}
+
+    {macro multiSelect(id)}
+            <input type="text" {id id/}>
+            {@aria:MultiSelect {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                items: [],
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:MultiSelect {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                items: [],
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+    {/macro}
+
+    {macro numberField(id)}
+            <input type="text" {id id/}>
+            {@aria:NumberField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:NumberField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+
+    {/macro}
+
+    {macro passwordField(id)}
+            <input type="text" {id id/}>
+            {@aria:PasswordField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:PasswordField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+    {/macro}
+
+    {macro radioButton(id)}
+        <input type="text" {id id/}>
+        {@aria:RadioButton {
+            id : 'radio1',
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            labelWidth: 100,
+            waiDescribedBy: "label-for-described-by",
+            waiLabelledBy: "label-for-labelled-by",
+            waiLabelHidden: true,
+            value: '1',
+            keyValue: '1'
+        }/} <br><br>
+        {@aria:RadioButton {
+            id : 'radio2',
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            labelWidth: 100,
+            waiLabel: "waiLabel",
+            waiLabelHidden: true,
+            value: '1',
+            keyValue: '1'
+        }/} <br><br>
+    {/macro}
+
+    {macro selectBox(id)}
+          <input type="text" {id id/}>
+          {@aria:SelectBox {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true,
+                options: [{label: 'option1',value: 1}]
+            }/} <br><br>
+            {@aria:SelectBox {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true,
+                options: [{label: 'option1',value: 1}]
+            }/} <br><br>
+    {/macro}
+
+    {macro textArea(id)}
+            <input type="text" {id id/}>
+            {@aria:Textarea {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:Textarea {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+    {/macro}
+
+    {macro textField(id)}
+            <input type="text" {id id/}>
+            {@aria:TextField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:TextField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+    {/macro}
+
+    {macro timeField(id)}
+            <input type="text" {id id/}>
+            {@aria:TimeField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiDescribedBy: "label-for-described-by",
+                waiLabelledBy: "label-for-labelled-by",
+                waiLabelHidden: true
+            }/} <br><br>
+            {@aria:TimeField {
+                waiAria : true,
+                label : "enabled - with aria label hidden",
+                labelWidth: 100,
+                waiLabel: "waiLabel",
+                waiLabelHidden: true
+            }/} <br><br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/label/MultiSelectJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/MultiSelectJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.MultiSelectJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "msWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/NumberFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/NumberFieldJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.NumberFieldJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "nfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/PasswordFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/PasswordFieldJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.PasswordFieldJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "pfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/RadioButtonJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/RadioButtonJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.RadioButtonJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "rbWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/SelectBoxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/SelectBoxJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.SelectBoxJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "sbWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/TextAreaJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/TextAreaJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.TextAreaJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "taWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/TextFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/TextFieldJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.TextFieldJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "tfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/TimeFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/TimeFieldJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.TimeFieldJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "tifWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/WaiInputLabelJawsTestSuite.js
+++ b/test/aria/widgets/wai/input/label/WaiInputLabelJawsTestSuite.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.WaiInputLabelJawsTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.widgets.wai.input.label.CheckboxJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.DateFieldJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.DatePickerJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.MultiSelectJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.NumberFieldJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.PasswordFieldJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.RadioButtonJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.SelectBoxJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.TextAreaJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.TextFieldJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.TimeFieldJawsTestCase");
+    }
+});

--- a/test/aria/widgets/wai/input/multiSelect/MultiSelectTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/multiSelect/MultiSelectTestCaseTpl.tpl
@@ -20,69 +20,28 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:MultiSelect {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                items: []
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:MultiSelect {
-                id : "default - no label",
-                labelWidth: 100,
-                items: []
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:MultiSelect {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                hideLabel: true,
-                items: []
+                items: [],
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:MultiSelect {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                },
-                items: []
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:MultiSelect {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                items: []
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:MultiSelect {
-                id : "enabled - no label",
-                waiAria : true,
-                items: []
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:MultiSelect {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                items: []
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:MultiSelect {
-                id : "disabled - no label",
-                waiAria : false,
-                items: []
+                label : "enabled - with aria label hidden",
+                items: [],
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/numberField/NumberFieldTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/numberField/NumberFieldTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:NumberField {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:NumberField {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:NumberField {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:NumberField {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:NumberField {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:NumberField {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:NumberField {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:NumberField {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/passwordField/PasswordFieldTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/passwordField/PasswordFieldTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:PasswordField {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:PasswordField {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:PasswordField {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:PasswordField {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:PasswordField {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:PasswordField {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:PasswordField {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:PasswordField {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/radiobutton/RadioButtonGroupLabelTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/radiobutton/RadioButtonGroupLabelTestCaseTpl.tpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.radiobutton.RadioButtonGroupLabelTestCaseTpl",
+    $hasScript : false
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        With accessibility enabled: <br>
+        {@aria:RadioButton {
+            id : "enabled",
+            waiAria : true,
+            label : "enabled",
+            labelWidth: 100,
+            waiLabel: "waiLabel",
+            waiDescribedBy: "waiDescribedBy",
+            waiLabelledBy: "waiLabelledBy",
+            waiLabelHidden: false
+        }/} <br><br>
+        With accessibility enabled - with aria label hidden: <br>
+        {@aria:RadioButton {
+            id : "enabled - with aria label hidden",
+            waiAria : true,
+            label : "enabled - with aria label hidden",
+            waiLabel: "waiLabel",
+            waiDescribedBy: "waiDescribedBy",
+            waiLabelledBy: "waiLabelledBy",
+            waiLabelHidden: true
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/radiobutton/RadioButtonTestCase.js
+++ b/test/aria/widgets/wai/input/radiobutton/RadioButtonTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.radiobutton.RadioButtonTestCase",
+    $extends : require("../InputBaseTestCase"),
+    $prototype : {
+        myTemplate : "test.aria.widgets.wai.input.radiobutton.RadioButtonGroupLabelTestCaseTpl"
+    }
+});

--- a/test/aria/widgets/wai/input/select/SelectTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/select/SelectTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:Select {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:Select {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:Select {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:Select {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:Select {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:Select {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:Select {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:Select {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/selectBox/SelectBoxTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/selectBox/SelectBoxTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:SelectBox {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:SelectBox {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:SelectBox {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:SelectBox {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:SelectBox {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:SelectBox {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:SelectBox {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:SelectBox {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/textArea/TextAreaTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/textArea/TextAreaTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:Textarea {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:Textarea {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:Textarea {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:Textarea {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:Textarea {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:Textarea {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:Textarea {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:Textarea {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/textField/TextFieldTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/textField/TextFieldTestCaseTpl.tpl
@@ -20,69 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:TextField {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100,
-                value: "default - with label"
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:TextField {
-                id : "default - no label",
-                labelWidth: 100,
-                value: "default - no label"
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:TextField {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:TextField {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:TextField {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100,
-                value: "enabled - with label"
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:TextField {
-                id : "enabled - no label",
-                waiAria : true,
-                value: "enabled - no label"
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:TextField {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false,
-                value: "disabled - with label"
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:TextField {
-                id : "disabled - no label",
-                waiAria : false,
-                value: "disabled - no label"
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 

--- a/test/aria/widgets/wai/input/timeField/TimeFieldTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/timeField/TimeFieldTestCaseTpl.tpl
@@ -20,63 +20,26 @@
     {macro main()}
         <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
         <div style="margin:10px;">
-            Using default accessibility and a label defined: <br>
+            With accessibility enabled: <br>
             {@aria:TimeField {
-                id : "default - with label",
-                label : "default - with label",
-                labelWidth: 100
-            }/} <br><br>
-            Using default accessibility and no label defined: <br>
-            {@aria:TimeField {
-                id : "default - no label",
-                labelWidth: 100
-            }/} <br><br>
-            With accessibility enabled and a label defined but hidden: <br>
-            {@aria:TimeField {
-                id : "enabled - with label hidden",
+                id : "enabled",
                 waiAria : true,
-                label : "enabled - with label hidden",
+                label : "enabled",
                 labelWidth: 100,
-                value: "enabled - with label hidden",
-                hideLabel: true
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: false
             }/} <br><br>
-            With accessibility enabled and a bound label defined but hidden: <br>
+            With accessibility enabled - with aria label hidden: <br>
             {@aria:TimeField {
-                id : "enabled - with bound label hidden",
+                id : "enabled - with aria label hidden",
                 waiAria : true,
-                label : "enabled - with bound label hidden",
-                labelWidth: 100,
-                value: "enabled - with bound label hidden",
-                hideLabel: true,
-                bind: {
-                  label: {
-                    to: "label",
-                    inside: data
-                  }
-                }
-            }/} <br><br>
-            With accessibility enabled and a label defined: <br>
-            {@aria:TimeField {
-                id : "enabled - with label",
-                waiAria : true,
-                label : "enabled - with label",
-                labelWidth: 100
-            }/} <br><br>
-            With accessibility enabled and no label defined: <br>
-            {@aria:TimeField {
-                id : "enabled - no label",
-                waiAria : true
-            }/}<br><br>
-            With accessibility disabled and a label defined: <br>
-            {@aria:TimeField {
-                id : "disabled - with label",
-                label : "disabled - with label",
-                waiAria : false
-            }/}<br><br>
-            With accessibility disabled and no label defined: <br>
-            {@aria:TimeField {
-                id : "disabled - no label",
-                waiAria : false
+                label : "enabled - with aria label hidden",
+                waiLabel: "waiLabel",
+                waiDescribedBy: "waiDescribedBy",
+                waiLabelledBy: "waiLabelledBy",
+                waiLabelHidden: true
             }/}
         </div>
 


### PR DESCRIPTION
This pull request provides the following changes: 

**Removes the following label related features that were previously developed in:**      

- https://github.com/ariatemplates/ariatemplates/pull/1511 Adding WAI support for the CheckBox widget
- https://github.com/ariatemplates/ariatemplates/pull/1504 Adding WAI support for Input widgets with/without labels

**Adds 4 new properties for input based widgets:**  

- `waiLabel:` sets 'aria-label' on the input, value will be used as the attributes value
- `waiDescribedBy:` sets 'aria-describedby' on the input, value will be used as the attributes value
- `waiLabelledBy:` sets 'aria-labelledby' on the input, value will be used as the attributes value
- `waiLabelHidden:` sets 'aria-hidden' on the label, value will be used as the attributes value  

_Note: these properties have been implemented just for INPUT based widgets._