### PR TITLE
Add Array.prototype.every to aria.utils.Array. New test added to ArrayTestCase

### DIFF
--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -182,6 +182,7 @@ var Aria = require("../Aria");
              * @param {Function} Function to test each element of the array. This function receives as arguments the
              * value, the index and the array.
              * @param {Object} thisObject Object to use as this when executing callback.
+             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback).
              */
             every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
                 // clone array to avoid mutation when executing the callback

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -184,7 +184,7 @@ var Aria = require("../Aria");
              * @param {Object}   thisObject - Object to use as this when executing callback. The default value, when thisObject 
              *                                is falsy, will be the given array.
              * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback) 
-             *                   false if at least one element returns a falsy value for the predicate (callback)
+             *                   false if at least one element returns a falsy value for the predicate (callback) 
              */
             every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
                 // clone array to prevent being impacted by possible mutations of the array in the callback

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -183,8 +183,8 @@ var Aria = require("../Aria");
              *                                value, the index and the array.
              * @param {Object}   thisObject - Object to use as this when executing callback. The default value, when thisObject 
              *                                is falsy, will be the given array.
-             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback). 
-             *                   false if at least one element returns a falsy value for the predicate (callback).
+             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback) 
+             *                   false if at least one element returns a falsy value for the predicate (callback)
              */
             every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
                 // clone array to prevent being impacted by possible mutations of the array in the callback
@@ -193,7 +193,7 @@ var Aria = require("../Aria");
                 thisObject = thisObject || array;
                 var arrayLength = workArray.length;
                 for (var arrayIndex = 0; arrayIndex < arrayLength; arrayIndex++) {
-                    if(!callback.call(thisObject, workArray[arrayIndex], arrayIndex, array)) {
+                    if ( !callback.call(thisObject, workArray[arrayIndex], arrayIndex, array) ) {
                         return false;
                     }
                 }

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -173,6 +173,30 @@ var Aria = require("../Aria");
                     }
                 }
                 return output;
+            },
+            /**
+             * This tests whether all elements in the array pass the test implemented by the provided function. 
+             * As long as the elements return truthy values, the loop will continue. However, as soon as a falsy
+             * value is returns, the answer will be returned without analyzed the rest of the elements.
+             * @param {Array} array Array to filter.
+             * @param {Function} Function to test each element of the array. This function receive as arguments the
+             * value, the index and the array.
+             * @param {Object} thisObject Object to use as this when executing callback.
+             */
+            every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
+                // clone array to avoid mutation when executing the callback
+                var workArray = arrayUtils.clone(array);
+
+                thisObject = thisObject || array;
+                var len = workArray.length;
+                for (var i = 0; i < len; i++) {
+                    if(!callback.call(thisObject, workArray[i], i, array)) {
+                        return false;
+                    }
+                }
+                return true;
+            } : function(array, callback, thisObject) {
+                return array.every(callback, thisObject);
             }
         }
     });

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -175,11 +175,11 @@ var Aria = require("../Aria");
                 return output;
             },
             /**
-             * This tests whether all elements in the array pass the test implemented by the provided function. 
-             * As long as the elements return truthy values, the loop will continue. However, as soon as a falsy
-             * value is returns, the answer will be returned without analyzed the rest of the elements.
-             * @param {Array} array Array to filter.
-             * @param {Function} Function to test each element of the array. This function receive as arguments the
+             * This tests whether all elements in the array pass the test given by the predicate callback function. 
+             * As long as the predicate (callback) returns truthy values, the loop will continue. However, as soon as a falsy
+             * value is returned, the function will return without analyzing the rest of the elements.
+             * @param {Array} array Array to analyze.
+             * @param {Function} Function to test each element of the array. This function receives as arguments the
              * value, the index and the array.
              * @param {Object} thisObject Object to use as this when executing callback.
              */
@@ -188,9 +188,9 @@ var Aria = require("../Aria");
                 var workArray = arrayUtils.clone(array);
 
                 thisObject = thisObject || array;
-                var len = workArray.length;
-                for (var i = 0; i < len; i++) {
-                    if(!callback.call(thisObject, workArray[i], i, array)) {
+                var arrayLength = workArray.length;
+                for (var arrayIndex = 0; arrayIndex < arrayLength; arrayIndex++) {
+                    if(!callback.call(thisObject, workArray[arrayIndex], arrayIndex, array)) {
                         return false;
                     }
                 }

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -175,17 +175,19 @@ var Aria = require("../Aria");
                 return output;
             },
             /**
-             * This tests whether all elements in the array pass the test given by the predicate callback function. 
+             * This tests whether all elements in the array pass the predicate given by the callback function. 
              * As long as the predicate (callback) returns truthy values, the loop will continue. However, as soon as a falsy
              * value is returned, the function will return without analyzing the rest of the elements.
-             * @param {Array} array Array to analyze.
-             * @param {Function} Function to test each element of the array. This function receives as arguments the
-             * value, the index and the array.
-             * @param {Object} thisObject Object to use as this when executing callback.
-             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback).
+             * @param {Array}    array      - Array to process.
+             * @param {Function} callback   - Function to test each element of the array. This function receives as arguments 
+             *                                value, the index and the array.
+             * @param {Object}   thisObject - Object to use as this when executing callback. The default value, when thisObject 
+             *                                is falsy, will be the given array.
+             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback) 
+             *                   false if at least one element returns a falsy value for the predicate (callback)
              */
             every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
-                // clone array to avoid mutation when executing the callback
+                // clone array to prevent being impacted by possible mutations of the array in the callback
                 var workArray = arrayUtils.clone(array);
 
                 thisObject = thisObject || array;

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -183,8 +183,8 @@ var Aria = require("../Aria");
              *                                value, the index and the array.
              * @param {Object}   thisObject - Object to use as this when executing callback. The default value, when thisObject 
              *                                is falsy, will be the given array.
-             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback) 
-             *                   false if at least one element returns a falsy value for the predicate (callback) 
+             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback). 
+             *                   false if at least one element returns a falsy value for the predicate (callback).
              */
             every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
                 // clone array to prevent being impacted by possible mutations of the array in the callback

