### PR TITLE
feat WAI-ARIA fixes an issue with the Fieldset widget label being read at the end of the Fieldset

### DIFF
--- a/src/aria/widgets/container/Fieldset.js
+++ b/src/aria/widgets/container/Fieldset.js
@@ -74,7 +74,7 @@ module.exports = Aria.classDefinition({
          */
         _init : function () {
             var domElt = this.getDom();
-            var content = aria.utils.Dom.getDomElementChild(domElt, 0);
+            var content = (this._cfg.label && this._cfg.waiAria) ? aria.utils.Dom.getDomElementChild(domElt, 1) : aria.utils.Dom.getDomElementChild(domElt, 0);
             this._frame.linkToDom(content);
             this.$Container._init.call(this);
         },
@@ -113,6 +113,10 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _widgetMarkupBegin : function (out) {
+            var label = this._cfg.label;
+            if (label && this._cfg.waiAria) {
+                out.write('<span class="xSROnly">' + ariaUtilsString.escapeHTML(label) + '</span>');
+            }
             this._frame.writeMarkupBegin(out);
         },
 
@@ -125,8 +129,8 @@ module.exports = Aria.classDefinition({
             this._frame.writeMarkupEnd(out);
             var label = this._cfg.label;
             if (label) {
-                out.write('<span class="xFieldset_' + this._cfg.sclass + '_normal_label">'
-                        + ariaUtilsString.escapeHTML(label) + '</span>');
+                var ariaHidden = this._cfg.waiAria ? ' aria-hidden="true"' : '';
+                out.write('<span class="xFieldset_' + this._cfg.sclass + '_normal_label"' + ariaHidden + '>' + ariaUtilsString.escapeHTML(label) + '</span>');
             }
         }
     }

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -39,5 +39,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.textInputBased.TextAreaMandatoryJawsTestCase");
         this.addTests("test.aria.widgets.wai.textInputBased.TextFieldMandatoryJawsTestCase");
 
+        this.addTests("test.aria.widgets.wai.fieldset.FieldsetLabelJawsTestCase");
+
     }
 });

--- a/test/aria/widgets/wai/fieldset/FieldsetLabelJawsTestCase.js
+++ b/test/aria/widgets/wai/fieldset/FieldsetLabelJawsTestCase.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.fieldset.FieldsetLabelJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.fieldset.FieldsetLabelJawsTestCaseTpl"
+        });
+        this.elementsToTest = "fsWaiEnabledStart";
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this._testElement();
+        },
+        _testElement : function () {
+            var domElement = this.getElementById(this.elementsToTest);
+            this.synEvent.execute([["ensureVisible", domElement], ["click", domElement], ["pause", 1000],
+                    ["type", null, "[down]"], ["pause", 1000], ["type", null, "[down]"], ["pause", 1000],
+                    ["type", null, "[down]"], ["pause", 1000], ["type", null, "[down]"], ["pause", 1000]], {
+                fn : this._testValue,
+                scope : this
+            });
+        },
+        _testValue : function () {
+            this.assertJawsHistoryEquals(true, this._resetTest, function (response) {
+                return /Group A\nradio button not checked\nOption A\nEnd of template/.test(response);
+            });
+        },
+        _resetTest : function () {
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/wai/fieldset/FieldsetLabelJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/fieldset/FieldsetLabelJawsTestCaseTpl.tpl
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.fieldset.FieldsetLabelJawsTestCaseTpl"
+}}
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-weight:bold;">Fieldset label accessibility sample</div>
+        <div style="margin:10px; overflow: auto; height: 600px;">
+            With accessibility enabled: <br><br>
+            {call fieldset("fsWaiEnabledStart") /}<br>
+        </div>
+    {/macro}
+
+    {macro fieldset(id)}
+
+      <input type="text" {id id/}>
+      {@aria:Fieldset {
+        label: "Group A",
+        width: 300,
+        waiAria : true
+      }}
+        {@aria:RadioButton {
+          label: "Option A",
+          keyValue: "a",
+          block: true,
+          waiAria : true
+        }/}
+       {/@aria:Fieldset}
+       <span>End of template</span>
+       <br><br>
+
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This change marks the current label with "aria-hidden", and adds another span containing the class "xSROnly" with the label content, and renders this span in the correct position before the frame.

_Note: this change is only switched on when accessibility is enabled._