### PR TITLE
Adding waiHasPopup on widgets extending ActionWidget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1200,6 +1200,10 @@ module.exports = Aria.beanDefinitions({
                 "waiLabelledBy" : {
                     $type : "json:String",
                     $description : "Sets aria-labelledby on the widget, value will be used as the attribute's value"
+                },
+                "waiHasPopup" : {
+                    $type : "json:Boolean",
+                    $description : "If true, sets aria-haspopup=\"true\" on the widget. Only used if waiAria is true."
                 }
             }
         },

--- a/src/aria/widgets/action/ActionWidget.js
+++ b/src/aria/widgets/action/ActionWidget.js
@@ -142,22 +142,14 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _getWaiAriaMarkup : function () {
-            // --------------------------------------------------- destructuring
-
             var cfg = this._cfg;
-
-            var waiAria = cfg.waiAria;
-
-            var waiLabel = cfg.waiLabel;
-            var waiLabelledBy = cfg.waiLabelledBy;
-            var waiDescribedBy = cfg.waiDescribedBy;
-
-            // ------------------------------------------------------ processing
-
             var markup = '';
 
-            if (waiAria) {
+            if (cfg.waiAria) {
                 markup = [];
+                var waiLabel = cfg.waiLabel;
+                var waiLabelledBy = cfg.waiLabelledBy;
+                var waiDescribedBy = cfg.waiDescribedBy;
 
                 if (waiLabel) {
                     markup.push('aria-label="' + ariaUtilsString.encodeForQuotedHTMLAttribute(waiLabel) + '"');
@@ -171,6 +163,10 @@ module.exports = Aria.classDefinition({
                     markup.push('aria-describedby="' + ariaUtilsString.encodeForQuotedHTMLAttribute(waiDescribedBy) + '"');
                 }
 
+                if (cfg.waiHasPopup) {
+                    markup.push('aria-haspopup="true"');
+                }
+
                 if (markup.length > 0) {
                     markup.unshift('');
                     markup.push('');
@@ -178,9 +174,6 @@ module.exports = Aria.classDefinition({
 
                 markup = markup.join(' ');
             }
-
-            // ---------------------------------------------------------- return
-
             return markup;
         }
     }

--- a/test/aria/widgets/wai/input/actionWidget/hasPopup/ButtonJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/hasPopup/ButtonJawsTestCase.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.actionWidget.hasPopup.ButtonJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 1000],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.noiseRegExps.push(/^Type/i);
+                    this.assertJawsHistoryEquals([
+                        "Edit",
+                        "More info button menu",
+                        "Normal Button",
+                        "Edit",
+                        "Normal Button",
+                        "More info button menu"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/actionWidget/hasPopup/ButtonJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/hasPopup/ButtonJawsTestCaseTpl.tpl
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.actionWidget.hasPopup.ButtonJawsTestCaseTpl"
+}}
+
+    {macro main()}
+        <div style="margin:10px;">
+            <input {id "tf1"/}><br>
+            {@aria:Button {
+                label: "More info",
+                waiHasPopup: true,
+                waiAria: true
+            } /}<br>
+            {@aria:Button {
+                label: "Normal",
+                waiAria: true
+            } /}<br>
+            <input {id "tf2"/}><br>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/actionWidget/hasPopup/LinkJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/hasPopup/LinkJawsTestCase.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.actionWidget.hasPopup.LinkJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 1000],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 1000]
+            ], {
+                fn: function () {
+                    this.noiseRegExps.push(/^Type/i);
+                    this.assertJawsHistoryEquals([
+                        "Edit",
+                        "Link Has Popup More info",
+                        "Link Normal",
+                        "Edit",
+                        "Normal Link",
+                        "More info Has Popup Link"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/actionWidget/hasPopup/LinkJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/hasPopup/LinkJawsTestCaseTpl.tpl
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.input.actionWidget.hasPopup.LinkJawsTestCaseTpl"
+}}
+
+    {macro main()}
+        <div style="margin:10px;">
+            <input {id "tf1"/}><br>
+            {@aria:Link {
+                label: "More info",
+                waiHasPopup: true,
+                waiAria: true
+            } /}<br>
+            {@aria:Link {
+                label: "Normal",
+                waiAria: true
+            } /}<br>
+            <input {id "tf2"/}><br>
+        </div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR adds the `waiHasPopup` property on all widgets which extend `ActionWidget` (`@aria:Button`, `@aria:Link`, ...).
