### PR TITLE
fix aria-activedescendant initially not set for the autocompletete widget

### DIFF
--- a/src/aria/widgets/TemplateBasedWidget.js
+++ b/src/aria/widgets/TemplateBasedWidget.js
@@ -154,7 +154,21 @@ module.exports = Aria.classDefinition({
             }
             this._tplWidget.initWidget();
             // initWidgetDom is done in the template callback
-        }
+        },
 
+        /**
+         * Calls the callback after the template is loaded (this can be immediately
+         * in case the template is already loaded).
+         * @param {aria.core.CfgBeans:Callback} callback called after the template is loaded
+         */
+        afterWidgetLoaded : function (callback) {
+            if (this._subTplCtxt) {
+                this.$callback(callback);
+            } else {
+                this.$onOnce({
+                    "widgetContentReady": callback
+                });
+            }
+        }
     }
 });

--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -235,7 +235,7 @@ module.exports = Aria.classDefinition({
             if (this._cfg.waiAria) {
                 var field = this.getTextInputField();
                 var listWidget = this.controller.getListWidget();
-                var ariaActiveDescendant = listWidget.getOptionDomId(this.controller.getDataModel().selectedIdx);
+                var ariaActiveDescendant = listWidget ? listWidget.getSelectedOptionDomId() : null;
                 if (ariaActiveDescendant != null) {
                     field.setAttribute("aria-activedescendant", ariaActiveDescendant);
                 } else {
@@ -255,13 +255,27 @@ module.exports = Aria.classDefinition({
             this.$DropDownListTrait._afterDropdownOpen.apply(this, arguments);
             if (this._cfg.waiAria) {
                 var field = this.getTextInputField();
-                field.setAttribute("aria-owns", this.controller.getListWidget().getListDomId());
-
+                var listWidget = this.controller.getListWidget();
+                field.setAttribute("aria-owns", listWidget.getListDomId());
                 var dropDownIcon = this._getDropdownIcon();
                 if (dropDownIcon) {
                     dropDownIcon.setAttribute("aria-expanded", "true");
                 }
+                listWidget.afterWidgetLoaded({
+                    fn: this._updateAriaActiveDescendant,
+                    scope: this
+                });
             }
+        },
+        /**
+         * @override
+         */
+        _waiSuggestionsChanged : function () {
+            var self = this;
+            setTimeout(function () {
+                self._updateAriaActiveDescendant();
+            }, 0);
+            this.$DropDownListTrait._waiSuggestionsChanged.apply(this, arguments);
         },
 
         /**

--- a/src/aria/widgets/form/list/List.js
+++ b/src/aria/widgets/form/list/List.js
@@ -275,6 +275,7 @@ module.exports = Aria.classDefinition({
             } else if (key == "items") {
                 moduleCtrl.setItems(newValue);
                 refreshNeeded = true;
+                this._retrieveControllerSelection();
             } else if (key == "multipleSelect") {
                 moduleCtrl.setMultipleSelect(newValue);
             }
@@ -357,6 +358,25 @@ module.exports = Aria.classDefinition({
                     return this._subTplCtxt.$getId(data.listItemDomIdPrefix + optionIndex);
                 }
             }
+        },
+
+        /**
+         * Returns the currently selected index.
+         * @return {Integer}
+         */
+        getSelectedIdx : function () {
+            if (this._subTplModuleCtrl) {
+                return this._subTplModuleCtrl.getData().selectedIndex;
+            }
+        },
+
+        /**
+         * Returns the id of the DOM element corresponding to the selected item.
+         * @return {String} id of the DOM element or undefined if the list is not fully loaded yet, accessibility
+         * is disabled or the index is invalid
+         */
+        getSelectedOptionDomId : function () {
+            return this.getOptionDomId(this.getSelectedIdx());
         }
     }
 });

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -26,6 +26,8 @@ Aria.classDefinition({
 
         this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest1");
         this.addTests("test.aria.widgets.wai.autoComplete.AutoCompleteJawsTest2");
+        this.addTests("test.aria.widgets.wai.autoComplete.preselect.AutoCompletePreselectJawsTest1");
+        this.addTests("test.aria.widgets.wai.autoComplete.preselect.AutoCompletePreselectJawsTest2");
 
         this.addTests("test.aria.widgets.wai.popup.dialog.modal.ModalDialogJawsTest");
         this.addTests("test.aria.widgets.wai.errorlist.binding.ErrorListBindingJawsTestCase");

--- a/test/aria/widgets/wai/autoComplete/preselect/AutoCompletePreselectJawsTest1.js
+++ b/test/aria/widgets/wai/autoComplete/preselect/AutoCompletePreselectJawsTest1.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.preselect.AutoCompletePreselectJawsTest1",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.autoComplete.preselect.AutoCompleteTpl"
+        });
+        this.noiseRegExps.push(/type in text/i);
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getInputField("country")], ["pause", 1000],
+                ["type", null, "+"], ["pause", 5000],
+                ["type", null, "4"], ["pause", 5000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[up]"], ["pause", 1000],
+                ["type", null, "[enter]"], ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals("Country Edit\nList view Austria +43 1 of 4\nThere are 3 other suggestions, use up and down arrow keys to navigate and enter to validate.\nList view Austria +43 1 of 2\nThere is 1 other suggestion, use up and down arrow keys to navigate and enter to validate.\nList view United Kingdom +44 2 of 2\nList view Austria +43 1 of 2\nCountry Edit\nAustria +43", this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/preselect/AutoCompletePreselectJawsTest2.js
+++ b/test/aria/widgets/wai/autoComplete/preselect/AutoCompletePreselectJawsTest2.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.preselect.AutoCompletePreselectJawsTest2",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.autoComplete.preselect.AutoCompleteTpl"
+        });
+        this.noiseRegExps.push(/type in text/i, /^i$/i);
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getInputField("country")], ["pause", 1000],
+                ["type", null, "+"], ["pause", 5000],
+                ["type", null, "3"], ["pause", 5000],
+                ["type", null, "[<shift>][home][>shift<]"], ["pause", 1000],
+                ["type", null, "i"], ["pause", 5000],
+                ["type", null, "s"], ["pause", 5000],
+                ["type", null, "[enter]"], ["pause", 3000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(                    [
+                        "Country Edit",
+                        "List view Austria +43 1 of 4",
+                        "There are 3 other suggestions, use up and down arrow keys to navigate and enter to validate.",
+                        "List view France +33 1 of 1",
+                        "There is no other suggestion. Press enter to accept it or change your entry.",
+                        "List view Israel +972 1 of 1",
+                        "There is no other suggestion. Press enter to accept it or change your entry.",
+                        "List view Israel +972 1 of 1",
+                        "There is no other suggestion. Press enter to accept it or change your entry.",
+                        "Country Edit",
+                        "Israel +972"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/autoComplete/preselect/AutoCompleteTpl.tpl
+++ b/test/aria/widgets/wai/autoComplete/preselect/AutoCompleteTpl.tpl
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.autoComplete.preselect.AutoCompleteTpl",
+    $hasScript : true
+}}
+
+    {macro main()}
+        <div style="margin:10px;font-size:+3;font-style:bold;">This test needs focus.</div>
+        <div style="margin:10px;">
+            {@aria:AutoComplete {
+                id : "country",
+                waiAria : true,
+                label : "Country",
+                labelWidth: 100,
+                autoFill : true,
+                preselect : "always",
+                resourcesHandler : this.acHandler,
+                waiSuggestionsStatusGetter: this.waiSuggestionsStatusGetter,
+                waiSuggestionAriaLabelGetter: this.waiSuggestionAriaLabelGetter
+            }/} <br><br>
+        </div>
+
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/autoComplete/preselect/AutoCompleteTplScript.js
+++ b/test/aria/widgets/wai/autoComplete/preselect/AutoCompleteTplScript.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var LCResourcesHandler = require("ariatemplates/resources/handlers/LCResourcesHandler");
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.autoComplete.preselect.AutoCompleteTplScript",
+    $constructor : function () {
+        this.acHandler = new LCResourcesHandler({
+            labelMatchAtWordBoundaries: true,
+            sortingMethod: function (a, b) {
+                return (a.label < b.label)
+                        ? -1
+                        : (a.label > b.label) ? 1 : 0;
+            }
+        });
+        this.acHandler.setSuggestions([{
+                label : 'Austria +43',
+                code : 'AT'
+            }, {
+                label : 'France +33',
+                code : 'FR'
+            }, {
+                label : 'United Kingdom +44',
+                code : 'GB'
+            }, {
+                label : 'Israel +972',
+                code : 'IL'
+            }]);
+    },
+    $destructor : function () {
+        this.acHandler.$dispose();
+        this.acHandler = null;
+    },
+    $prototype: {
+        waiSuggestionsStatusGetter : function (number) {
+           if (number === 0) {
+               return "There is no suggestion.";
+           } else {
+               var remainingSuggestions = number - 1;
+               if (remainingSuggestions === 0) {
+                   return "There is no other suggestion. Press enter to accept it or change your entry.";
+               }
+               return (remainingSuggestions === 1 ? "There is 1 other suggestion" : "There are " + remainingSuggestions + " other suggestions") + ", use up and down arrow keys to navigate and enter to validate.";
+           }
+       },
+
+       waiSuggestionAriaLabelGetter : function (object) {
+           return object.value.label + " " + (object.index + 1) + " of " + object.total;
+       }
+    }
+});


### PR DESCRIPTION
When using the `@aria:AutoComplete` component with `waiAria = true`, the `aria-activedescendant` attribute was not set until the user navigates the suggestions with up/down arrow keys.

This was an issue when a suggestion is preselected while the user types (which can happen, for example, if the `preselect` property is set to `"always"`)
