### PR TITLE
Adding the titleTag property on the ErrorList widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1594,6 +1594,15 @@ module.exports = Aria.beanDefinitions({
                     $description : "Title to be displayed in the widget.",
                     $default : ""
                 },
+                "titleTag" : {
+                    $type : "json:String",
+                    $description : "HTML tag used to display the title in the widget.",
+                    $regExp: /^[a-z0-9]+$/i
+                },
+                "titleClassName" : {
+                    $type : "json:String",
+                    $description : "CSS classes to style the title. It is only taken into account if titleTag is specified."
+                },
                 "filterTypes" : {
                     $type : "json:Array",
                     $description : "If not null, specifies the types of messages which should be displayed in the widget. It must match the type property in aria.utils.validators.CfgBeans.Message.",

--- a/src/aria/widgets/errorlist/CfgBeans.js
+++ b/src/aria/widgets/errorlist/CfgBeans.js
@@ -37,6 +37,14 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "Title for the list of messages."
                 },
+                "titleTag" : {
+                    $type : "json:String",
+                    $description : "HTML tag used to display the title."
+                },
+                "titleClassName" : {
+                    $type : "json:String",
+                    $description : "CSS classes to style the title. It is only taken into account if titleTag is specified."
+                },
                 "displayCodes" : {
                     $type : "json:Boolean",
                     $description : "True if message codes should be displayed along with localized messages."

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -58,6 +58,8 @@ module.exports = Aria.classDefinition({
                     filterTypes : cfg.filterTypes,
                     displayCodes : cfg.displayCodes,
                     title : cfg.title,
+                    titleTag : cfg.titleTag,
+                    titleClassName : cfg.titleClassName,
                     messages : cfg.messages
                 }
             }

--- a/src/aria/widgets/errorlist/ErrorListController.js
+++ b/src/aria/widgets/errorlist/ErrorListController.js
@@ -45,6 +45,8 @@ module.exports = Aria.classDefinition({
             this._data = {
                 waiAria : args.waiAria,
                 title : args.title,
+                titleTag : args.titleTag,
+                titleClassName : args.titleClassName,
                 divCfg : args.divCfg,
                 filterTypes : args.filterTypes,
                 displayCodes : args.displayCodes

--- a/src/aria/widgets/errorlist/ErrorListTemplate.tpl
+++ b/src/aria/widgets/errorlist/ErrorListTemplate.tpl
@@ -21,8 +21,14 @@
     {macro main()}
         {if data.messages.length > 0}
             {@aria:Div data.divCfg}
+                {if data.titleTag}
+                    <${data.titleTag} {if data.titleClassName}class="${data.titleClassName}"{/if}>
+                {/if}
                 {@aria:Icon {icon: getIcon()}/}
                 <span style="padding: 3px 16px 3px 10px; font-weight: bold;"{if data.waiAria} tabindex="0"{/if}>${data.title}</span>
+                {if data.titleTag}
+                    </${data.titleTag}>
+                {/if}
                 <div style="padding: 3px 0 0 0;">
                     {call messagesList(data.messages)/}
                 </div>

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -29,6 +29,7 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
         this.addTests("test.aria.widgets.wai.errorlist.binding.ErrorListBindingJawsTestCase");
+        this.addTests("test.aria.widgets.wai.errorlist.titleTag.ErrorListTitleTagJawsTestCase");
         this.addTests("test.aria.widgets.wai.tabs.TabsJawsTest");
 
         this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxJawsTestCase");

--- a/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagJawsTestCase.js
+++ b/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagJawsTestCase.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+require("ariatemplates/widgets/errorlist/ErrorListTemplate.tpl"); // just to be sure the template is loaded when the test is run, since it depends on its (DOM) content
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.errorlist.titleTag.ErrorListTitleTagJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+
+    $constructor : function() {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.errorlist.titleTag.ErrorListTitleTagTpl"
+        });
+     },
+
+    $prototype : {
+        runTemplateTest : function () {
+            var classNameCheck = this.getElementsByClassName(this.testDiv, "myErrorListH1ClassName");
+            this.assertEquals(classNameCheck.length, 1, "Unexpected number of tags with the myErrorListH1ClassName class: %1");
+            this.assertEquals(classNameCheck[0].tagName.toLowerCase(), "h1", "Unexpected element with the myErrorListH1ClassName class: %1");
+            this.assertTrue(classNameCheck[0].innerHTML.indexOf("MyErrorListTitleWithFirstHeadingLevel") > -1, "The element with the myErrorListH1ClassName class does not have the expected content.");
+
+            this.synEvent.execute([
+                ["type", null, "[<insert>][F6][>insert<]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[enter]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(
+                        "Heading List dialog\nheadings List view\nMyErrorListTitleWithFirstHeadingLevel : 1\n1 of 3\nMyErrorListTitleWithSecondHeadingLevel : 2\nMyErrorListTitleWithThirdHeadingLevel : 3\nheading level 3 MyErrorListTitleWithThirdHeadingLevel\nMyErrorListTitleWithThirdHeadingLevel\nheading level 3\nlist of 1 items\n• MyError3Description\nlist end\nMyErrorListTitleWithNoHTag",
+                        this.end,
+                        function (response) {
+                            return response.split("\n").filter(function (line) {
+                                return line.indexOf("page") == -1 &&
+                                    line.indexOf("Arrow") == -1 ;
+                            }).join("\n");
+                        }
+                    );
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagTpl.tpl
+++ b/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagTpl.tpl
@@ -1,0 +1,51 @@
+{Template {
+    $classpath : "test.aria.widgets.wai.errorlist.titleTag.ErrorListTitleTagTpl"
+}}
+
+    {macro main()}
+        <div style="margin: 10px;">
+            {@aria:ErrorList {
+                margins: "10 1 10 1",
+                title: "MyErrorListTitleWithFirstHeadingLevel",
+                titleTag: "h1",
+                titleClassName: "myErrorListH1ClassName",
+                waiAria: true,
+                messages: [{
+                    type: "E",
+                    localizedMessage: "MyError1Description"
+                }]
+            }/}
+            {@aria:ErrorList {
+                margins: "10 1 10 1",
+                title: "MyErrorListTitleWithSecondHeadingLevel",
+                titleTag: "h2",
+                waiAria: true,
+                messages: [{
+                    type: "E",
+                    localizedMessage: "MyError2Description"
+                }]
+            }/}
+
+            {@aria:ErrorList {
+                margins: "10 1 10 1",
+                title: "MyErrorListTitleWithThirdHeadingLevel",
+                titleTag: "h3",
+                waiAria: true,
+                messages: [{
+                    type: "E",
+                    localizedMessage: "MyError3Description"
+                }]
+            }/}
+
+            {@aria:ErrorList {
+                margins: "10 1 10 1",
+                title: "MyErrorListTitleWithNoHTag",
+                waiAria: true,
+                messages: [{
+                    type: "E",
+                    localizedMessage: "MyError4Description"
+                }]
+            }/}
+        </div>
+  {/macro}
+{/Template}


### PR DESCRIPTION
This PR adds the `titleTag` property on the `ErrorList` widget to allow setting the tag used for the title in the `ErrorList` widget.

This is especially useful for accessibility: screen readers often provide a way to navigate through the heading tags of the page.