### PR TITLE
Initially disabled radio buttons misbehaving when enabled

### DIFF
--- a/src/aria/widgets/form/RadioButton.js
+++ b/src/aria/widgets/form/RadioButton.js
@@ -39,17 +39,13 @@ var ariaWidgetsFormCheckBox = require("./CheckBox");
          */
         $constructor : function (cfg, ctxt) {
             this.$CheckBox.constructor.apply(this, arguments);
-            if (this._skinObj.simpleHTML) {
-                if (!idManager) {
-                    idManager = new ariaUtilsIdManager("radio");
-                }
-                this._inputName = idManager.getId();
+            if (!idManager) {
+                idManager = new ariaUtilsIdManager("radio");
             }
+            this._inputName = idManager.getId();
 
             // use array and not store as index is important
-            if (!this._cfg.disabled) {
-                this._instances.push(this);
-            }
+            this._instances.push(this);
         },
 
         $destructor : function () {
@@ -174,7 +170,7 @@ var ariaWidgetsFormCheckBox = require("./CheckBox");
                 var index = ariaUtilsArray.indexOf(this._instances, this), radioButtonNb = this._instances.length;
                 var bindings, next, nextBinding;
                 var waiAria = this._cfg.waiAria;
-                while (index > 0 || index < radioButtonNb) {
+                while (index >= 0 && index < radioButtonNb) {
                     index = index + direction;
                     if (waiAria) {
                         if (index < 0) {
@@ -188,7 +184,7 @@ var ariaWidgetsFormCheckBox = require("./CheckBox");
                     }
                     next = this._instances[index];
                     bindings = next._cfg.bind;
-                    if (bindings) {
+                    if (!next.getProperty("disabled") && bindings) {
                         nextBinding = bindings.value;
                         if (nextBinding) {
                             // next radio button needs to be bound to the same data. Otherwise, continue.

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -34,6 +34,7 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.wai.input.checkbox.CheckboxJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonGroupJawsTestCase");
+        this.addTests("test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsJawsTestCase");
         this.addTests("test.aria.widgets.wai.input.label.WaiInputLabelJawsTestSuite");
         this.addTests("test.aria.widgets.wai.iconLabel.IconLabelJawsTest");
 

--- a/test/aria/widgets/wai/input/WaiInputTestSuite.js
+++ b/test/aria/widgets/wai/input/WaiInputTestSuite.js
@@ -26,6 +26,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.numberField.NumberFieldTestCase");
         this.addTests("test.aria.widgets.wai.input.passwordField.PasswordFieldTestCase");
         this.addTests("test.aria.widgets.wai.input.radiobutton.RadioButtonTestCase");
+        this.addTests("test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTestCase");
         this.addTests("test.aria.widgets.wai.input.select.SelectTestCase");
         this.addTests("test.aria.widgets.wai.input.selectBox.SelectBoxTestCase");
         this.addTests("test.aria.widgets.wai.input.textArea.TextAreaTestCase");

--- a/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsJawsTestCase.js
+++ b/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsJawsTestCase.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 1000],
+                ["type", null, "[tab]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[tab]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[up]"], ["pause", 1000],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "List box Automatic radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual option 1 radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual option 2 radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual option 4 radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual option 2 radio button checked",
+                        "To change the selection press Up or Down Arrow.",
+                        "List box Manual radio button checked",
+                        "To change the selection press Up or Down Arrow."
+                    ].join("\n"),
+                    this.end, function (response) {
+                        return response.replace(/.*(edit|text).*\n?/gi, "");
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTestCase.js
+++ b/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTestCase.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.core.Browser"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {
+            firstGroup: "auto",
+            manualOption: "opt1"
+        };
+        this.setTestEnv({
+            data: this.data,
+            template : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTpl"
+        });
+    },
+    $prototype : {
+        run: function () {
+            // Because of the following bug, this test is disabled on IE <= 9
+            // https://connect.microsoft.com/IE/feedback/details/703991/ie9-allows-for-the-focusing-of-the-input-type-radio-tabindex-1-element-via-the-tab-key
+            var browser = aria.core.Browser;
+            if (browser.isIE && browser.majorVersion <= 9) {
+                this.skipTest = true;
+            }
+            this.$RobotTestCase.run.call(this);
+        },
+
+        runTemplateTest : function () {
+            function step0 () {
+                var tf1 = this.getElementById("tf1");
+                this.executeAndCheck([ ["click", tf1], ["waitFocus", tf1], ["type", null, "[tab]"] ], {
+                    firstGroup: "auto",
+                    manualOption: "opt1",
+                    focusLabel: "Automatic"
+                }, step1);
+            }
+
+            function step1 () {
+                this.executeAndCheck([ ["type", null, "[down]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt1",
+                    focusLabel: "Manual"
+                }, step2);
+            }
+
+            function step2 () {
+                this.executeAndCheck([ ["type", null, "[tab]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt1",
+                    focusLabel: "Manual option 1"
+                }, step3);
+            }
+
+            function step3 () {
+                this.executeAndCheck([ ["type", null, "[down]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt2",
+                    focusLabel: "Manual option 2"
+                }, step4);
+            }
+
+            function step4 () {
+                this.executeAndCheck([ ["type", null, "[down]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt4",
+                    focusLabel: "Manual option 4"
+                }, step5);
+            }
+
+            function step5 () {
+                this.executeAndCheck([ ["type", null, "[up]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt2",
+                    focusLabel: "Manual option 2"
+                }, step6);
+            }
+
+            function step6 () {
+                this.executeAndCheck([ ["type", null, "[<shift>][tab][>shift<]"] ], {
+                    firstGroup: "manual",
+                    manualOption: "opt2",
+                    focusLabel: "Manual"
+                }, step7);
+            }
+
+            function step7 () {
+                this.executeAndCheck([ ["type", null, "[up]"] ], {
+                    firstGroup: "auto",
+                    manualOption: "opt2",
+                    focusLabel: "Automatic"
+                }, step8);
+            }
+
+            function step7 () {
+                this.executeAndCheck([ ["type", null, "[tab]"], ["waitFocus", this.getElementById("tf2")] ], {
+                    firstGroup: "auto",
+                    manualOption: "opt2"
+                }, this.end());
+            }
+
+            step0.call(this);
+        },
+
+        executeAndCheck: function (commands, checks, cb) {
+            this.synEvent.execute(commands, {
+                scope: this,
+                fn: function () {
+                    this.waitFor({
+                        condition: function () {
+                            var res = true;
+                            res = res && this.data.firstGroup === checks.firstGroup;
+                            res = res && this.data.manualOption === checks.manualOption;
+                            res = res && this.getFocusedEltLabel() === checks.focusLabel;
+                            return res;
+                        },
+                        callback: cb
+                    });
+                }
+            });
+        },
+
+        getFocusedEltLabel: function () {
+            var activeElement = Aria.$window.document.activeElement;
+            if (activeElement) {
+                var widget = activeElement.parentNode.__widget;
+                if (widget) {
+                    return widget._cfg.label;
+                }
+            }
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTpl.tpl
+++ b/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTpl.tpl
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTpl",
+    $hasScript : true
+}}
+
+    {macro main()}
+        <input {id "tf1"/}>
+        <div style="margin:10px;" role="radiogroup">
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "auto",
+                label : "Automatic",
+                bind: {
+                  value: {
+                    to: "firstGroup",
+                    inside: data
+                  }
+                }
+            }/}<br>
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "manual",
+                label : "Manual",
+                bind: {
+                  value: {
+                    to: "firstGroup",
+                    inside: data
+                  }
+                }
+            }/}<br>
+        <div style="padding-left:10px;" role="radiogroup">
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "opt1",
+                label : "Manual option 1",
+                bind: {
+                    value: {
+                        to: "manualOption",
+                        inside: data
+                    },
+                    disabled: {
+                        to: "firstGroup",
+                        inside: data,
+                        transform: areManualOptsDisabled
+                    }
+                }
+            }/}<br>
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "opt2",
+                label : "Manual option 2",
+                bind: {
+                    value: {
+                        to: "manualOption",
+                        inside: data
+                    },
+                    disabled: {
+                        to: "firstGroup",
+                        inside: data,
+                        transform: areManualOptsDisabled
+                    }
+                }
+            }/}<br>
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "opt3",
+                label : "Manual option 3",
+                disabled: true,
+                bind: {
+                    value: {
+                        to: "manualOption",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            {@aria:RadioButton {
+                waiAria : true,
+                keyValue: "opt4",
+                label : "Manual option 4",
+                bind: {
+                    value: {
+                        to: "manualOption",
+                        inside: data
+                    },
+                    disabled: {
+                        to: "firstGroup",
+                        inside: data,
+                        transform: areManualOptsDisabled
+                    }
+                }
+            }/}
+        </div>
+        </div>
+        <input {id "tf2"/}>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTplScript.js
+++ b/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsTplScript.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTplScript",
+    $prototype: {
+        areManualOptsDisabled: function (value) {
+            return value !== "manual";
+        }
+    }
+});


### PR DESCRIPTION
Initially disabled radio buttons were excluded from the array of all radio button instances and never added (even when re-enabled), which prevented them from reacting correctly to arrow up and down navigation.

This commit makes sure all radio buttons (whether they are enabled or not) are present in the array of all radio button instances. Disabled radio buttons are simply skipped when looping through the array.