### PR TITLE
Factorizing filters for Jaws test cases, improves the stability of those tests

### DIFF
--- a/src/aria/jsunit/JawsTestCase.js
+++ b/src/aria/jsunit/JawsTestCase.js
@@ -14,6 +14,7 @@
  */
 var Aria = require("../Aria");
 var ariaUtilsString = require("../utils/String");
+var ariaUtilsArray = require("../utils/Array");
 
 /**
  * Class to be extended to create a template test case which checks the behavior with
@@ -22,7 +23,30 @@ var ariaUtilsString = require("../utils/String");
 module.exports = Aria.classDefinition({
     $classpath : "aria.jsunit.JawsTestCase",
     $extends : require("./RobotTestCase"),
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+
+        /**
+         * Lines matching one of those regular expressions are considered noise and will be removed by removeNoise.
+         */
+        this.noiseRegExps = [/^(Aria Templates tests frame|Aria Templates tests document|New tab page)$/i];
+    },
     $prototype : {
+        /**
+         * If set to true, normalizeSpaces is not called in filterJawsHistory.
+         */
+        skipNormalizeSpaces: false,
+
+        /**
+         * If set to true, removeNoise is not called in filterJawsHistory
+         */
+        skipRemoveNoise: false,
+
+        /**
+         * If set to true, removeDuplicates is not called in filterJawsHistory.
+         */
+        skipRemoveDuplicates: false,
+
         /**
          * Private helper function, starts the tests once the template has been successfully loaded and rendered
          */
@@ -83,8 +107,7 @@ module.exports = Aria.classDefinition({
 
         /**
          * Sends the keyboard/mouse events necessary to retrieve Jaws history.
-         * The raw history is processed to make it easier to compare between
-         * several executions.
+         * The raw history is returned without any processing.
          * @param {aria.core.CfgBeans:Callback} cb
          */
         retrieveJawsHistory : function (cb) {
@@ -101,30 +124,32 @@ module.exports = Aria.classDefinition({
             ], {
                 fn: function () {
                     textArea.parentNode.removeChild(textArea);
-                    var textAreaContent = textArea.value;
-                    var globalFilterRegExp = /^(Aria Templates tests frame|Aria Templates tests document|New tab page)$/gi;
-                    var lines = ariaUtilsString.trim(textAreaContent).split("\n");
-                    for (var i = lines.length - 1; i >= 0; i--) {
-                        var curLine = lines[i];
-                        curLine = curLine.replace(/\s+/g, " ");
-                        curLine = ariaUtilsString.trim(curLine);
-                        if (curLine && !globalFilterRegExp.test(curLine)) {
-                            lines[i] = curLine;
-                        } else {
-                            lines.splice(i, 1);
-                        }
-                    }
-
-                    textAreaContent = lines.join("\n");
-                    this.$callback(cb, textAreaContent);
+                    this.$callback(cb, textArea.value);
                 },
                 scope: this
             });
         },
 
         /**
-         * Retrieves Jaws history (with this.retrieveJawsHistory) and
-         * asserts that it is equal to the expected string.
+         * Applies usual Jaws history filters.
+         */
+        filterJawsHistory: function (response) {
+            if (!this.skipNormalizeSpaces) {
+                response = this.normalizeSpaces(response);
+            }
+            if (!this.skipRemoveNoise) {
+                response = this.removeNoise(response);
+            }
+            if (!this.skipRemoveDuplicates) {
+                response = this.removeDuplicates(response);
+            }
+            return response;
+        },
+
+        /**
+         * Retrieves Jaws history (with this.retrieveJawsHistory), filters it with
+         * both filterJawsHistory and the provided filter function and asserts that
+         * the result is equal to the expected string.
          * @param {aria.core.CfgBeans:Callback} cb
          * @param {function} filterFn optionnal. The filter function to apply to the response.
          */
@@ -133,6 +158,7 @@ module.exports = Aria.classDefinition({
                 fn: function (response) {
                     var originalResponse = response;
 
+                    response = this.filterJawsHistory(response);
                     if (filterFn) {
                         response = filterFn.call(this, response);
                     }
@@ -160,19 +186,64 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Remove duplicate sentences
+         * Removes lines which introduce noise in the Jaws history.
          * @param {String} response JAWS response to be processed
+         * @return {String}
          */
-        removeDuplicates : function (response) {
-            var lines = response.split("\n");
-            var newLines = [lines[0]];
-            for(var i = 1, ii = lines.length; i < ii; i++) {
-                var line = lines[i];
-                if (line != lines[i - 1]) {
-                    newLines.push(line);
+        removeNoise : function (response) {
+            return this.removeMatchingLines(response, this.noiseRegExps);
+        },
+
+        /**
+         * Removes lines which match the given regular expressions.
+         * @param {String} response JAWS response to be processed
+         * @param {Array} regExps array of regular expressions
+         * @return {String}
+         */
+        removeMatchingLines : function (response, regExps) {
+            var l = regExps.length;
+            var lines = ariaUtilsString.trim(response).split("\n");
+            lines = ariaUtilsArray.filter(lines, function (line) {
+                for (var i = 0; i < l; i++) {
+                    if (regExps[i].test(line)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+            return lines.join("\n");
+        },
+
+        /**
+         * Normalizes spaces in Jaws history, including:
+         * - removing spaces at the beginning and the end of each line
+         * - replacing multiples consecutive spaces by a single one
+         * - removing blank lines
+         * @param {String} response JAWS response to be processed
+         * @return {String}
+         */
+        normalizeSpaces : function (response) {
+            var lines = ariaUtilsString.trim(response).split("\n");
+            for (var i = lines.length - 1; i >= 0; i--) {
+                var curLine = lines[i];
+                curLine = curLine.replace(/\s+/g, " ");
+                curLine = ariaUtilsString.trim(curLine);
+                if (curLine) {
+                    lines[i] = curLine;
+                } else {
+                    lines.splice(i, 1);
                 }
             }
-            return newLines.join("\n");
+            return lines.join("\n");
+        },
+
+        /**
+         * Removes duplicate lines
+         * @param {String} response JAWS response to be processed
+         * @return {String}
+         */
+        removeDuplicates : function (response) {
+            return response.replace(/(^|\n)(.*)(\n\2)+(?=\n|$)/ig, "$1$2");
         }
     }
 });

--- a/test/aria/widgets/wai/errorlist/binding/ErrorListBindingJawsTestCase.js
+++ b/test/aria/widgets/wai/errorlist/binding/ErrorListBindingJawsTestCase.js
@@ -43,6 +43,7 @@ module.exports = Aria.classDefinition({
             }
         });
 
+        this.noiseRegExps.push(/\\$/, /^Email Address:$/i);
      },
 
     $prototype : {
@@ -58,10 +59,6 @@ module.exports = Aria.classDefinition({
         },
 
         runTemplateTest : function () {
-
-            var doubleSlashRegExp = /\\\n/gi;
-            var removeInsertedEmail = /\nEmail Address:\n/gi;
-
             this.synEvent.execute([
                 ["click", this.getInputField("email")],
                 ["pause", 1000],
@@ -87,14 +84,7 @@ module.exports = Aria.classDefinition({
                 fn: function () {
                     this.assertJawsHistoryEquals(
                         "Email Address: Edit\nType in text.\nSubmit\nButton\nError\nError • The first name is a required field using a mandatory validator.• The last name is a required field using a mandatory validator.• The phone number is a required field using a mandatory validator.• The email is a required field using a mandatory validator.\nlist of 4 items\n• Link The first name is a required field using a mandatory validator.\n• Link The last name is a required field using a mandatory validator.\nAlert!\nThe last name is a required field using a mandatory validator.\nPhone Number:\nEdit\nAlert!\nThe phone number is a required field using a mandatory validator.",
-                        this.end,
-                        function (response) {
-                            return this.removeDuplicates(
-                                response
-                                    .replace(doubleSlashRegExp, "\n")
-                                    .replace(removeInsertedEmail, "\n")
-                            );
-                        }
+                        this.end
                     );
                 },
                 scope: this

--- a/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagJawsTestCase.js
+++ b/test/aria/widgets/wai/errorlist/titleTag/ErrorListTitleTagJawsTestCase.js
@@ -26,6 +26,7 @@ module.exports = Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.errorlist.titleTag.ErrorListTitleTagTpl"
         });
+        this.noiseRegExps.push(/page|Arrow/);
      },
 
     $prototype : {
@@ -56,13 +57,7 @@ module.exports = Aria.classDefinition({
                 fn: function () {
                     this.assertJawsHistoryEquals(
                         "Heading List dialog\nheadings List view\nMyErrorListTitleWithFirstHeadingLevel : 1\n1 of 3\nMyErrorListTitleWithSecondHeadingLevel : 2\nMyErrorListTitleWithThirdHeadingLevel : 3\nheading level 3 MyErrorListTitleWithThirdHeadingLevel\nMyErrorListTitleWithThirdHeadingLevel\nheading level 3\nlist of 1 items\n• MyError3Description\nlist end\nMyErrorListTitleWithNoHTag",
-                        this.end,
-                        function (response) {
-                            return response.split("\n").filter(function (line) {
-                                return line.indexOf("page") == -1 &&
-                                    line.indexOf("Arrow") == -1 ;
-                            }).join("\n");
-                        }
+                        this.end
                     );
                 },
                 scope: this

--- a/test/aria/widgets/wai/iconLabel/IconLabelJawsTest.js
+++ b/test/aria/widgets/wai/iconLabel/IconLabelJawsTest.js
@@ -28,12 +28,6 @@ Aria.classDefinition({
          * This method is always the first entry point to a template test Start the test by focusing the first field
          */
         runTemplateTest : function () {
-            /*
-            var checkedRegExp = /not checked\nchecked/g;
-            var notCheckedRegExp = /checked\nnot checked/g;
-            var chechBoxStartingLineRegExp = /\ncheck box/g;
-            */
-
             this.synEvent.execute([
                 ["click", this.getElementById("tf")],
                 ["pause", 2000],
@@ -62,10 +56,7 @@ Aria.classDefinition({
                 fn: function () {
                     this.assertJawsHistoryEquals(
                         "First textfield Edit\nType in text.\nCity Edit\nType in text.\nPress space to open the autocomplete list button menu collapsed\nTravel date Edit\nType in text.\nPress space to open the calendar button menu collapsed\nMulti-select: Edit\nType in text.\nPress space to open the selection list button menu collapsed\nAll Countries: Edit\nType in text.\nPress space to open the selection list\nbutton menu collapsed",
-                        this.end,
-                        function(response) {
-                            return this.removeDuplicates(response);
-                        }
+                        this.end
                     );
                 },
                 scope: this

--- a/test/aria/widgets/wai/input/checkbox/CheckBoxDisabledBaseJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckBoxDisabledBaseJawsTestCase.js
@@ -64,6 +64,9 @@ Aria.classDefinition({
             step1.call(this);
         },
 
+        // skips removeDuplicates in assertJawsHistoryEquals, as we call it ourselves from filterResponse
+        skipRemoveDuplicates: true,
+
         filterResponse: function (response) {
             response = response.replace(/(^|\n).*type.*(?=\n)/gi, "").trim();
             response = response.replace(/\n(?=check box)/gi, " "); // replaces the new line before "check box" by a space

--- a/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
@@ -21,11 +21,13 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.input.checkbox.CheckboxTestCaseTpl"
         });
+        this.noiseRegExps.push(/(First textfield Edit|Type in text\.)$/i);
     },
     $prototype : {
-        runTemplateTest : function () {
+        // We call removeDuplicates ourselves after applying some replacements
+        skipRemoveDuplicates: true,
 
-            var filterRegExp = /(First textfield Edit|Type in text\.)\n/gi;
+        runTemplateTest : function () {
             var checkedRegExp = /not checked\nchecked/g;
             var notCheckedRegExp = /checked\nnot checked/g;
 
@@ -60,9 +62,7 @@ Aria.classDefinition({
                         "Checkbox A check box not checked\nCheckbox A check box checked\nCheckbox A\nCheckbox B check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B\nCheckbox C check box not checked\nCheckbox C check box checked\nCheckbox C\nLast textfield\nCheckbox C check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B check box not checked",
                     this.end,
                     function(response) {
-                        return response.replace(filterRegExp, "").
-                            replace(checkedRegExp, "checked").
-                            replace(notCheckedRegExp, "not checked");
+                        return this.removeDuplicates(response.replace(checkedRegExp, "checked").replace(notCheckedRegExp, "not checked"));
                     });
                 },
                 scope: this

--- a/test/aria/widgets/wai/input/radiobutton/RadioButtonGroupJawsTestCase.js
+++ b/test/aria/widgets/wai/input/radiobutton/RadioButtonGroupJawsTestCase.js
@@ -21,11 +21,10 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.input.radiobutton.RadioButtonGroupTestCaseTpl"
         });
+        this.noiseRegExps.push(/(First textfield Edit|Type in text\.)$/i);
     },
     $prototype : {
         runTemplateTest : function () {
-
-            var filterRegExp = /(First textfield Edit|Type in text\.)\n/gi;
 
             this.synEvent.execute([
                 ["click", this.getElementById("tf1")],
@@ -50,10 +49,8 @@ Aria.classDefinition({
                 fn: function () {
                     this.assertJawsHistoryEquals(
                         "radio button not checked\nRadio A radio button checked\nRadio A\nradio button not checked\nRadio B\nradio button not checked\nRadio C\nRadio C radio button checked\nRadio B\nradio button not checked\nRadio B radio button checked\nRadio B\nradio button not checked\nRadio C\nLast textfield\nEdit\nList box Radio B radio button checked\nTo change the selection press Up or Down Arrow.",
-                    this.end,
-                    function(response) {
-                        return response.replace(filterRegExp, "");
-                    });
+                        this.end
+                    );
                 },
                 scope: this
             });

--- a/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsJawsTestCase.js
+++ b/test/aria/widgets/wai/input/radiobutton/initiallyDisabled/InitiallyDisabledRadioButtonsJawsTestCase.js
@@ -21,6 +21,7 @@ Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.input.radiobutton.initiallyDisabled.InitiallyDisabledRadioButtonsTpl"
         });
+        this.noiseRegExps.push(/(edit|text)/i);
     },
     $prototype : {
         runTemplateTest : function () {
@@ -51,10 +52,7 @@ Aria.classDefinition({
                         "To change the selection press Up or Down Arrow.",
                         "List box Manual radio button checked",
                         "To change the selection press Up or Down Arrow."
-                    ].join("\n"),
-                    this.end, function (response) {
-                        return response.replace(/.*(edit|text).*\n?/gi, "");
-                    });
+                    ].join("\n"), this.end);
                 },
                 scope: this
             });

--- a/test/aria/widgets/wai/multiselect/MultiSelectJawsTest.js
+++ b/test/aria/widgets/wai/multiselect/MultiSelectJawsTest.js
@@ -23,6 +23,8 @@ Aria.classDefinition({
         });
     },
     $prototype : {
+        // skips removeDuplicates in assertJawsHistoryEquals, as we call it ourselves from our filter function
+        skipRemoveDuplicates: true,
 
         /**
          * This method is always the first entry point to a template test Start the test by focusing the first field

--- a/test/aria/widgets/wai/multiselect/MultiSelectTabJawsTest.js
+++ b/test/aria/widgets/wai/multiselect/MultiSelectTabJawsTest.js
@@ -23,6 +23,8 @@ Aria.classDefinition({
         });
     },
     $prototype : {
+        // skips removeDuplicates in assertJawsHistoryEquals, as we call it ourselves from filterResponse
+        skipRemoveDuplicates: true,
 
         /**
          * This method is always the first entry point to a template test Start the test by focusing the first field

--- a/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/titleTag/DialogTitleTagJawsTestCase.js
@@ -24,6 +24,7 @@ module.exports = Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagTpl"
         });
+        this.noiseRegExps.push(/page|Arrow/);
      },
 
     $prototype : {
@@ -61,13 +62,7 @@ module.exports = Aria.classDefinition({
                         // This test is intended to be run in attester only.
                         // The list of links takes into account the "Pause" link displayed by attester
                         "Heading List dialog\nheadings List view\nMyDialogTitle : 1\n1 of 1\nheading level 1 MyDialogTitle\nMyDialogTitle heading level 1\nLinks List dialog\nlinks List view\nLinkInTheDialog\n2 of 2\nPause\nLinkInTheDialog\nLink LinkInTheDialog\nLinkInTheDialog Link\nHeading List dialog\nheadings List view\nBackgroundTitle : 1\n1 of 1\nheading level 1 BackgroundTitle\nBackgroundTitle\nheading level 1\nLinks List dialog\nlinks List view\nBackgroundLink\n2 of 2\nPause\nBackgroundLink\nLink BackgroundLink\nBackgroundLink Link",
-                        this.end,
-                        function (response) {
-                            return response.split("\n").filter(function (line) {
-                                return line.indexOf("page") == -1 &&
-                                    line.indexOf("Arrow") == -1 ;
-                            }).join("\n");
-                        }
+                        this.end
                     );
                 },
                 scope: this

--- a/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/waiEscapeMsg/DialogEscapeJawsTestCase.js
@@ -24,6 +24,7 @@ module.exports = Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.popup.dialog.waiEscapeMsg.DialogEscapeTpl"
         });
+        this.noiseRegExps.push(/Edit|Type/);
      },
 
     $prototype : {
@@ -43,13 +44,7 @@ module.exports = Aria.classDefinition({
                 fn: function () {
                     this.assertJawsHistoryEquals(
                         "Open dialog Button\nMyDialogTitle dialog\nMyDialogTitle heading level 1\nPress escape again to close the dialog.\nOpen dialog Button\nMyDialog is closed.",
-                        this.end,
-                        function (response) {
-                            return response.split("\n").filter(function (line) {
-                                return line.indexOf("Edit") == -1 &&
-                                    line.indexOf("Type") == -1 ;
-                            }).join("\n");
-                        }
+                        this.end
                     );
                 },
                 scope: this


### PR DESCRIPTION
This PR refactors the way filters for Jaws history are applied in Jaws test cases:
* `retrieveJawsHistory` no longer does any filtering, it returns the raw Jaws history
* `assertJawsHistoryEquals` now first executes `filterJawsHistory` before any provided filter function
* `filterJawsHistory` executes by default the 3 following common filters on all tests:
   * `normalizeSpaces` (can be disabled with `this.skipNormalizeSpaces = true`)
   * `removeNoise` (can be disabled with `this.skipRemoveNoise = true`)
   * `removeDuplicates` (can be disabled with `this.skipRemoveDuplicates = true`)
* `removeNoise` can be configured by changing the array of regular expressions stored in `this.noiseRegExps`