### PR TITLE
Making dialog title and buttons focusable or not by configuration

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2053,6 +2053,18 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:Boolean",
                     $description : "Whether the first element in the dialog is automatically focused when the dialog is displayed. By default, it is true for modal dialogs and false for other dialogs."
                 },
+                "focusableTitle" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the title of the dialog is focusable. By default, this property takes the same value as waiAria."
+                },
+                "focusableMaximize" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the maximize button of the dialog is focusable. By default, this property is true only if waiAria is true and maximizeLabel is defined."
+                },
+                "focusableClose" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the close button of the dialog is focusable. By default, this property is true only if waiAria is true and closeLabel is defined."
+                },
                 "xpos" : {
                     $type : "json:Integer",
                     $description : "x position of the top left corner of the dialog box.",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -216,6 +216,15 @@ module.exports = Aria.classDefinition({
             if (cfg.autoFocus == null) {
                 cfg.autoFocus = cfg.modal;
             }
+            if (cfg.focusableTitle == null) {
+                cfg.focusableTitle = cfg.waiAria;
+            }
+            if (cfg.focusableClose == null) {
+                cfg.focusableClose = !!(cfg.waiAria && cfg.closeLabel);
+            }
+            if (cfg.focusableMaximize == null) {
+                cfg.focusableMaximize = !!(cfg.waiAria && cfg.maximizeLabel);
+            }
         },
 
         /**
@@ -258,7 +267,7 @@ module.exports = Aria.classDefinition({
          * @param {String} cssClassPostfix
          * @param {String} skinIcon
          */
-        __writeTitlebarButton : function (out, delegateId, cssClassPostfix, skinIcon, label) {
+        __writeTitlebarButton : function (out, delegateId, cssClassPostfix, skinIcon, label, focusable) {
             // --------------------------------------------------- destructuring
 
             var cfg = this._cfg;
@@ -295,15 +304,19 @@ module.exports = Aria.classDefinition({
                 waiAria : waiAria
             };
 
-            if (waiAria) {
-                if (label) {
-                    iconConfiguration.tooltip = label;
-                    iconConfiguration.label = label;
-                }
+            if (label) {
+                iconConfiguration.tooltip = label;
+                iconConfiguration.label = label;
+            }
 
+            if (label || focusable) {
                 iconConfiguration.role = 'button';
+            }
+
+            if (focusable) {
                 iconConfiguration.tabIndex = 0;
             }
+
 
             var button = new ariaWidgetsIcon(iconConfiguration, this._context, this._lineNumber);
 
@@ -359,6 +372,9 @@ module.exports = Aria.classDefinition({
                 maxHeight = math.min(this._cfg.maxHeight, containerSize.height);
                 maxWidth = math.min(this._cfg.maxWidth, containerSize.width);
             }
+
+            this.writeTitleBar(out);
+
             this._div = new ariaWidgetsContainerDiv({
                 sclass : this._skinObj.divsclass,
                 margins : "0 0 0 0",
@@ -403,6 +419,10 @@ module.exports = Aria.classDefinition({
                             '</span>'].join(''));
                 }
             }
+        },
+
+        writeTitleBar: function (out) {
+            var cfg = this._cfg;
 
             // title bar (begin) -----------------------------------------------
 
@@ -427,6 +447,9 @@ module.exports = Aria.classDefinition({
             if (cfg.waiAria) {
                 attributes.push('id="' + this.__getLabelId() + '"');
             }
+            if (cfg.focusableTitle) {
+                attributes.push('tabIndex="0"');
+            }
             attributes.push('class="' + [
                 'x' + this._skinnableClass + '_title',
                 'x' + this._skinnableClass + '_' + cfg.sclass + '_title'
@@ -442,7 +465,7 @@ module.exports = Aria.classDefinition({
                     fn : this._onCloseBtnEvent,
                     scope : this
                 });
-                this.__writeTitlebarButton(out, this._closeDelegateId, "close", "closeIcon", this._cfg.closeLabel);
+                this.__writeTitlebarButton(out, this._closeDelegateId, "close", "closeIcon", this._cfg.closeLabel, this._cfg.focusableClose);
             }
 
             // title bar > maximize button -------------------------------------
@@ -452,7 +475,7 @@ module.exports = Aria.classDefinition({
                     fn : this._onMaximizeBtnEvent,
                     scope : this
                 });
-                this.__writeTitlebarButton(out, this._maximizeDelegateId, "maximize", "maximizeIcon", this._cfg.maximizeLabel);
+                this.__writeTitlebarButton(out, this._maximizeDelegateId, "maximize", "maximizeIcon", this._cfg.maximizeLabel, this._cfg.focusableMaximize);
             }
 
             // title bar (end) -------------------------------------------------
@@ -774,7 +797,7 @@ module.exports = Aria.classDefinition({
             var cfg = this._cfg;
             var getDomElementChild = ariaUtilsDom.getDomElementChild;
             this._domElt = this._popup.domElement;
-            var titleBarDomElt = this._titleBarDomElt = getDomElementChild(this._domElt, 0, true);
+            var titleBarDomElt = this._titleBarDomElt = getDomElementChild(this._domElt, 0);
             this._titleDomElt = getDomElementChild(titleBarDomElt, cfg.icon ? 1 : 0);
             this._onDimensionsChanged();
 
@@ -1210,7 +1233,7 @@ module.exports = Aria.classDefinition({
             }
             if (this._handlesArr) {
                 this._resizable = {};
-                var handleArr = this._handlesArr, index = 0, parent = this._domElt, getDomElementChild = ariaUtilsDom.getDomElementChild;
+                var handleArr = this._handlesArr, index = 1, parent = this._domElt, getDomElementChild = ariaUtilsDom.getDomElementChild;
                 for (var i = 0, ii = handleArr.length; i < ii; i++) {
                     var handleElement = getDomElementChild(parent, ++index, false), axis = null, cursor;
                     cursor = handleArr[i];

--- a/src/aria/widgets/container/DialogStyle.tpl.css
+++ b/src/aria/widgets/container/DialogStyle.tpl.css
@@ -22,6 +22,7 @@
     {macro main()}
         .xDialog_titleBar {
             position:absolute;
+            z-index: 1;
         }
         .xDialog_icon {
             float:left;
@@ -128,8 +129,7 @@
             {/if}
         }
         .xDialog_${skinClassName}_title {
-            padding-left: 6px;
-            padding-top: 6px;
+            padding: 6px;
             color:${skinClass.titleColor};
             font-weight:bold;
             white-space: nowrap;

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -47,6 +47,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.multiselect.MultiSelectJawsTest");
 
         this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipJawsTestSuite");
-
+        this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableItemsJawsTestSuite");
     }
 });

--- a/test/aria/widgets/container/dialog/resize/AbstractResizableDialogTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/AbstractResizableDialogTestCase.js
@@ -386,7 +386,7 @@ Aria.classDefinition({
             var options = {};
             options.parent = this.getWidgetInstance(dialogId)._domElt;
             if (index) {
-                options.handle = aria.utils.Dom.getDomElementChild(options.parent, index, false);
+                options.handle = aria.utils.Dom.getDomElementChild(options.parent, index + 1, false);
             }
             return options;
         },

--- a/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollTestCase.js
@@ -103,7 +103,7 @@ Aria.classDefinition({
             var options = {};
             options.parent = this.getWidgetInstance(dialogId)._domElt;
             if (index) {
-                options.handle = aria.utils.Dom.getDomElementChild(options.parent, index, false);
+                options.handle = aria.utils.Dom.getDomElementChild(options.parent, 1 + index, false);
             }
             return options;
         }

--- a/test/aria/widgets/container/dialog/sizes/DialogMaxWidthTestCase.js
+++ b/test/aria/widgets/container/dialog/sizes/DialogMaxWidthTestCase.js
@@ -49,8 +49,8 @@ Aria.classDefinition({
 
             var dom = dialog._domElt;
             var children = dom.children;
-            var dialogBody = children[0];
-            var dialogTitle = children[1];
+            var dialogBody = children[1];
+            var dialogTitle = children[0];
             var dialogTitleText = aria.utils.Dom.getElementsByClassName(dialogTitle, "xDialog_title")[0];
             var dialogCloseIcon = aria.utils.Dom.getElementsByClassName(dialogTitle, "xDialog_close")[0];
 

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableCloseButtonJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableCloseButtonJawsTestCase.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.FocusableCloseButtonJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.focusableItems.Tpl",
+            data : {
+                dialogs: [{
+                    title: "Mydialogtitle",
+                    macro: "dialogContent",
+                    closeLabel: "Myclosebutton",
+                    width: 500,
+                    height: 500,
+                    modal: true,
+                    waiAria: true,
+                    bind: {
+                        visible: {
+                            to: "visible",
+                            inside: {}
+                        }
+                    }
+                }]
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("button0")],
+                ["pause", 2000],
+                ["type", null, "[tab]"],
+                ["pause", 2000],
+                ["type", null, "[escape]"],
+                ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(true, this.end, function (text) {
+                        return !/Do nothing Button/.test(text) && /Mydialogtitle/.test(text) && /Myclosebutton Button/.test(text);
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableItemsJawsTestSuite.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableItemsJawsTestSuite.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.FocusableItemsJawsTestSuite",
+    $extends : "aria.jsunit.TestSuite",
+    $constructor : function () {
+        this.$TestSuite.constructor.call(this);
+        this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableTitleJawsTestCase");
+        this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.UnfocusableTitleJawsTestCase");
+        this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableCloseButtonJawsTestCase");
+        this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.UnfocusableCloseButtonJawsTestCase");
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableTitleJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/FocusableTitleJawsTestCase.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.FocusableTitleJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.focusableItems.Tpl",
+            data : {
+                dialogs: [{
+                    title: "Mydialogtitle",
+                    macro: "dialogContent",
+                    width: 500,
+                    height: 500,
+                    modal: true,
+                    waiAria: true,
+                    bind: {
+                        visible: {
+                            to: "visible",
+                            inside: {}
+                        }
+                    }
+                }]
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("button0")],
+                ["pause", 2000],
+                ["type", null, "[down][down][down]"],
+                ["pause", 2000],
+                ["type", null, "[escape]"],
+                ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(true, this.end, function (text) {
+                        return !/Do nothing Button/.test(text) && /Mydialogtitle/.test(text) && /This is the content of my dialog!/.test(text);
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/Tpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/Tpl.tpl
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.Tpl",
+    $hasScript : true
+}}
+
+    {macro main()}
+        <div style="margin: 10px;">
+            {foreach dlg in data.dialogs}
+                {separator}<br><br>{/separator}
+                {@aria:Button {
+                    id: "button" + dlg_index,
+                    label: "Show dialog " + dlg_index + " (" + dlg.title + ")",
+                    onclick: {
+                        fn: openDialog,
+                        args: dlg
+                    }
+                }/}
+                {@aria:Dialog dlg/}
+            {/foreach}
+        </div>
+    {/macro}
+
+    {macro dialogContent()}
+        <p>This is the content of my dialog!</p>
+        {@aria:Button {
+            label: "Do nothing"
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/TplScript.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/TplScript.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.focusableItems.TplScript',
+
+    $prototype : {
+        openDialog : function (evt, dlg) {
+            this.$json.setValue(dlg.bind.visible.inside, dlg.bind.visible.to, true);
+        },
+
+        defaultDialogCfg: function () {
+            return {
+                title: "Default dialog",
+                macro: "dialogContent",
+                width: 500,
+                height: 500,
+                modal: true,
+                waiAria: true,
+                bind: {
+                    visible: {
+                        inside: {
+                            value: false
+                        },
+                        to: "value"
+                    }
+                }
+            };
+        },
+
+        $dataReady: function () {
+            var data = this.data;
+            if (!data.dialogs) {
+                data.dialogs = [];
+                var dlg;
+
+                dlg = this.defaultDialogCfg();
+                data.dialogs.push(dlg);
+
+                dlg = this.defaultDialogCfg();
+                dlg.title = "Dialog with focusable title and focusable buttons";
+                dlg.maximizable = true;
+                dlg.closeLabel = "Close";
+                dlg.maximizeLabel = "Maximize";
+                data.dialogs.push(dlg);
+
+                dlg = this.defaultDialogCfg();
+                dlg.title = "Dialog with focusable title, focusable maximize and unfocusable close";
+                dlg.focusableClose = false;
+                dlg.maximizable = true;
+                dlg.closeLabel = "Close";
+                dlg.maximizeLabel = "Maximize";
+                data.dialogs.push(dlg);
+
+                dlg = this.defaultDialogCfg();
+                dlg.title = "Dialog with focusable title and unfocusable buttons";
+                dlg.focusableClose = false;
+                dlg.focusableMaximize = false;
+                dlg.maximizable = true;
+                dlg.closeLabel = "Close";
+                dlg.maximizeLabel = "Maximize";
+                data.dialogs.push(dlg);
+
+            }
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/UnfocusableCloseButtonJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/UnfocusableCloseButtonJawsTestCase.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.UnfocusableCloseButtonJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.focusableItems.Tpl",
+            data : {
+                dialogs: [{
+                    title: "Mydialogtitle",
+                    macro: "dialogContent",
+                    closeLabel: "Myclosebutton",
+                    focusableClose: false,
+                    width: 500,
+                    height: 500,
+                    modal: true,
+                    waiAria: true,
+                    bind: {
+                        visible: {
+                            to: "visible",
+                            inside: {}
+                        }
+                    }
+                }]
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("button0")],
+                ["pause", 2000],
+                ["type", null, "[tab]"],
+                ["pause", 2000],
+                ["type", null, "[escape]"],
+                ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(true, this.end, function (text) {
+                        return /Do nothing Button/.test(text) && /Mydialogtitle/.test(text) && !/Myclosebutton Button/.test(text);
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/focusableItems/UnfocusableTitleJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/focusableItems/UnfocusableTitleJawsTestCase.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.focusableItems.UnfocusableTitleJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.focusableItems.Tpl",
+            data : {
+                dialogs: [{
+                    title: "Mydialogtitle",
+                    macro: "dialogContent",
+                    focusableTitle: false,
+                    width: 500,
+                    height: 500,
+                    modal: true,
+                    waiAria: true,
+                    bind: {
+                        visible: {
+                            to: "visible",
+                            inside: {}
+                        }
+                    }
+                }]
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("button0")],
+                ["pause", 2000],
+                ["type", null, "[down][down][down]"],
+                ["pause", 2000],
+                ["type", null, "[escape]"],
+                ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(true, this.end, function (text) {
+                        return /Do nothing Button/.test(text) && /Mydialogtitle/.test(text) && !/This is the content of my dialog!/.test(text);
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/modal/Base.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/Base.js
@@ -271,6 +271,7 @@ module.exports = Aria.classDefinition({
             this._localAsyncSequence(function (add) {
                 add('_openDialog', dialog);
                 add('_navigateForward');
+                add('_navigateForward');
 
                 add('_pressEnter');
                 add(isMaximized.waitForTrue);
@@ -287,6 +288,7 @@ module.exports = Aria.classDefinition({
 
             this._localAsyncSequence(function (add) {
                 add('_openDialog', dialog);
+                add('_navigateForward');
 
                 add('_pressEnter');
                 add(isOpened.waitForFalse);

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
@@ -93,8 +93,11 @@ module.exports = Aria.classDefinition({
 
                 step(['type', null, '[enter]']);
 
+                entry(dialog.title + ' dialog');
+                entry(dialog.title);
+
                 if (!dialog.fullyEmpty) {
-                    entry(dialog.title + ' dialog');
+                    step(['type', null, '[tab]']);
                     entry(dialog.closeLabel + ' Button');
 
                     step(['type', null, '[tab]']);
@@ -102,9 +105,8 @@ module.exports = Aria.classDefinition({
                 }
 
                 step(['type', null, '[escape]']);
-                if (!dialog.fullyEmpty) {
-                    entry(dialog.buttonLabel + ' Button');
-                }
+
+                entry(dialog.buttonLabel + ' Button');
             });
         }
     }


### PR DESCRIPTION
This PR adds 3 new configuration options for `aria:Dialog` widgets:
- `focusableTitle`: whether the title of the dialog is focusable. By default, it is set to true if `waiAria` is true.
- `focusableClose` and `focusableMaximize`: whether the corresponding button is focusable. By default, it is set to true if `waiAria` is true and the corresponding label is defined.
