### PR TITLE
Improving stability of CheckboxJawsTestCase

### DIFF
--- a/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
@@ -30,6 +30,7 @@ Aria.classDefinition({
         runTemplateTest : function () {
             var checkedRegExp = /not checked\nchecked/g;
             var notCheckedRegExp = /checked\nnot checked/g;
+            var newLineBeforeCheckbox = /\n(?=check box)/g;
 
             this.synEvent.execute([
                 ["click", this.getElementById("tf1")],
@@ -62,7 +63,7 @@ Aria.classDefinition({
                         "Checkbox A check box not checked\nCheckbox A check box checked\nCheckbox A\nCheckbox B check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B\nCheckbox C check box not checked\nCheckbox C check box checked\nCheckbox C\nLast textfield\nCheckbox C check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B check box not checked",
                     this.end,
                     function(response) {
-                        return this.removeDuplicates(response.replace(checkedRegExp, "checked").replace(notCheckedRegExp, "not checked"));
+                        return this.removeDuplicates(response.replace(newLineBeforeCheckbox, " ").replace(checkedRegExp, "checked").replace(notCheckedRegExp, "not checked"));
                     });
                 },
                 scope: this

--- a/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/checkbox/CheckboxJawsTestCase.js
@@ -63,7 +63,11 @@ Aria.classDefinition({
                         "Checkbox A check box not checked\nCheckbox A check box checked\nCheckbox A\nCheckbox B check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B\nCheckbox C check box not checked\nCheckbox C check box checked\nCheckbox C\nLast textfield\nCheckbox C check box not checked\nCheckbox B\nCheckbox B check box checked\nCheckbox B check box not checked",
                     this.end,
                     function(response) {
-                        return this.removeDuplicates(response.replace(newLineBeforeCheckbox, " ").replace(checkedRegExp, "checked").replace(notCheckedRegExp, "not checked"));
+                        return this.removeDuplicates(
+                            response.replace(newLineBeforeCheckbox, " ")
+                                .replace(checkedRegExp, "checked")
+                                .replace(notCheckedRegExp, "not checked")
+                        );
                     });
                 },
                 scope: this


### PR DESCRIPTION
`test.aria.widgets.wai.input.checkbox.CheckboxJawsTestCase` sometimes failed because Jaws sometimes breaks `Checkbox B check box not checked` into two lines in Jaws history (the new line being inserted before `check box`).
