### PR TITLE
feat #1675 Implement the "disabled" attribute for the Link widget

### DIFF
--- a/src/aria/widgets/action/ActionWidget.js
+++ b/src/aria/widgets/action/ActionWidget.js
@@ -151,7 +151,6 @@ module.exports = Aria.classDefinition({
             var waiLabel = cfg.waiLabel;
             var waiLabelledBy = cfg.waiLabelledBy;
             var waiDescribedBy = cfg.waiDescribedBy;
-            var disabled = cfg.disabled;
 
             // ------------------------------------------------------ processing
 
@@ -171,8 +170,6 @@ module.exports = Aria.classDefinition({
                 if (waiDescribedBy) {
                     markup.push('aria-describedby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(waiDescribedBy) + '"');
                 }
-
-                markup.push('aria-disabled="' + (disabled ? 'true' : 'false') + '"');
 
                 if (markup.length > 0) {
                     markup.unshift('');

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -72,6 +72,7 @@ module.exports = Aria.classDefinition({
                     ' href="javascript:(function(){})()"',
                     (cfg.tabIndex != null ? ' tabindex=' + this._calculateTabIndex() + '"' : ''),
                     this._getWaiAriaMarkup(),
+                    cfg.disabled ? ' disabled ' : '',
                 '>',
                     ariaUtilsString.escapeHTML(cfg.label),
                 '</a>'
@@ -164,12 +165,19 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _updateState : function () {
-            if (this._focusElt) {
-                var cfg = this._cfg, linkClass = "xLink_" + cfg.sclass;
+            var cfg = this._cfg;
+
+            var focusedElement = this._focusElt;
+
+            if (focusedElement) {
+                var linkClass = "xLink_" + cfg.sclass;
                 if (cfg.disabled) {
                     linkClass = "xLink_" + cfg.sclass + "_disabled xLink_disabled";
+                    focusedElement.setAttribute('disabled', '');
+                } else {
+                    focusedElement.removeAttribute('disabled');
                 }
-                this._focusElt.className = linkClass;
+                focusedElement.className = linkClass;
             }
         }
     }

--- a/test/aria/widgets/wai/input/actionWidget/Base.js
+++ b/test/aria/widgets/wai/input/actionWidget/Base.js
@@ -40,7 +40,7 @@ module.exports = Aria.classDefinition({
                 name: 'withTabKey',
                 key: 'tab'
             },
-            // There are a lot of "blank" elements, required pressing the down key twice more
+            // Note for "actionsCount" values below: there are a lot of "blank" elements, requiring pressing the down key twice more
             {
                 name: 'withDownKey',
                 key: 'down'
@@ -50,7 +50,7 @@ module.exports = Aria.classDefinition({
         this.testData = {
             'link': {
                 withTabKey: {
-                    actionsCount: 5,
+                    actionsCount: 4,
                     expectedOutput: [
                         'this is the link label Link',
 
@@ -58,8 +58,6 @@ module.exports = Aria.classDefinition({
 
                         'link with external description Link',
                         'this is the link external description',
-
-                        'disabled link Unavailable Link',
 
                         'link: no wai ARIA Link'
                     ]
@@ -81,7 +79,7 @@ module.exports = Aria.classDefinition({
             },
             'button': {
                 withTabKey: {
-                    actionsCount: 5,
+                    actionsCount: 4,
                     expectedOutput: [
                         'this is the button label Button',
 
@@ -89,8 +87,6 @@ module.exports = Aria.classDefinition({
 
                         'button with external description Button',
                         'this is the button external description',
-
-                        'disabled button Button Unavailable',
 
                         'button: no wai ARIA Button'
                     ]
@@ -117,7 +113,7 @@ module.exports = Aria.classDefinition({
             },
             'button_simple': {
                 withTabKey: {
-                    actionsCount: 4, // a disabled button cannot be focused
+                    actionsCount: 4,
                     expectedOutput: [
                         'this is the button_simple label Button',
 
@@ -151,7 +147,7 @@ module.exports = Aria.classDefinition({
             },
             'icon_button': {
                 withTabKey: {
-                    actionsCount: 5,
+                    actionsCount: 4,
                     expectedOutput: [
                         'this is the icon_button label Button',
 
@@ -159,8 +155,6 @@ module.exports = Aria.classDefinition({
 
                         'Unlabeled 0 Button',
                         'this is the icon_button external description',
-
-                        'Unlabeled 0 Button Unavailable',
 
                         'Unlabeled 0 Button'
                     ]


### PR DESCRIPTION
Also made the following change to all "ActionWidget" based widgets: now the "aria-disabled" attribute is not set anymore in WAI-ARIA mode, "disabled" must be sufficient.

For now, this PR depends on https://github.com/ariatemplates/ariatemplates/pull/1662 Without that, the following tests are failing (even though the final expected output has already been fixed):

- test.aria.widgets.wai.input.actionWidget.Button
- test.aria.widgets.wai.input.actionWidget.IconButton

References:

- AT-1398
- PTR 11630074