### PR TITLE
Adding the waiEscapeMsg and waiCloseMsg properties on the Dialog widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2044,6 +2044,14 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "The label to use for the close icon (can be used in various ways such as for tooltip or accessibility)."
                 },
+                "waiEscapeMsg" : {
+                    $type : "json:String",
+                    $description : "If this property is defined and if waiAria is activated, the user has to press escape twice (instead of only once) to close the dialog. This property specifies the message to read after the user pressed escape the first time."
+                },
+                "waiCloseMsg" : {
+                    $type : "json:String",
+                    $description : "When waiAria is activated, this property specifies the message to read when the modal dialog is closed."
+                },
                 "maximizable" : {
                     $type : "json:Boolean",
                     $description : "Whether the dialog has a maximize button in its title bar. Note that you can set this to false and programatically maximize the Dialog to achieve a fullscreen-only Dialog solution.",

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -50,5 +50,6 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipJawsTestSuite");
         this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableItemsJawsTestSuite");
         this.addTests("test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagJawsTestCase");
+        this.addTests("test.aria.widgets.wai.popup.dialog.waiEscapeMsg.DialogEscapeJawsTestCase");
     }
 });

--- a/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeJawsTestCase.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.waiEscapeMsg.DialogEscapeJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+
+    $constructor : function() {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.waiEscapeMsg.DialogEscapeTpl"
+        });
+     },
+
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("myInput")],
+                ["pause", 1000],
+                ["type", null, "[tab]"],
+                ["pause", 1000],
+                ["type", null, "[space]"],
+                ["pause", 1000],
+                ["type", null, "[escape]"],
+                ["pause", 1000],
+                ["type", null, "[escape]"],
+                ["pause", 5000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(
+                        "Open dialog Button\nMyDialogTitle dialog\nMyDialogTitle heading level 1\nPress escape again to close the dialog.\nOpen dialog Button\nMyDialog is closed.",
+                        this.end,
+                        function (response) {
+                            return response.split("\n").filter(function (line) {
+                                return line.indexOf("Edit") == -1 &&
+                                    line.indexOf("Type") == -1 ;
+                            }).join("\n");
+                        }
+                    );
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeTpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeTpl.tpl
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.popup.dialog.waiEscapeMsg.DialogEscapeTpl"
+}}
+
+    {macro main()}
+        <input {id "myInput"/}>
+        {@aria:Button {
+            label: "Open dialog",
+            onclick: function () {
+                this.$json.setValue(this.data, "dialogVisible", true);
+            }
+        }/}
+        {@aria:Dialog {
+            waiAria: true,
+            modal: true,
+            title: "MyDialogTitle",
+            macro: "dialogContent",
+            width: 500,
+            height: 200,
+            waiEscapeMsg: "Press escape again to close the dialog.",
+            waiCloseMsg: "MyDialog is closed.",
+            bind: {
+                visible: {
+                    to: "dialogVisible",
+                    inside: data
+                }
+            }
+        } /}
+    {/macro}
+
+    {macro dialogContent()}
+        Sample dialog
+    {/macro}
+{/Template}


### PR DESCRIPTION
This PR adds the following properties on the dialog widget:

- `waiEscapeMsg`: If this property is defined and if `waiAria` is activated, the user has to press escape twice (instead of only once) to close the dialog. This property specifies the message to read after the user pressed escape the first time.

- `waiCloseMsg`: When `waiAria` is activated, this property specifies the message to read when the modal dialog is closed.