### PR TITLE
Improving the readability of Jaws test case failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "noder-js": "1.6.2"
   },
   "devDependencies": {
-    "attester": "2.4.1",
+    "attester": "2.4.3",
     "express": "3.4.8",
     "grunt": "0.4.2",
     "grunt-contrib-jshint": "0.8.0",

--- a/src/aria/jsunit/JawsTestCase.js
+++ b/src/aria/jsunit/JawsTestCase.js
@@ -14,7 +14,6 @@
  */
 var Aria = require("../Aria");
 var ariaUtilsString = require("../utils/String");
-var ariaUtilsJson = require("../utils/Json");
 
 /**
  * Class to be extended to create a template test case which checks the behavior with
@@ -145,13 +144,13 @@ module.exports = Aria.classDefinition({
                     } else {
                         message.push('History was not filtered');
                     }
-                    message.push("JAWS history" + (changed ? ' (filtered)' : '') + ": " + ariaUtilsJson.convertToJsonString(response));
-                    message.push("Expected history: " + ariaUtilsJson.convertToJsonString(expectedOutput));
+                    message.push("JAWS history" + (changed ? ' (filtered)' : '') + ":", "", response, "");
+                    message.push("Expected history:", "", expectedOutput, "");
 
                     if (changed) {
-                        message.push("JAWS history (original): " + ariaUtilsJson.convertToJsonString(originalResponse));
+                        message.push("JAWS history (original): ", "", originalResponse, "");
                     }
-                    message = message.join('.\n') + '.';
+                    message = message.join('\n');
 
                     this.assertEquals(response, expectedOutput, message);
                     this.$callback(callback);


### PR DESCRIPTION
This PR adds some line breaks in the error message of Jaws test cases so that it is easier to compare the actual Jaws history with the expected one.