### PR TITLE
feat #1665 WAI-ARIA - Tab & TabPanel - Specifications update

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2227,6 +2227,27 @@ module.exports = Aria.beanDefinitions({
                 "selectedTab" : {
                     $type : "json:String",
                     $description : "The id of the currently selected tab"
+                },
+                "waiHidden" : {
+                    $type : "json:Boolean",
+                    $description : "Sets aria-hidden on the tab when set to true",
+                    $default : false
+                },
+                "waiLabel" : {
+                    $type : "json:String",
+                    $description : "Sets aria-label on the widget, value will be used as the attribute's value"
+                },
+                "waiLabelledBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-labelledby on the widget, value will be used as the attribute's value"
+                },
+                "waiDescribedBy" : {
+                    $type : "json:String",
+                    $description : "Sets aria-describedby on the widget, value will be used as the attribute's value"
+                },
+                "waiTitleTag" : {
+                    $type : "json:String",
+                    $description : "Adds a wrapper element around the widget element if specified, value sets the tag name of the element"
                 }
             }
         },

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -15,10 +15,12 @@
 var Aria = require("../../Aria");
 
 var ariaUtilsArray = require("../../utils/Array");
+var ariaUtilsDom = require("../../utils/Dom");
 
 var ariaWidgetsFramesFrameFactory = require("../frames/FrameFactory");
 var ariaWidgetsContainerTabStyle = require("./TabStyle.tpl.css");
 var ariaWidgetsContainerContainer = require("./Container");
+var ariaTemplatesNavigationManager = require("../../templates/NavigationManager");
 
 
 /**
@@ -52,6 +54,10 @@ module.exports = Aria.classDefinition({
                 inside: inside,
                 to: this._getLabelIdPropertyName(cfg)
             };
+        }
+
+        if (cfg.waiAria) {
+            this._customTabIndexProvided = true;
         }
 
         // ---------------------------------------------------------------------
@@ -97,50 +103,6 @@ module.exports = Aria.classDefinition({
          * @override
          */
         this._spanStyle = "z-index:100;vertical-align:top;";
