### PR TITLE
New readOnlyTextField property on the aria:MultiSelect widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -804,6 +804,10 @@ module.exports = Aria.beanDefinitions({
                 "displayOptions" : {
                     $type : "FormListCfg:displayOptions",
                     $description : "Display options that are not interpreted by the list controller."
+                },
+                "readOnlyTextField" : {
+                    $type: "json:Boolean",
+                    $description : "If true, the user can only modify the value of the widget by opening the popup (the text field is not modifiable)."
                 }
             }
         },

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -396,6 +396,15 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Returns whether the text input is read-only.
+         * @return {Boolean} true if the text input should be read-only.
+         * @override
+         */
+        isTextInputReadOnly : function () {
+            return this._cfg.readOnlyTextField || this.$DropDownTextInput.isTextInputReadOnly.call(this);
+        },
+
+        /**
          * Return the caret position in the DatePicker. It works also if the focus is on the expand icon.
          * @return {Object} the caret position (start end end)
          */

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -343,7 +343,7 @@ module.exports = Aria.classDefinition({
 
             if (this._isTextarea) {
                 out.write(['<textarea class="', className, '"', Aria.testMode ? ' id="' + this._domId + '_textarea"' : '',
-                        cfg.disabled ? ' disabled="disabled"' : cfg.readOnly ? ' readonly="readonly"' : '',
+                        cfg.disabled ? ' disabled="disabled"' : this.isTextInputReadOnly() ? ' readonly="readonly"' : '',
                         ariaRequired, ' type="', type, '" style="color:', color,
                         ';overflow:auto;resize:none;height: ' + this._frame.innerHeight + 'px; width:', inputWidth,
                         'px;"', 'value=""', (cfg.maxlength > -1 ? 'maxlength="' + cfg.maxlength + '" ' : ' '),
@@ -354,7 +354,7 @@ module.exports = Aria.classDefinition({
                 ].join(''));
             } else {
                 out.write(['<input class="', className, '"', Aria.testMode ? ' id="' + this._domId + '_input"' : '',
-                        cfg.disabled ? ' disabled="disabled"' : cfg.readOnly ? ' readonly="readonly"' : '',
+                        cfg.disabled ? ' disabled="disabled"' : this.isTextInputReadOnly() ? ' readonly="readonly"' : '',
                         ariaRequired, ' type="', type, '" style="color:', color, ';width:',
                         inputWidth, 'px;"', 'value="',
                         stringUtils.encodeForQuotedHTMLAttribute((this._helpTextSet) ? cfg.helptext : text), '" ',
@@ -843,6 +843,16 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Returns whether the text input is read-only.
+         * Note that having a read-only text input does not necessarily mean that the whole widget is read-only.
+         * Depending on the widget, it may be possible to change the value through its drop-down popup, for example.
+         * @return {Boolean} true if the text input should be read-only.
+         */
+        isTextInputReadOnly : function () {
+            return this._cfg.readOnly;
+        },
+
+        /**
          * This is called when the bindings are updated. It will update the textfield when either the error, mandatory,
          * readOnly or disabled settings change.
          * @protected
@@ -854,7 +864,7 @@ module.exports = Aria.classDefinition({
                 this._updateState();
                 // sets the readOnly disabled flags in the input according to
                 // the recently changed cfg object
-                inputElm.readOnly = this._cfg.readOnly;
+                inputElm.readOnly = this.isTextInputReadOnly();
                 inputElm.disabled = this._cfg.disabled;
 
                 if (this._cfg.waiAria) {

--- a/test/JawsTestSuite.js
+++ b/test/JawsTestSuite.js
@@ -51,6 +51,7 @@ Aria.classDefinition({
         this.addTests("test.aria.widgets.wai.input.selectBox.SelectBoxSuggestionsJawsTestCase");
 
         this.addTests("test.aria.widgets.wai.multiselect.MultiSelectJawsTestCase");
+        this.addTests("test.aria.widgets.wai.multiselect.readOnlyTextField.ReadOnlyTextFieldJawsTestCase");
 
         this.addTests("test.aria.widgets.wai.popup.errortooltip.ErrorTooltipJawsTestSuite");
         this.addTests("test.aria.widgets.wai.popup.dialog.focusableItems.FocusableItemsJawsTestSuite");

--- a/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldJawsTestCase.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.multiselect.readOnlyTextField.ReadOnlyTextFieldJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.multiselect.readOnlyTextField.ReadOnlyTextFieldTpl"
+        });
+    },
+    $prototype : {
+        // skips removeDuplicates in assertJawsHistoryEquals, as we call it ourselves from our filter function
+        skipRemoveDuplicates: true,
+
+        /**
+         * This method is always the first entry point to a template test Start the test by focusing the first field
+         */
+        runTemplateTest : function () {
+            var checkedRegExp = /not checked\nchecked/g;
+            var notCheckedRegExp = /checked\nnot checked/g;
+            var chechBoxStartingLineRegExp = /\ncheck box/g;
+
+            this.synEvent.execute([
+                ["click", this.getElementById("tf")], ["pause", 2000],
+                ["type", null, "[tab]"], ["pause", 2000],
+                ["type", null, "[down]"], ["pause", 2000],
+                ["type", null, "[space]"], ["pause", 2000],
+                ["type", null, "[space]"], ["pause", 2000],
+                ["type", null, "[escape]"], ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "Edit",
+                        "Type in text.",
+                        "What do you need to be happy? read only edit",
+                        "Press down then space to open the list of check boxes.",
+                        "Press space to open the list of check boxes",
+                        "button menu collapsed",
+                        "God check box not checked",
+                        "God check box checked",
+                        "What do you need to be happy? read only edit",
+                        "God",
+                        "Press down then space to open the list of check boxes."
+                    ].join("\n"),
+                    this.end,
+                    function(response) {
+                        return this.removeDuplicates(response.
+                            replace(chechBoxStartingLineRegExp, " check box").
+                            replace(checkedRegExp, "checked").
+                            replace(notCheckedRegExp, "not checked")
+                        );
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldTpl.tpl
+++ b/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldTpl.tpl
@@ -1,0 +1,43 @@
+{Template {
+    $classpath:'test.aria.widgets.wai.multiselect.readOnlyTextField.ReadOnlyTextFieldTpl'
+}}
+
+    {macro main()}
+        <div style="margin: 10px;">
+            <input {id "tf"/}> <br>
+            {@aria:MultiSelect {
+                id :"happyMS",
+                waiAria: true,
+                waiDescribedBy: "happyMSDescription",
+                iconTooltip: "Press space to open the list of check boxes",
+                readOnlyTextField: true,
+                label : "What do you need to be happy?",
+                labelWidth : 200,
+                width: 650,
+                displayOptions : {
+                    listDisplay : "label"
+                },
+                items : [
+                    {label : "God", value : "God"},
+                    {label : "Love", value : "Love"},
+                    {label : "Forgiveness", value : "Forgiveness"},
+                    {label : "Hope", value : "Hope"},
+                    {label : "A spouse", value : "spouse"},
+                    {label : "Good friends", value : "goodfriends"},
+                    {label : "Food", value : "Food"},
+                    {label : "Clothing", value : "Clothing"},
+                    {label : "Shelter", value : "Shelter"},
+                    {label : "A good job", value : "goodjob"},
+                    {label : "A car", value : "car"},
+                    {label : "A good computer", value : "goodcomputer"},
+                    {label : "A smartphone", value: "smartphone"},
+                    {label : "JavaScript", value : "Javascript"},
+                    {label : "A good browser", value: "goodbrowser"},
+                    {label : "Aria Templates", value : "ariatemplates"}
+                ]
+            }/}
+        </div>
+        <span id="happyMSDescription" style="display:none;">Press down then space to open the list of check boxes.</div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This commit adds the `readOnlyTextField` property to the multiselect. If true, the user can only modify the value of the widget by opening the popup (the text field is not modifiable).