### PR TITLE
Fixing random failures of ExpandButtonCheck

### DIFF
--- a/test/aria/widgets/form/autocomplete/expandbutton/test4/ExpandButtonCheck.js
+++ b/test/aria/widgets/form/autocomplete/expandbutton/test4/ExpandButtonCheck.js
@@ -21,51 +21,37 @@ Aria.classDefinition({
          * This method is always the first entry point to a template test Start the test by focusing the first field
          */
         runTemplateTest : function () {
-            this.synEvent.click(this.getInputField("ac1"), {
-                fn : this._clickAC,
+            var field = this.getInputField("ac1");
+            this.synEvent.click(field, {
+                fn : function () {
+                    this.waitForDomEltFocus(field, this._clickAC);
+                },
                 scope : this
             });
         },
 
-        _clickAC : function (id, continueWith) {
+        _clickAC : function (id) {
             var expandButton = this.getExpandButton("ac1");
             this.synEvent.click(expandButton, {
-                fn : this._openAC,
+                fn : function () {
+                    this.waitForDropDownPopup("ac1", this._afterSelect);
+                },
                 scope : this
             });
-        },
-
-        _openAC : function (evt, args) {
-            aria.core.Timer.addCallback({
-                fn : this._selectFirstItem,
-                scope : this,
-                delay : 1000
-            });
-        },
-
-        _selectFirstItem : function () {
-            aria.core.Timer.addCallback({
-                fn : this._afterSelect,
-                scope : this,
-                delay : 1000
-            });
-
         },
 
         _afterSelect : function () {
             this.synEvent.type(null, "[down][down][enter]", {
-                fn : this._checkSelected,
+                fn : function () {
+                    this.waitFor({
+                        condition: function () {
+                            return !this.getWidgetDropDownPopup("ac1");
+                        },
+                        callback: this._checkSelectedEntry
+                    });
+                },
                 scope : this
             });
-        },
-
-        _checkSelected : function () {
-            aria.core.Timer.addCallback({
-                fn : this._checkSelectedEntry,
-                scope : this,
-                delay : 1000
-            });
-
         },
 
         _checkSelectedEntry : function () {
@@ -73,53 +59,56 @@ Aria.classDefinition({
             this.assertTrue(value == "Finnair", "The value of the autocomplete is " + value
                     + ", but it should be Finnair");
 
-            this.synEvent.click(this.getInputField("ac1"), {
-                fn : this._clickAC2,
-                scope : this
-            });
-        },
-
-        _clickAC2 : function (id, continueWith) {
             var expandButton = this.getExpandButton("ac1");
             this.synEvent.click(expandButton, {
-                fn : this._openAC2,
+                fn : function (evt, args) {
+                    this.waitForDropDownPopup("ac1", this._afterSelect2);
+                },
                 scope : this
-            });
-        },
-
-        _openAC2 : function (evt, args) {
-            aria.core.Timer.addCallback({
-                fn : this._checkHighlighted,
-                scope : this,
-                delay : 1000
-            });
-        },
-
-        _checkHighlighted : function () {
-            aria.core.Timer.addCallback({
-                fn : this._afterSelect2,
-                scope : this,
-                delay : 1000
             });
         },
 
         _afterSelect2 : function () {
-            var dropdownPopup = this.getWidgetInstance("ac1")._dropdownPopup;
-            var selectedElt = this.getElementsByClassName(dropdownPopup.domElement, "xListSelectedItem_dropdown")[0];
+            var dropdownPopup = this.getWidgetDropDownPopup("ac1");
+            var selectedElt = this.getElementsByClassName(dropdownPopup, "xListSelectedItem_dropdown")[0];
 
             this.assertTrue(selectedElt.innerHTML.match(/<strong>Finnair<\/strong>/gi).length == 1, "The value of the selected element is "
                     + selectedElt.innerHTML + ", but it should be \n<strong>Finnair</strong>\n");
 
             var expandButton = this.getExpandButton("ac1");
             this.synEvent.click(expandButton, {
-                fn : this._closeAC,
+                fn : function () {
+                    this.waitFor({
+                        condition: function () {
+                            return !this.getWidgetDropDownPopup("ac1");
+                        },
+                        callback: this._clickAC2
+                    });
+                },
+                scope : this
+            });
+        },
+
+        _clickAC2 : function (id) {
+            var field = this.getInputField("ac1");
+            this.synEvent.click(field, {
+                fn : function () {
+                    this.waitForDomEltFocus(field, this._closeAC);
+                },
                 scope : this
             });
         },
 
         _closeAC : function () {
             this.synEvent.type(null, "[backspace][backspace][backspace][backspace][backspace][backspace][backspace]", {
-                fn : this._checkText,
+                fn : function () {
+                    this.waitFor({
+                        condition: function () {
+                            return this.getInputField("ac1").value === "";
+                        },
+                        callback: this._checkText
+                    });
+                },
                 scope : this
             });
         },
@@ -130,7 +119,7 @@ Aria.classDefinition({
             var expandButton = this.getExpandButton("ac1");
             this.synEvent.click(expandButton, {
                 fn : function () {
-                  this.waitForDropDownPopup("ac1", this._openAC3);
+                    this.waitForDropDownPopup("ac1", this._openAC3);
                 },
                 scope : this
             });


### PR DESCRIPTION
This PR makes `ExpandButtonCheck` more stable by using `waitFor` functions.

(cf a random failure here: https://travis-ci.org/ariatemplates/ariatemplates/builds/142181917#L1287)