### PR TITLE
Adding the titleTag property on the Dialog widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2012,6 +2012,11 @@ module.exports = Aria.beanDefinitions({
                     $description : "The title of the dialog which will be displayed in the header",
                     $default : ""
                 },
+                "titleTag" : {
+                    $type : "json:String",
+                    $description : "HTML tag used to display the title in the widget. The default value is 'h1' when waiAria is true and 'span' otherwise.",
+                    $regExp: /^[a-z0-9]+$/i
+                },
                 "visible" : {
                     $type : "json:Boolean",
                     $description : "A boolean whether the dialog is visible",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -225,6 +225,9 @@ module.exports = Aria.classDefinition({
             if (cfg.focusableMaximize == null) {
                 cfg.focusableMaximize = !!(cfg.waiAria && cfg.maximizeLabel);
             }
+            if (cfg.titleTag == null) {
+                cfg.titleTag = cfg.waiAria ? "h1" : "span";
+            }
         },
 
         /**
@@ -455,7 +458,7 @@ module.exports = Aria.classDefinition({
                 'x' + this._skinnableClass + '_' + cfg.sclass + '_title'
             ].join(' ') + '"');
 
-            out.write('<span ' + attributes.join(' ') + '>' + ariaUtilsString.escapeHTML(cfg.title) + '</span>');
+            out.write('<' + cfg.titleTag + ' ' + attributes.join(' ') + '>' + ariaUtilsString.escapeHTML(cfg.title) + '</' + cfg.titleTag + '>');
 
             // title bar > close button ----------------------------------------
 

--- a/src/aria/widgets/container/DialogStyle.tpl.css
+++ b/src/aria/widgets/container/DialogStyle.tpl.css
@@ -28,6 +28,8 @@
             float:left;
         }
         .xDialog_title {
+            margin: 0px;
+            font-size: 1em;
             float:left;
         }
         .xDialog_close {

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -49,5 +49,6 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipJawsTestSuite");
         this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableItemsJawsTestSuite");
+        this.addTests("test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagJawsTestCase");
     }
 });

--- a/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
+++ b/test/aria/widgets/wai/popup/dialog/modal/ModalDialogJawsTest.js
@@ -94,7 +94,7 @@ module.exports = Aria.classDefinition({
                 step(['type', null, '[enter]']);
 
                 entry(dialog.title + ' dialog');
-                entry(dialog.title);
+                entry(dialog.title + ' heading level 1');
 
                 if (!dialog.fullyEmpty) {
                     step(['type', null, '[tab]']);

--- a/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagJawsTestCase.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+
+    $constructor : function() {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagTpl"
+        });
+     },
+
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["type", null, "[<insert>][F6][>insert<]"],
+                ["pause", 1000],
+                ["type", null, "[enter]"],
+                ["pause", 1000],
+                ["type", null, "[<insert>][F7][>insert<]"],
+                ["pause", 1000],
+                ["type", null, "[up]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[<alt>]m[>alt<]"],
+                ["pause", 1000],
+                ["type", null, "[escape]"],
+                ["pause", 1000],
+                ["type", null, "[<insert>][F6][>insert<]"],
+                ["pause", 1000],
+                ["type", null, "[enter]"],
+                ["pause", 1000],
+                ["type", null, "[<insert>][F7][>insert<]"],
+                ["pause", 1000],
+                ["type", null, "[up]"],
+                ["pause", 1000],
+                ["type", null, "[down]"],
+                ["pause", 1000],
+                ["type", null, "[<alt>]m[>alt<]"],
+                ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(
+                        // This test is intended to be run in attester only.
+                        // The list of links takes into account the "Pause" link displayed by attester
+                        "Heading List dialog\nheadings List view\nMyDialogTitle : 1\n1 of 1\nheading level 1 MyDialogTitle\nMyDialogTitle heading level 1\nLinks List dialog\nlinks List view\nLinkInTheDialog\n2 of 2\nPause\nLinkInTheDialog\nLink LinkInTheDialog\nLinkInTheDialog Link\nHeading List dialog\nheadings List view\nBackgroundTitle : 1\n1 of 1\nheading level 1 BackgroundTitle\nBackgroundTitle\nheading level 1\nLinks List dialog\nlinks List view\nBackgroundLink\n2 of 2\nPause\nBackgroundLink\nLink BackgroundLink\nBackgroundLink Link",
+                        this.end,
+                        function (response) {
+                            return response.split("\n").filter(function (line) {
+                                return line.indexOf("page") == -1 &&
+                                    line.indexOf("Arrow") == -1 ;
+                            }).join("\n");
+                        }
+                    );
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagTpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagTpl.tpl
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagTpl"
+}}
+
+    {macro main()}
+        <h1>BackgroundTitle</h1>
+
+        <a href="http://ariatemplates.com">BackgroundLink</a>
+
+        {@aria:Dialog {
+            waiAria: true,
+            modal: true,
+            title: "MyDialogTitle",
+            macro: "dialogContent",
+            width: 500,
+            height: 200,
+            visible: true,
+            bind: {
+                visible: {
+                    to: "dialogVisible",
+                    inside: data
+                }
+            }
+        } /}
+    {/macro}
+
+    {macro dialogContent()}
+        <a href="http://at-diff.ariatemplates.com">LinkInTheDialog</a>
+    {/macro}
+{/Template}


### PR DESCRIPTION
This PR adds the `titleTag` property to the Dialog widget to allow setting the tag used for the title in the dialog.
By default, the tag used for dialogs is now `h1` when `waiAria` is `true` and `span` (as before) otherwise.

This is especially useful for accessibility: screen readers often provide a way to navigate through the heading tags of the page.
