### PR TITLE
WAI-ARIA adding support for aria label related attributes in the link widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1292,6 +1292,18 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:Boolean",
                     $description : "A boolean whether the button is disabled or not",
                     $default : false
+                },
+                "waiLabel" : {
+                    $type : "json:String",
+                    $description : "Sets aria-label on the link, value will be used as the attributes value"
+                },
+                "waiDescribedBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-describedby on the link, value will be used as the attributes value"
+                },
+                "waiLabelledBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-labelledby on the link, value will be used as the attributes value"
                 }
             }
         },

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -66,7 +66,7 @@ module.exports = Aria.classDefinition({
             }
             out.write(['<a', Aria.testMode ? ' id="' + this._domId + '_link"' : '', ' class="', linkClass,
                     '" href="javascript:(function(){})()"',
-                    (cfg.tabIndex != null ? ' tabindex=' + this._calculateTabIndex() + '"' : ''), '>',
+                    (cfg.tabIndex != null ? ' tabindex=' + this._calculateTabIndex() + '"' : ''), this._getAriaLabelMarkup(), '>',
                     ariaUtilsString.escapeHTML(cfg.label), '</a>'].join(''));
             cfg = null;
         },
@@ -78,6 +78,22 @@ module.exports = Aria.classDefinition({
         _init : function () {
             this._focusElt = this.getDom().firstChild;
             this.$ActionWidget._init.call(this);
+        },
+
+        /**
+
+        /**
+         * Returns the markup for the aria-label related attributes on a DOM element if accessibility is enabled.
+         * @protected
+         */
+        _getAriaLabelMarkup : function () {
+            var markup = [];
+            if (this._cfg.waiAria) {
+              if (this._cfg.waiLabel) {markup.push(' aria-label="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiLabel) + '" ');}
+              if (this._cfg.waiLabelledBy) {markup.push(' aria-labelledby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiLabelledBy) + '" ');}
+              if (this._cfg.waiDescribedBy) {markup.push(' aria-describedby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(this._cfg.waiDescribedBy) + '" ');}
+            }
+            return markup.join('');
         },
 
         /**

--- a/test/aria/widgets/wai/input/WaiInputTestSuite.js
+++ b/test/aria/widgets/wai/input/WaiInputTestSuite.js
@@ -21,6 +21,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxTestCase");
         this.addTests("test.aria.widgets.wai.input.dateField.DateFieldTestCase");
         this.addTests("test.aria.widgets.wai.input.datePicker.DatePickerTestCase");
+        this.addTests("test.aria.widgets.wai.input.link.LinkTestCase");
         this.addTests("test.aria.widgets.wai.input.multiSelect.MultiSelectTestCase");
         this.addTests("test.aria.widgets.wai.input.numberField.NumberFieldTestCase");
         this.addTests("test.aria.widgets.wai.input.passwordField.PasswordFieldTestCase");

--- a/test/aria/widgets/wai/input/label/LabelJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/label/LabelJawsTestCaseTpl.tpl
@@ -25,6 +25,7 @@
             {call checkBox("cbWaiEnabledStart") /}<br>
             {call dateField("dfWaiEnabledStart") /}<br>
             {call datePicker("dpWaiEnabledStart") /}<br>
+            {call link("lWaiEnabledStart") /}<br>
             {call multiSelect("msWaiEnabledStart") /}<br>
             {call numberField("nfWaiEnabledStart") /}<br>
             {call passwordField("pfWaiEnabledStart") /}<br>
@@ -94,6 +95,23 @@
             waiLabel: "waiLabel",
             waiLabelHidden: true
         }/}
+    {/macro}
+
+    {macro link(id)}
+            <input type="text" {id id/}>
+            {@aria:Link {
+              label : "enabled - with aria label hidden",
+              margins : "60 x x 60",
+              waiAria: true,
+              waiDescribedBy: "label-for-described-by",
+              waiLabelledBy: "label-for-labelled-by",
+            }/} <br><br>
+            {@aria:Link {
+              label : "enabled - with aria label hidden",
+              margins : "60 x x 60",
+              waiAria: true,
+              waiLabel: "waiLabel"
+            }/} <br><br>
     {/macro}
 
     {macro multiSelect(id)}

--- a/test/aria/widgets/wai/input/label/LinkJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/LinkJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.label.LinkJawsTestCase",
+    $extends : require("./LabelJawsTestCase"),
+    $prototype : {
+        elementsToTest : "lWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/input/label/WaiInputLabelJawsTestSuite.js
+++ b/test/aria/widgets/wai/input/label/WaiInputLabelJawsTestSuite.js
@@ -21,6 +21,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.label.CheckboxJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.DateFieldJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.DatePickerJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.label.LinkJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.MultiSelectJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.NumberFieldJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.PasswordFieldJawsTestCase");

--- a/test/aria/widgets/wai/input/link/LinkLabelTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/link/LinkLabelTestCaseTpl.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.link.LinkLabelTestCaseTpl",
+    $hasScript : false
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        With accessibility enabled: <br>
+        {@aria:Link {
+            id : "enabled",
+            waiAria : true,
+            label : "enabled",
+            waiLabel: "waiLabel",
+            waiDescribedBy: "waiDescribedBy",
+            waiLabelledBy: "waiLabelledBy"
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/link/LinkTestCase.js
+++ b/test/aria/widgets/wai/input/link/LinkTestCase.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.link.LinkTestCase",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.input.link.LinkLabelTestCaseTpl"
+        });
+    },
+    $prototype : {
+
+        checkAccessibility : function () {
+            var linkWidget = this.getWidgetInstance("enabled");
+            linkWidget.getDom();
+            var link = linkWidget._focusElt;
+            this.assertEquals(link.getAttribute('aria-labelledby'), 'waiLabelledBy', "If there is an ariaLabelledBy property defined the attribute aria-labelledby is added to the link element. %1 is not equal to %2.");
+            this.assertEquals(link.getAttribute('aria-describedby'), 'waiDescribedBy', "If there is an waiDescribedBy property defined the attribute aria-describedby is added to the link element. %1 is not equal to %2.");
+            this.assertEquals(link.getAttribute('aria-label'), 'waiLabel', "If there is an waiLabel property defined the attribute aria-label is added to the link element. %1 is not equal to %2.");
+        },
+
+        runTemplateTest : function () {
+            this.checkAccessibility();
+            this.notifyTemplateTestEnd();
+        }
+    }
+});


### PR DESCRIPTION
**Adds 3 new properties for the link widget:**

- `waiLabel:` sets 'aria-label' on the link, value will be used as the attributes value
- `waiDescribedBy:` sets 'aria-describedby' on the link, value will be used as the attributes value
- `waiLabelledBy:` sets 'aria-labelledby' on the link, value will be used as the attributes value

_Note: the 'aria-hidden' property is not needed as there is no label element for the link widget._