-
-        // ---------------------------------------------------------------------
-
-        var extraAttributes = [];
-
-        if (cfg.waiAria) {
-            extraAttributes.push(['role', 'tab']);
-
-            var bind = cfg.bind;
-            if (bind != null) {
-                var binding = bind.selectedTab;
-
-                if (binding != null) {
-                    var inside = binding.inside;
-                    var to = binding.to;
-
-                    var selected = inside[to] === cfg.tabId;
-                    var value = selected ? 'true' : 'false';
-
-                    extraAttributes.push(['aria-selected', value]);
-                    extraAttributes.push(['aria-expanded', value]);
-                }
-            }
-
-            var value = cfg.disabled ? 'true' : 'false';
-            extraAttributes.push(['aria-disabled', value]);
-
-            this._updateLabelId();
-
-            var id = this._getControlledTabPanelId();
-            if (id != null) {
-                extraAttributes.push(['aria-controls', id]);
-            }
-        }
-
-        var _extraAttributes = '';
-        ariaUtilsArray.forEach(extraAttributes, function (attribute) {
-            var key = attribute[0];
-            var value = attribute[1];
-
-            _extraAttributes += ' ' + key + '="' + value + '"';
-        });
-        _extraAttributes += ' ';
-        this._extraAttributes = _extraAttributes;
     },
 
     $destructor : function () {
@@ -173,6 +135,90 @@ module.exports = Aria.classDefinition({
             }
 
             aria.widgets.container.Tab.superclass._init.call(this);
+        },
+
+        _getWaiAriaElement : function () {
+            return ariaUtilsDom.getElementById(this._waiElementId);
+        },
+
+        _getWaiAriaAttributesMarkup: function () {
+            // --------------------------------------------------- destructuring
+
+            var cfg = this._cfg;
+
+            var tabIndex = cfg.tabIndex;
+            var disabled = cfg.disabled;
+            var waiHidden = cfg.waiHidden;
+            var waiLabel = cfg.waiLabel;
+            var waiLabelledBy = cfg.waiLabelledBy;
+            var waiDescribedBy = cfg.waiDescribedBy;
+
+            var bind = cfg.bind;
+            var tabId = cfg.tabId;
+
+            // ------------------------------------------------------ processing
+
+            var waiAttributes = [];
+
+            if (tabIndex != null && !disabled) {
+                waiAttributes.push(['tabindex', this._calculateTabIndex()]);
+            }
+
+            waiAttributes.push(['role', 'tab']);
+
+            if (waiHidden) {
+                waiAttributes.push(['aria-hidden', 'true']);
+            }
+
+            if (waiLabel) {
+                waiAttributes.push(['aria-label', waiLabel]);
+            }
+
+            if (waiLabelledBy) {
+                waiAttributes.push(['aria-labelledby', waiLabelledBy]);
+            }
+
+            if (waiDescribedBy) {
+                waiAttributes.push(['aria-describedby', waiDescribedBy]);
+            }
+
+            if (bind != null) {
+                var binding = bind.selectedTab;
+
+                if (binding != null) {
+                    var inside = binding.inside;
+                    var to = binding.to;
+
+                    var selected = inside[to] === tabId;
+                    var value = selected ? 'true' : 'false';
+
+                    waiAttributes.push(['aria-selected', value]);
+                    waiAttributes.push(['aria-expanded', value]);
+                }
+            }
+
+            var value = disabled ? 'true' : 'false';
+            waiAttributes.push(['aria-disabled', value]);
+
+            this._updateLabelId();
+
+            var id = this._getControlledTabPanelId();
+            if (id != null) {
+                waiAttributes.push(['aria-controls', id]);
+            }
+
+            // ---------------------------------------------------------- return
+
+            var waiAttributesString = '';
+            ariaUtilsArray.forEach(waiAttributes, function (attribute) {
+                var key = attribute[0];
+                var value = attribute[1];
+
+                waiAttributesString += ' ' + key + '="' + value + '"';
+            });
+            waiAttributesString += ' ';
+
+            return waiAttributesString;
         },
 
 
@@ -219,7 +265,7 @@ module.exports = Aria.classDefinition({
         _updateLabelId : function (selectedTab) {
             // --------------------------------------------------- destructuring
 
-            var id = this._domId;
+            var id = this._waiElementId;
             var cfg = this._cfg;
 
             var tabId = cfg.tabId;
@@ -279,7 +325,7 @@ module.exports = Aria.classDefinition({
 
             var attributeName = 'aria-controls';
 
-            var element = this.getDom();
+            var element = this._getWaiAriaElement();
             if (!id) {
                 element.removeAttribute(attributeName);
             } else {
@@ -315,8 +361,6 @@ module.exports = Aria.classDefinition({
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             // --------------------------------------------------- destructuring
 
-            var element = this.getDom();
-
             var cfg = this._cfg;
             var tabId = cfg.tabId;
             var waiAria = cfg.waiAria;
@@ -342,6 +386,7 @@ module.exports = Aria.classDefinition({
                 this._updateState();
 
                 if (waiAria) {
+                    var element = this._getWaiAriaElement();
                     var value = isSelected ? 'true' : 'false';
                     element.setAttribute('aria-selected', value);
                     element.setAttribute('aria-expanded', value);
@@ -363,7 +408,26 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _widgetMarkupBegin : function (out) {
+            // --------------------------------------------------- destructuring
+
+            var cfg = this._cfg;
+
+            var waiAria = cfg.waiAria;
+            var waiTitleTag = cfg.waiTitleTag;
+
+            // ------------------------------------------------------ processing
+
             this._frame.writeMarkupBegin(out);
+
+            if (waiAria) {
+                var waiElementId = this._createDynamicId();
+                this._waiElementId = waiElementId;
+
+                if (waiTitleTag) {
+                    out.write('<' + waiTitleTag + '>');
+                }
+                out.write('<a id="' + waiElementId + '" ' + this._getWaiAriaAttributesMarkup() + '>');
+            }
         },
 
         /**
@@ -372,6 +436,22 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _widgetMarkupEnd : function (out) {
+            // --------------------------------------------------- destructuring
+
+            var cfg = this._cfg;
+
+            var waiAria = cfg.waiAria;
+            var waiTitleTag = cfg.waiTitleTag;
+
+            // ------------------------------------------------------ processing
+
+            if (waiAria) {
+                out.write('</a>');
+                if (waiTitleTag) {
+                    out.write('</' + waiTitleTag + '>');
+                }
+            }
+
             this._frame.writeMarkupEnd(out);
         },
 
@@ -422,6 +502,16 @@ module.exports = Aria.classDefinition({
          */
         _selectTab : function () {
             this.changeProperty("selectedTab", this._cfg.tabId);
+            if (this._cfg.waiAria) {
+                // Focusing the Tab before focusing the TabPanel is not enough to make the screen reader read the tab's title first
+                // A sufficient timeout would be necessary, but we can't program that way safely
+                // this._focus();
+                var controlledTabPanelId = this._getControlledTabPanelId();
+                if (controlledTabPanelId != null) {
+                    var tabPanelElement = ariaUtilsDom.getElementById(controlledTabPanelId);
+                    ariaTemplatesNavigationManager.focusFirst(tabPanelElement);
+                }
+            }
         },
 
         /**
@@ -431,7 +521,7 @@ module.exports = Aria.classDefinition({
          */
         _dom_onclick : function (domEvt) {
             this._selectTab();
-            if (this._cfg && !this._hasFocus) {
+            if (this._cfg && !this._hasFocus && !this._cfg.waiAria) {
                 this._focus();
             }
         },

--- a/src/aria/widgets/container/TabPanel.js
+++ b/src/aria/widgets/container/TabPanel.js
@@ -77,6 +77,10 @@ module.exports = Aria.classDefinition({
         var extraAttributes = [];
 
         if (cfg.waiAria) {
+            if (cfg.tabIndex == null) {
+                cfg.tabIndex = -1;
+            }
+
             extraAttributes.push(['role', 'tabpanel']);
 
             this._updateControlledTabPanelId();

--- a/test/aria/widgets/wai/tabs/update1/TabsJawsTest.js
+++ b/test/aria/widgets/wai/tabs/update1/TabsJawsTest.js
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+var EnhancedJawsTestCase = require('test/EnhancedJawsTestCase');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.tabs.update1.TabsJawsTest',
+    $extends : EnhancedJawsTestCase,
+
+    $constructor : function () {
+        this.$EnhancedJawsTestCase.constructor.call(this);
+
+        var data = {};
+
+        var binding = {
+            inside: data,
+            to: 'selectedTab'
+        };
+
+        var tabs = [
+            {
+                textContent: 'One',
+                hidden: true
+            },
+            {
+                textContent: 'Two',
+                label: 'Two as internal label'
+            },
+            {
+                textContent: 'Three',
+                labelId: 'three_label',
+                label: 'Three as external label'
+            },
+            {
+                textContent: 'Four',
+                descriptionId: 'four_description',
+                description: 'Fourth tab description',
+                wrapper: 'h6',
+                wrapperText: 'heading level 6'
+            }
+        ];
+        data.tabs = tabs;
+
+        var labeledTabs = [];
+        data.labeledTabs = labeledTabs;
+
+        var describedTabs = [];
+        data.describedTabs = describedTabs;
+
+        ariaUtilsArray.forEach(tabs, function(tab, index) {
+            // -----------------------------------------------------------------
+
+            var configuration = tab.configuration;
+            if (configuration == null) {
+                configuration = {};
+                tab.configuration = configuration;
+            }
+
+            var hidden = tab.hidden;
+
+            var textContent = tab.textContent;
+
+            var label = tab.label;
+            var labelId = tab.labelId;
+
+            var description = tab.description;
+            var descriptionId = tab.descriptionId;
+
+            var wrapper = tab.wrapper;
+
+            // -----------------------------------------------------------------
+
+            // -----------------------------------------------------------------
+
+            configuration.tabId = 'tab_' + index;
+            configuration.waiAria = true;
+            configuration.bind = {
+                selectedTab: binding
+            };
+            configuration.tabIndex = 0;
+
+            // -----------------------------------------------------------------
+
+            if (hidden != null) {
+                configuration.waiHidden = hidden;
+            }
+
+            if (label != null) {
+                if (labelId != null) {
+                    configuration.waiLabelledBy = labelId;
+                    labeledTabs.push(tab);
+                } else {
+                    configuration.waiLabel = label;
+                }
+            }
+
+            if (description != null) {
+                configuration.waiDescribedBy = descriptionId;
+                describedTabs.push(tab);
+            }
+
+            if (wrapper != null) {
+                configuration.waiTitleTag = wrapper;
+            }
+
+            // -----------------------------------------------------------------
+
+            var title = label == null ? textContent : label;
+            tab.title = title;
+        });
+
+        var tabPanel = {
+            configuration: {
+                id: 'tab_panel',
+                macro: 'displayTabPanelContent',
+                waiAria: true,
+                tabIndex: -1,
+                bind: {
+                    selectedTab: binding
+                }
+            }
+        };
+        data.tabPanel = tabPanel;
+
+        var elementBefore = {
+            id: 'element_before',
+            textContent: 'Element before'
+        };
+        data.elementBefore = elementBefore;
+
+        var elementInside = {
+            id: 'element_inside',
+            textContent: 'Element inside'
+        };
+        data.elementInside = elementInside;
+
+        this.setTestEnv({
+            template : 'test.aria.widgets.wai.tabs.update1.Tpl',
+            data : data
+        });
+    },
+
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    $prototype : {
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            var data = this._getData();
+            var elementBefore = data.elementBefore;
+
+            this._filter = function (content) {
+                function createLineRegExp(content) {
+                    return new RegExp('^' + content + '\\s*\\n?', 'gm');
+                }
+
+                var regexps = [];
+                regexps.push(createLineRegExp(elementBefore.textContent));
+
+                ariaUtilsArray.forEach(regexps, function(regexp) {
+                    content = content.replace(regexp, '');
+                });
+
+                return content;
+            };
+
+            this._localAsyncSequence(function (add) {
+                add('_test');
+                add('_checkHistory');
+            }, this.end);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        _test : function (callback) {
+            var data = this._getData();
+
+            var tabs = data.tabs;
+            var tabPanel = data.tabPanel;
+            var elementBefore = data.elementBefore;
+            var elementInside = data.elementInside;
+
+            this._executeStepsAndWriteHistory(callback, function (api) {
+                // ----------------------------------------------- destructuring
+
+                var step = api.addStep;
+                var entry = api.addToHistory;
+
+                // --------------------------------------------- local functions
+
+                var self = this;
+
+                function selectStartPoint() {
+                    step(['click', self.getElementById(elementBefore.id)]);
+                }
+
+                function getTabDescription(tab, key) {
+                    // ---------------------------------------------------------
+
+                    var isJawsNavigation = key === 'down';
+                    var description = [];
+
+                    // ---------------------------------------------------------
+
+                    if (isJawsNavigation) {
+                        if (tab.wrapper != null) {
+                            description.push(tab.wrapperText);
+                        } else {
+                            entry(tab.textContent);
+                        }
+                    } else {
+                        description.push(tab.title);
+                    }
+
+                    // ---------------------------------------------------------
+
+                    description.push('Tab');
+                    if (isJawsNavigation) {
+                        description.push('closed');
+                    }
+                    description.push('collapsed');
+                    if (!isJawsNavigation) {
+                        description.push('Use JawsKey+Alt+R to read descriptive text');
+                    }
+                    if (isJawsNavigation && tab.wrapper != null) {
+                        description.push(tab.textContent);
+                    }
+                    entry(description.join(' '));
+
+                    // ---------------------------------------------------------
+
+                    if (!isJawsNavigation) {
+                        if (tab.labelId) {
+                            entry(tab.textContent);
+                        }
+
+                        if (tab.description != null) {
+                            entry(tab.description);
+                        }
+                        entry('To activate tab page press Spacebar.');
+                    }
+                }
+
+                function goThroughTabs(key) {
+                    var isJawsNavigation = key === 'down';
+
+                    ariaUtilsArray.forEach(tabs, function (tab, index) {
+                        if (isJawsNavigation && tab.hidden) {
+                            return;
+                        }
+
+                        if (isJawsNavigation && tab.wrapper != null) {
+                            step(['type', null, '[' + key + ']']);
+                        }
+
+                        step(['type', null, '[' + key + ']']);
+                        getTabDescription(tab, key);
+                    });
+                }
+
+                // -------------------------------------------------- processing
+
+                // -------------------------------------------------------------
+
+                selectStartPoint();
+
+                goThroughTabs('tab');
+
+                step(['type', null, '[tab]']);
+                entry(elementInside.textContent);
+
+                // -------------------------------------------------------------
+
+                selectStartPoint();
+
+                goThroughTabs('down');
+
+                // -------------------------------------------------------------
+
+                step(['type', null, '[space]']);
+                entry(elementInside.textContent);
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/tabs/update1/Tpl.tpl
+++ b/test/aria/widgets/wai/tabs/update1/Tpl.tpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : 'test.aria.widgets.wai.tabs.update1.Tpl',
+    $css: ['test.aria.widgets.wai.tabs.TplCSS']
+}}
+
+    {macro main()}
+        {foreach tab inArray this.data.labeledTabs}
+            <div id='${tab.labelId}'>${tab.label}</div>
+        {/foreach}
+
+        {foreach tab inArray this.data.describedTabs}
+            <div id='${tab.descriptionId}'>${tab.description}</div>
+        {/foreach}
+
+        <a tabindex='0' {id this.data.elementBefore.id /}>${this.data.elementBefore.textContent}</a><br/>
+
+        {foreach tab inArray this.data.tabs}
+            {@aria:Tab tab.configuration}
+                ${tab.textContent}
+            {/@aria:Tab}
+        {/foreach}
+
+        {@aria:TabPanel this.data.tabPanel.configuration /}
+    {/macro}
+
+    {macro displayTabPanelContent()}
+        <a tabindex='0' {id this.data.elementInside.id /}>${this.data.elementInside.textContent}</a><br/>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/tabs/update1/TplCSS.tpl.css
+++ b/test/aria/widgets/wai/tabs/update1/TplCSS.tpl.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{CSSTemplate {
+  $classpath : 'test.aria.widgets.wai.tabs.update1.TplCSS'
+}}
+    {macro main()}
+        *:focus {
+            outline: solid red 1px;
+        }
+    {/macro}
+{/CSSTemplate}


### PR DESCRIPTION
Tab:

- tabs are now "a" elements, and all the accessibility attributes, as well as the tabindex for focusing, are put on this element
- ability to add a wrapper element around the "a", with a custom tag
- support for: aria-hidden, aria-label, aria-labelledby, aria-describedby

TabPanel:

- now the tabIndex defaults to -1

Global behavior:

- when a Tab is selected, the first element of its associated TabPanel is focused

Glitches:

- when clicking on a Tab to select it, since the focus is set to the TabPanel the Tab title is not read