### PR TITLE
Listening to tap events for popup icons of DatePicker and similar widgets

### DIFF
--- a/src/aria/touch/Event.js
+++ b/src/aria/touch/Event.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 var Aria = require("../Aria");
-
+var ariaUtilsDevice = require("../utils/Device");
 
 /**
  * Event utility to handle touch device detection.
@@ -49,8 +49,8 @@ module.exports = Aria.classDefinition({
                 this.touch = false;
                 return;
             }
-            this.touch = (('ontouchstart' in Aria.$frameworkWindow) || Aria.$frameworkWindow.DocumentTouch
-                    && Aria.$frameworkWindow.document instanceof Aria.$frameworkWindow.DocumentTouch);
+            this.touch = ariaUtilsDevice.isTouch();
+
             if (!this.touch) {
                 this.touchEventMap = {
                     "touchstart" : "mousedown",

--- a/src/aria/utils/$SafeTap.js
+++ b/src/aria/utils/$SafeTap.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var asyncRequire = require("noder-js/asyncRequire").create(module);
+var touchDevice = require("./Device").isTouch();
+var ariaTouchClickBuster = null;
+
+var registerSafeTap = function (event) {
+    if (ariaTouchClickBuster) {
+        ariaTouchClickBuster.registerTap(event);
+        return true;
+    } else {
+        return false;
+    }
+};
+
+var getRegisterSafeTap = exports.getRegisterSafeTap = function () {
+    return registerSafeTap;
+};
+
+getRegisterSafeTap.$preload = function () {
+    if (touchDevice) {
+        return asyncRequire("../touch/ClickBuster", "../touch/SafeTap").spreadSync(function (clickBuster) {
+            ariaTouchClickBuster = clickBuster;
+        });
+    }
+};

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -321,7 +321,7 @@ module.exports = Aria.classDefinition({
          */
         _toggleDropdown : function () {
             // toggleDropdown should not make the virtual keyboard appear on touch devices
-            this._updateFocusNoKeyboard();
+            this._updateFocusNoKeyboard(true);
             var report = this.controller.toggleDropdown(this.getTextInputField().value, this._dropdownPopup != null);
             this._reactToControllerReport(report, {
                 hasFocus : true

--- a/src/aria/widgets/frames/FrameWithIcons.js
+++ b/src/aria/widgets/frames/FrameWithIcons.js
@@ -20,6 +20,7 @@ var ariaUtilsType = require("../../utils/Type");
 var ariaUtilsArray = require("../../utils/Array");
 var ariaUtilsDelegate = require("../../utils/Delegate");
 var ariaUtilsString = require("../../utils/String");
+var registerSafeTap = require("../../utils/$SafeTap").getRegisterSafeTap();
 
 /**
  * A frame with icons on the left and right. To create an object of this class, use the createFrame static method (not
@@ -206,6 +207,7 @@ module.exports = Aria.classDefinition({
          */
         eventMap : {
             "click" : "iconClick",
+            "safetap" : "iconClick",
             "mousedown" : "iconMouseDown",
             "mouseup" : "iconMouseUp",
             "keydown" : "iconKeyDown",
@@ -484,7 +486,15 @@ module.exports = Aria.classDefinition({
          * @param {String} iconName
          */
         _delegateIcon : function (event, iconName) {
-            var eventName = this.eventMap[event.type];
+            var eventType = event.type;
+            if (eventType == "safetap" && !registerSafeTap(event)) {
+                // $SafeTap does not load the SafeTap class on non-touch devices
+                // however, that class may be loaded for any other reason, in which case
+                // we can receive safetap events but then registerSafeTap returns false
+                // and we can ignore the safetap event (as there will be also a click event)
+                return;
+            }
+            var eventName = this.eventMap[eventType];
             if (eventName) {
                 this.$raiseEvent({
                     name : eventName,


### PR DESCRIPTION
In order to fix issues when trying to open the DatePicker popup (or popups of similar widgets), we now listen to the tap event instead of the click event on touch devices.

Touch devices are detected using `aria.utils.Device.isTouch()`.
`aria.touch.Tap` is only loaded if a touch device is detected.