### PR TITLE
Configurable default values for any widget property of the Aria library

### DIFF
--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -25,6 +25,7 @@ var ariaWidgetLibsBindableWidget = require("../widgetLibs/BindableWidget");
 var ariaCoreTplClassLoader = require("../core/TplClassLoader");
 var ariaCoreJsonValidator = require("../core/JsonValidator");
 var environment = require("../core/environment/Environment");
+var ariaWidgetsEnvironmentWidgetSettings = require("./environment/WidgetSettings");
 
 /**
  * Base Widget class from which all widgets must derive
@@ -137,6 +138,7 @@ module.exports = Aria.classDefinition({
          */
         this.__initWhileContentChange = false;
 
+        this.applyWidgetDefaults(cfg);
         this._cfgOk = ariaCoreJsonValidator.validateCfg(this._cfgBean || this._cfgPackage + "." + this.$class + "Cfg", cfg);
 
         // Check if the defined skinClass exists for this widget, if not set it to 'std'
@@ -224,6 +226,26 @@ module.exports = Aria.classDefinition({
          * @type String
          */
         _skinnableClass : null,
+
+        /**
+         * Apply the default configuration from the environment for the specified widget.
+         * @param {Object} cfg widget configuration (which has to be completed with defaults from the environment)
+         * @param {String} widgetName name of the widget. If omitted, this.$class is used.
+         */
+        applyWidgetDefaults : function (cfg, widgetName) {
+            if (!widgetName) {
+                widgetName = this.$class;
+            }
+            var allDefaults = ariaWidgetsEnvironmentWidgetSettings.getWidgetDefaults();
+            var widgetDefaults = allDefaults[widgetName];
+            if (widgetDefaults) {
+                for (var property in widgetDefaults) {
+                    if (widgetDefaults.hasOwnProperty(property) && !cfg.hasOwnProperty(property)) {
+                        cfg[property] = widgetDefaults[property];
+                    }
+                }
+            }
+        },
 
         /**
          * Initialize the binding description.

--- a/src/aria/widgets/environment/WidgetSettings.js
+++ b/src/aria/widgets/environment/WidgetSettings.js
@@ -37,12 +37,18 @@ module.exports = Aria.classDefinition({
 
         /**
          * Returns the widget settings
-         * @public
-         * @return {aria.widgets.environment.WidgetSettingsCfgBeans:AppCfg.WidgetSettingsCfg}
+         * @return {aria.widgets.environment.WidgetSettingsCfgBeans:WidgetSettingsCfg}
          */
         getWidgetSettings : function () {
             return this.checkApplicationSettings("widgetSettings");
-        }
+        },
 
+        /**
+         * Returns the widget defaults
+         * @return {aria.widgets.environment.WidgetSettingsCfgBeans:AppCfg.widgetDefaults}
+         */
+        getWidgetDefaults : function () {
+            return this.checkApplicationSettings("widgetDefaults");
+        }
     }
 });

--- a/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
+++ b/src/aria/widgets/environment/WidgetSettingsCfgBeans.js
@@ -37,7 +37,15 @@ module.exports = Aria.beanDefinitions({
             $properties : {
                 "widgetSettings" : {
                     $type : "WidgetSettingsCfg",
-                    $description : "Default widget settings for the application",
+                    $description : "General widget settings for the application",
+                    $default : {}
+                },
+                "widgetDefaults" : {
+                    $type : "json:Map",
+                    $description : "Default widget properties for each type of widget in the Aria library. Each key in the map is the name of a widget (for example: AutoComplete or DatePicker) and each value is an object containing the corresponding properties and their values to apply by default for all instances of this widget.",
+                    $contentType: {
+                        $type: "json:ObjectRef"
+                    },
                     $default : {}
                 }
             }

--- a/test/aria/widgets/WidgetsTestSuite.js
+++ b/test/aria/widgets/WidgetsTestSuite.js
@@ -39,6 +39,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.controllers.SelectControllerTest");
         this.addTests("test.aria.widgets.dropdown.DropDownTestSuite");
         this.addTests("test.aria.widgets.environment.WidgetSettings");
+        this.addTests("test.aria.widgets.defaults.CheckDefaultsTest");
         this.addTests("test.aria.widgets.errorlist.ErrorListControllerTest");
         this.addTests("test.aria.widgets.errorlist.ListErrorTestCase");
         this.addTests("test.aria.widgets.action.iconbutton.issue276.IconButtonTestCase");

--- a/test/aria/widgets/defaults/CheckDefaultsTest.js
+++ b/test/aria/widgets/defaults/CheckDefaultsTest.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var AppEnvironment = require("ariatemplates/core/AppEnvironment");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.defaults.CheckDefaultsTest",
+    $extends : require("ariatemplates/jsunit/TemplateTestCase"),
+    $prototype : {
+        run : function () {
+            AppEnvironment.setEnvironment({
+                widgetDefaults: {
+                    DatePicker: {
+                        calendarNumberOfUnits: 5
+                    }
+                }
+            }, {
+                scope: this,
+                fn: this.$TemplateTestCase.run
+            });
+        },
+
+        runTemplateTest : function () {
+            var dp1 = this.getWidgetInstance("dp1");
+            this.assertEquals(dp1._cfg.calendarNumberOfUnits, 5, "Default value of 5 for calendarNumberOfUnits not taken into account in first date picker.");
+            var dp2 = this.getWidgetInstance("dp2");
+            this.assertEquals(dp2._cfg.calendarNumberOfUnits, 1, "Overridden value of 1 for calendarNumberOfUnits not taken into account in the second date picker.");
+
+            AppEnvironment.setEnvironment({
+                widgetDefaults: {
+                    DatePicker: {
+                        calendarNumberOfUnits: 2
+                    }
+                }
+            }, {
+                scope: this,
+                fn: this.afterChangingEnv
+            });
+
+        },
+
+        afterChangingEnv : function () {
+            this.templateCtxt.$refresh();
+
+            var dp1 = this.getWidgetInstance("dp1");
+            this.assertEquals(dp1._cfg.calendarNumberOfUnits, 2, "Default value of 2 for calendarNumberOfUnits not taken into account in first date picker.");
+            var dp2 = this.getWidgetInstance("dp2");
+            this.assertEquals(dp2._cfg.calendarNumberOfUnits, 1, "Overridden value of 1 for calendarNumberOfUnits not taken into account in the second date picker.");
+
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/defaults/CheckDefaultsTestTpl.tpl
+++ b/test/aria/widgets/defaults/CheckDefaultsTestTpl.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath:"test.aria.widgets.defaults.CheckDefaultsTestTpl"
+}}
+
+    {macro main()}
+        Default datepicker:<br>
+        {@aria:DatePicker {
+            id: "dp1"
+        }/}
+        <br><br>
+        Datepicker with 1 unit:<br>
+        {@aria:DatePicker {
+            id: "dp2",
+            calendarNumberOfUnits: 1
+        }/}
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR adds the `widgetDefaults` parameter in the environment, allowing to specify a default value for any property of any widget in the Aria widget library.

For example, to set the `calendarNumberOfUnits` property for all instances of the `@aria:DatePicker` widget (if those instances do not specify any value for this property):

```js
  aria.core.AppEnvironment.setEnvironment({
    widgetDefaults: {
      DatePicker: {
        calendarNumberOfUnits: 5
      }
    }
  });
```