### PR TITLE
feat WAI-ARIA fixes an issue with the TextField widget when it is a required field

### DIFF
--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -339,7 +339,7 @@ module.exports = Aria.classDefinition({
                 spellCheck = ' spellcheck="' + (cfg.spellCheck ? "true" : "false") + '"';
             }
 
-            var ariaRequired = (cfg.waiAria && cfg.mandatory) ? ' required' : '';
+            var ariaRequired = (cfg.waiAria && cfg.mandatory) ? ' aria-required="true"' : '';
 
             if (this._isTextarea) {
                 out.write(['<textarea class="', className, '"', Aria.testMode ? ' id="' + this._domId + '_textarea"' : '',
@@ -763,9 +763,9 @@ module.exports = Aria.classDefinition({
                 if (cfg.waiAria && propertyName === 'mandatory') {
                     var input = this.getTextInputField();
                     if (newValue) {
-                        input.setAttribute("required", "");
+                        input.setAttribute("aria-required", "true");
                     } else {
-                        input.removeAttribute("required");
+                        input.removeAttribute("aria-required");
                     }
                 }
 

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -35,5 +35,9 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonGroupJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.WaiInputLabelJawsTestSuite");
 
+        this.addTests("test.aria.widgets.wai.textInputBased.NumberFieldMandatoryJawsTestCase");
+        this.addTests("test.aria.widgets.wai.textInputBased.TextAreaMandatoryJawsTestCase");
+        this.addTests("test.aria.widgets.wai.textInputBased.TextFieldMandatoryJawsTestCase");
+
     }
 });

--- a/test/aria/widgets/wai/textInputBased/MandatoryJawsTestCase.js
+++ b/test/aria/widgets/wai/textInputBased/MandatoryJawsTestCase.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.textInputBased.MandatoryJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.textInputBased.MandatoryJawsTestCaseTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this._testElement();
+        },
+        _testElement : function () {
+            var domElement = this.getElementById(this.elementsToTest);
+            this.synEvent.execute([["ensureVisible", domElement], ["click", domElement], ["pause", 1000],
+                    ["type", null, "[tab]"], ["pause", 1000], ["type", null, "[tab]"], ["pause", 1000]], {
+                fn : this._testValue,
+                scope : this
+            });
+        },
+        _testValue : function () {
+            this.assertJawsHistoryEquals(true, this._resetTest, function (response) {
+                if (!/Required/.test(response)) {
+                    return false;
+                }
+                return true;
+            });
+        },
+        _resetTest : function () {
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/wai/textInputBased/MandatoryJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/textInputBased/MandatoryJawsTestCaseTpl.tpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.textInputBased.MandatoryJawsTestCaseTpl"
+}}
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-weight:bold;">Mandatory accessibility sample</div>
+        <div style="margin:10px; overflow: auto; height: 600px;">
+            With accessibility enabled: <br><br>
+            {call numberField("nfWaiEnabledStart") /}<br>
+            {call textArea("taWaiEnabledStart") /}<br>
+            {call textField("tfWaiEnabledStart") /}<br>
+        </div>
+    {/macro}
+
+    {macro numberField(id)}
+        <input type="text" {id id/}>
+        {@aria:NumberField {
+            waiAria : true,
+            mandatory: true
+        }/} <br><br>
+    {/macro}
+
+    {macro textArea(id)}
+        <input type="text" {id id/}>
+        {@aria:Textarea {
+            waiAria : true,
+            mandatory: true
+        }/} <br><br>
+    {/macro}
+
+    {macro textField(id)}
+        <input type="text" {id id/}>
+        {@aria:TextField {
+            waiAria : true,
+            mandatory: true
+        }/} <br><br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/textInputBased/NumberFieldMandatoryJawsTestCase.js
+++ b/test/aria/widgets/wai/textInputBased/NumberFieldMandatoryJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.textInputBased.NumberFieldMandatoryJawsTestCase",
+    $extends : require("./MandatoryJawsTestCase"),
+    $prototype : {
+        elementsToTest : "nfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/textInputBased/TextAreaMandatoryJawsTestCase.js
+++ b/test/aria/widgets/wai/textInputBased/TextAreaMandatoryJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.textInputBased.TextAreaMandatoryJawsTestCase",
+    $extends : require("./MandatoryJawsTestCase"),
+    $prototype : {
+        elementsToTest : "taWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/textInputBased/TextFieldMandatoryJawsTestCase.js
+++ b/test/aria/widgets/wai/textInputBased/TextFieldMandatoryJawsTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.textInputBased.TextFieldMandatoryJawsTestCase",
+    $extends : require("./MandatoryJawsTestCase"),
+    $prototype : {
+        elementsToTest : "tfWaiEnabledStart"
+    }
+});

--- a/test/aria/widgets/wai/textInputBased/TextInputTestCase.js
+++ b/test/aria/widgets/wai/textInputBased/TextInputTestCase.js
@@ -71,9 +71,9 @@ module.exports = Aria.classDefinition({
 
             dataUtils.validateModel(data);
             if (data.mandatory) {
-                this.assertTrue(input.getAttribute("required") != null, "required should be set in " + inputId);
+                this.assertTrue(input.getAttribute("aria-required") != null, "required should be set in " + inputId);
             } else {
-                this.assertTrue(input.getAttribute("required") == null, "required shouldn't be set in " + inputId);
+                this.assertTrue(input.getAttribute("aria-required") == null, "required shouldn't be set in " + inputId);
             }
 
             if (input.parentNode.className.indexOf("Error") > -1) {


### PR DESCRIPTION
The attribute `aria-required="true"`is now added to the widgets input dom element when the widget property `mandatory: true` is set.  