### PR TITLE
Jaws reads "not checked unavailable" when the checkbox is checked (and disabled)

### DIFF
--- a/src/aria/widgets/form/RadioButton.js
+++ b/src/aria/widgets/form/RadioButton.js
@@ -203,13 +203,12 @@ var ariaWidgetsFormCheckBox = require("./CheckBox");
              * @protected
              */
             _updateDomForState : function () {
+                this.$CheckBox._updateDomForState.call(this);
                 if (this._cfg.waiAria) {
                     // update the attributes for WAI
                     var element = this._getFocusableElement();
                     element.setAttribute('tabindex', this._calculateTabIndex());
                 }
-
-                this.$CheckBox._updateDomForState.call(this);
             },
 
             /**

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -33,6 +33,10 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.tabs.TabsJawsTest");
 
         this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxInitiallyDisabledJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxDynamicallyDisabledJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxNotCheckedDisabledJawsTestCase");
+
         this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonGroupJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.WaiInputLabelJawsTestSuite");

--- a/test/aria/widgets/wai/input/checkbox/CheckBoxDisabledBaseJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckBoxDisabledBaseJawsTestCase.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledBaseJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.data = {};
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledTestCaseTpl",
+            data: this.data
+        });
+        this.defaultTestTimeout = 120000;
+    },
+    $prototype : {
+        EXPECTED_OUTPUT_DISABLED: "First textfield Edit\nstd input 1 check box checked Unavailable\nstd input 1\nstd input 2 check box checked Unavailable\nstd input 3 check box checked Unavailable\nsimple input 1 check box checked Unavailable\nsimple input 1\nsimple input 2 check box checked Unavailable\nsimple input 3 check box checked Unavailable\nLast textfield",
+
+        setupCheckedDisabledState: function () {
+            var data = this.data;
+            aria.utils.Json.setValue(data, "checkboxChecked", true);
+            aria.utils.Json.setValue(data, "checkboxDisabled", true);
+        },
+
+        removeCheckedDisabledState: function () {
+            aria.utils.Json.setValue(this.data, "checkboxDisabled", false);
+        },
+
+        runTemplateTest : function () {
+            function step1() {
+                this.checkAllCheckedUnavailable(step2);
+            }
+
+            function step2() {
+                this.clearJawsHistory(step3);
+            }
+
+            function step3() {
+                this.checkDontReact(step4);
+            }
+
+            function step4() {
+                this.clearJawsHistory(step5);
+            }
+
+            function step5() {
+                this.removeCheckedDisabledState();
+                this.checkAllEnabled(this.end);
+            }
+
+            step1.call(this);
+        },
+
+        filterResponse: function (response) {
+            response = response.replace(/(^|\n).*type.*(?=\n)/gi, "").trim();
+            response = response.replace(/\n(?=check box)/gi, " "); // replaces the new line before "check box" by a space
+            // sometimes Jaws says something and immediately correct himself, we only take into account the correction:
+            response = response.replace(/not checked Unavailable\n(?=checked Unavailable\n)/gi, "");
+            response = this.removeDuplicates(response);
+            return response;
+        },
+
+        checkAllCheckedUnavailable : function (cb) {
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 500],
+                ["type", null, "[tab]"], ["pause", 500],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(
+                        "First textfield Edit\nLast textfield Edit\n" + this.EXPECTED_OUTPUT_DISABLED,
+                        cb,
+                        this.filterResponse
+                    );
+                },
+                scope: this
+            });
+        },
+
+        checkDontReact : function (cb) {
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 1500],
+                ["type", null, "[down]"], ["pause", 500]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(this.EXPECTED_OUTPUT_DISABLED, cb, this.filterResponse);
+                },
+                scope: this
+            });
+        },
+
+        checkAllEnabled : function (cb) {
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500],
+                ["type", null, "[down]"], ["pause", 500]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(this.EXPECTED_OUTPUT_DISABLED.replace(/ unavailable/gi, ""), cb, this.filterResponse);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/checkbox/CheckboxDisabledTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxDisabledTestCaseTpl.tpl
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledTestCaseTpl"
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        <fieldset style="margin:10px;">
+            <legend>State of the checkboxes</legend>
+            {@aria:CheckBox {
+                waiAria : true,
+                label : "Checked",
+                labelWidth: 100,
+                bind: {
+                    value: {
+                        to: "checkboxChecked",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            {@aria:CheckBox {
+                waiAria : true,
+                label : "Disabled",
+                labelWidth: 100,
+                bind: {
+                    value: {
+                        to: "checkboxDisabled",
+                        inside: data
+                    }
+                }
+            }/}
+        </fieldset>
+
+        {@aria:TextField {
+            id : "tf1",
+            label : "First textfield",
+            labelWidth: 100,
+            value: "",
+            margins: "10 10 10 10"
+        }/}
+
+        {call checkBoxes("std") /}
+        {call checkBoxes("simple") /}
+
+        {@aria:TextField {
+            id : "tf2",
+            label : "Last textfield",
+            labelWidth: 100,
+            value: "",
+            margins: "10 10 10 10"
+        }/}
+
+    {/macro}
+
+    {macro checkBoxes(sclass)}
+        <div style="margin:10px;">
+            {@aria:CheckBox {
+                waiAria : true,
+                label : sclass + " input 1",
+                labelWidth: 100,
+                sclass: sclass,
+                bind: {
+                    disabled: {
+                        to: "checkboxDisabled",
+                        inside: data
+                    },
+                    value: {
+                        to: "checkboxChecked",
+                        inside: data
+                    }
+                }
+            }/}
+            {@aria:CheckBox {
+                waiAria : true,
+                label : sclass + " input 2",
+                waiLabelHidden: true,
+                waiLabel : sclass + " input 2",
+                labelWidth: 100,
+                sclass: sclass,
+                bind: {
+                    disabled: {
+                        to: "checkboxDisabled",
+                        inside: data
+                    },
+                    value: {
+                        to: "checkboxChecked",
+                        inside: data
+                    }
+                }
+            }/}
+            <span class="xSROnly" id="${sclass+"input3Label"}" aria-hidden="true">${sclass} input 3</span>
+            {@aria:CheckBox {
+                waiAria : true,
+                label: sclass + " input 3",
+                waiLabelHidden: true,
+                waiLabelledBy: sclass + "input3Label",
+                labelWidth: 100,
+                sclass: sclass,
+                bind: {
+                    disabled: {
+                        to: "checkboxDisabled",
+                        inside: data
+                    },
+                    value: {
+                        to: "checkboxChecked",
+                        inside: data
+                    }
+                }
+            } /}
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/checkbox/CheckboxDynamicallyDisabledJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxDynamicallyDisabledJawsTestCase.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxDynamicallyDisabledJawsTestCase",
+    $extends : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledBaseJawsTestCase",
+    $prototype : {
+        runTemplateTest: function () {
+            this.setupCheckedDisabledState();
+            this.$CheckboxDisabledBaseJawsTestCase.runTemplateTest.call(this);
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/checkbox/CheckboxInitiallyDisabledJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxInitiallyDisabledJawsTestCase.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxInitiallyDisabledJawsTestCase",
+    $extends : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledBaseJawsTestCase",
+    $constructor : function () {
+        this.$CheckboxDisabledBaseJawsTestCase.constructor.call(this);
+        this.setupCheckedDisabledState();
+    }
+});

--- a/test/aria/widgets/wai/input/checkbox/CheckboxNotCheckedDisabledJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxNotCheckedDisabledJawsTestCase.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.checkbox.CheckboxNotCheckedDisabledJawsTestCase",
+    $extends : "test.aria.widgets.wai.input.checkbox.CheckboxDisabledBaseJawsTestCase",
+    $constructor : function () {
+        this.$CheckboxDisabledBaseJawsTestCase.constructor.call(this);
+        aria.utils.Json.setValue(this.data, "checkboxDisabled", true);
+        aria.utils.Json.setValue(this.data, "checkboxChecked", false);
+        this.EXPECTED_OUTPUT_DISABLED = this.EXPECTED_OUTPUT_DISABLED.replace(/checked/gi, "not checked");
+    }
+});


### PR DESCRIPTION
This PR fixes the following issue in IE 11 / Jaws 16: in some cases a disabled checked checkbox is read as "not checked unavailable" instead of "checked unavailable".