### PR TITLE
Removing dependency on non-standard String.trim function

### DIFF
--- a/src/aria/utils/String.js
+++ b/src/aria/utils/String.js
@@ -48,8 +48,8 @@ module.exports = Aria.classDefinition({
          * @param {String} string If this argument is not a string, it is returned unmodified.
          * @return {String}
          */
-        trim : String.trim ? String.trim : function (string) {
-            return typeof string === 'string' ? string.replace(/^\s+|\s+$/g, '') : string;
+        trim : function (string) {
+            return typeof string === 'string' ? string.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '') : string;
         },
 
         /**


### PR DESCRIPTION
String.trim is a non-standard method implemented in Firefox:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#String_generic_methods

This PR removes the dependency on this method.
This also fixes the new `test.aria.utils.String.testNullTrim` test method which was introduced in #1626 (in commit afa3a47647ccd2a2c6f7285d1b039150e8049cfe) and was failing on Firefox.