--- a/test/aria/utils/ArrayTestCase.js
+++ b/test/aria/utils/ArrayTestCase.js
@@ -237,6 +237,46 @@ Aria.classDefinition({
                 result += value;
             }, this);
             this.assertTrue(result === "123459");
+        },
+
+        testEvery : function () {
+            // shortcut
+            var every = aria.utils.Array.every;
+
+            // doing stuff on empty array should do nothing
+            var count = 0;
+            every([], function () {
+                count++;
+            });
+            this.assertTrue(count === 0);
+
+            // forEach simple test
+            var testArray = [1, 2, 3, 4, 5, 9], result = "";
+            every(testArray, function (value, index, array) {
+                // changing the array should not break
+                testArray = [];
+                result += value;
+                return value !== 4;
+            }, this);
+            this.assertTrue(result === "1234");
+
+            testArray = [1, 2, 3, 4, 5, 9], result = "";
+            every(testArray, function (value, index, array) {
+                // changing the array should not break
+                testArray = [];
+                result += value;
+                return false;
+            }, this);
+            this.assertTrue(result === "1");
+
+            testArray = [1, 2, 3, 4, 5, 9], result = "";
+            every(testArray, function (value, index, array) {
+                // changing the array should not break
+                testArray = [];
+                result += value;
+                return true;
+            }, this);
+            this.assertTrue(result === "123459");
         }
     }
 });

--- a/test/aria/utils/ArrayTestCase.js
+++ b/test/aria/utils/ArrayTestCase.js
@@ -250,34 +250,24 @@ Aria.classDefinition({
             });
             this.assertTrue(count === 0);
 
-            // every test when specific item false
+            // simple test false
             var testArray = [1, 2, 3, 4, 5, 9], result = "";
-            every(testArray, function (value, index, array) {
+            this.assertFalse(every(testArray, function (value, index, array) {
                 // changing the array should not break
                 testArray = [];
                 result += value;
                 return value !== 4;
-            }, this);
+            }, this));
             this.assertTrue(result === "1234");
 
-            // every test when all false
+            // simple test true
             testArray = [1, 2, 3, 4, 5, 9], result = "";
-            every(testArray, function (value, index, array) {
-                // changing the array should not break
-                testArray = [];
-                result += value;
-                return false;
-            }, this);
-            this.assertTrue(result === "1");
-
-            // every test when all true
-            testArray = [1, 2, 3, 4, 5, 9], result = "";
-            every(testArray, function (value, index, array) {
+            this.assertTrue(every(testArray, function (value, index, array) {
                 // changing the array should not break
                 testArray = [];
                 result += value;
                 return true;
-            }, this);
+            }, this));
             this.assertTrue(result === "123459");
         }
     }

--- a/test/aria/utils/ArrayTestCase.js
+++ b/test/aria/utils/ArrayTestCase.js
@@ -250,7 +250,7 @@ Aria.classDefinition({
             });
             this.assertTrue(count === 0);
 
-            // forEach simple test
+            // every test when specific item false
             var testArray = [1, 2, 3, 4, 5, 9], result = "";
             every(testArray, function (value, index, array) {
                 // changing the array should not break
@@ -260,6 +260,7 @@ Aria.classDefinition({
             }, this);
             this.assertTrue(result === "1234");
 
+            // every test when all false
             testArray = [1, 2, 3, 4, 5, 9], result = "";
             every(testArray, function (value, index, array) {
                 // changing the array should not break
@@ -269,6 +270,7 @@ Aria.classDefinition({
             }, this);
             this.assertTrue(result === "1");
 
+            // every test when all true
             testArray = [1, 2, 3, 4, 5, 9], result = "";
             every(testArray, function (value, index, array) {
                 // changing the array should not break

--- a/test/aria/utils/ArrayTestCase.js
+++ b/test/aria/utils/ArrayTestCase.js
@@ -261,7 +261,8 @@ Aria.classDefinition({
             this.assertTrue(result === "1234");
 
             // simple test true
-            testArray = [1, 2, 3, 4, 5, 9], result = "";
+            testArray = [1, 2, 3, 4, 5, 9];
+            result = "";
             this.assertTrue(every(testArray, function (value, index, array) {
                 // changing the array should not break
                 testArray = [];


### PR DESCRIPTION
This pull request would like to add the Array.prototype.every method to the aria.utils.Array object. This is to polyfill older versions of the browser and also to have a clean way of performing tasks on Arrays. The purpose of this addition is to allow us to write recursion that will replicate the break functionality, so we don't have to waste time looping through the list when the required item is found.