### PR TITLE
fix SelectTemplateTestCase missing in test suite

### DIFF
--- a/test/aria/widgets/form/select/SelectTestSuite.js
+++ b/test/aria/widgets/form/select/SelectTestSuite.js
@@ -29,7 +29,8 @@ Aria.classDefinition({
                 "test.aria.widgets.form.select.popupWidth.SelectTestCase",
                 "test.aria.widgets.form.select.boundOptionsRemoval.SelectTemplateTestCase",
                 "test.aria.widgets.form.select.nocontroller.NoControllerTestCase",
-                "test.aria.widgets.form.select.mouseWheel.SelectMouseWheelTestCase"
+                "test.aria.widgets.form.select.mouseWheel.SelectMouseWheelTestCase",
+                "test.aria.widgets.form.select.valueAndOptionsBinding.SelectTemplateTestCase"
         ];
     }
 });


### PR DESCRIPTION
test.aria.widgets.form.select.valueAndOptionsBinding.SelectTemplateTestCase is missing