### PR TITLE
Removing arbitrary limit of +/-365 in the date parser

### DIFF
--- a/src/aria/utils/Date.js
+++ b/src/aria/utils/Date.js
@@ -375,7 +375,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
          * @private
          * @type RegExp
          */
-        this._interpret_specialCase2 = /^[+\-]\d{1,3}$/;
+        this._interpret_specialCase2 = /^[+\-]\d+$/;
 
         /**
          * special case 3 RegExp : 10DEC/+-5 -> 10DEC +-5 days. Localized regexp.It is set in method
@@ -1081,12 +1081,6 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
          */
         interpretWithRefDate : function (dateStr, referenceDate) {
             var shift = parseInt(dateStr, 10), jsdate;
-
-            // format valid only if number of days <= 365
-            if (Math.abs(shift) > 365) {
-                return null;
-            }
-
             // When a reference date is set, the shift needs to be added to the reference date.
             if (referenceDate != null) {
                 jsdate = new Date(referenceDate.getTime());
@@ -1094,6 +1088,10 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
                 jsdate = new Date();
             }
             jsdate.setDate(jsdate.getDate() + shift);
+            if (!ariaUtilsType.isValidDate(jsdate)) {
+                // too large shift values (such as +100000000) lead to an invalid date
+                return null;
+            }
             return jsdate;
 
         },
@@ -1108,13 +1106,13 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             var execResult = this._interpret_specialCase3.exec(dateStr), jsdate;
             var newEntry = execResult[1];
             var shift = parseInt(execResult[3], 10);
-            // format valid only if number of days <= 365
-            if (Math.abs(shift) > 365) {
-                return null;
-            }
             jsdate = this.interpretDateAndMonth(newEntry, options);
             if (jsdate) {
                 jsdate.setDate(jsdate.getDate() + shift);
+                if (!ariaUtilsType.isValidDate(jsdate)) {
+                    // too large shift values (such as +100000000) lead to an invalid date
+                    return null;
+                }
             }
             return jsdate;
 
@@ -1779,7 +1777,7 @@ var ariaUtilsDate = module.exports = Aria.classDefinition({
             this._interpret_monthTexts = monthTexts;
             var source = monthTexts.join("|").replace("\\", "\\\\").replace(/\s/g, "\\s").replace(/\./g, "\\.");
             this._interpret_isMonth = new RegExp("(" + source + ")", "i");
-            this._interpret_specialCase3 = new RegExp("^(\\d{1,2}\\s*(" + source + ")\\s*\\d{0,4})\\/([+\\-]\\d{1,3})$", "i");
+            this._interpret_specialCase3 = new RegExp("^(\\d{1,2}\\s*(" + source + ")\\s*\\d{0,4})\\/([+\\-]\\d+)$", "i");
         },
 
         /**

--- a/src/aria/utils/Type.js
+++ b/src/aria/utils/Type.js
@@ -74,12 +74,32 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Check if the value is an integer.
+         * @param {Object} value
+         * @return {Boolean} isInteger
+         */
+        isInteger : function (value) {
+            return this.isNumber(value) &&
+                    (Math.floor(value) === value) &&
+                    (value + 1) !== value; // is finite and precise
+        },
+
+        /**
          * Check if the value is a js Date
          * @param {Object} value
          * @return {Boolean} isDate
          */
         isDate : function (value) {
             return Object.prototype.toString.apply(value) === "[object Date]";
+        },
+
+        /**
+         * Check if the value is a valid js Date
+         * @param {Object} value
+         * @param {Boolean} isValidDate
+         */
+        isValidDate : function (date) {
+            return this.isDate(date) && this.isInteger(date.valueOf());
         },
 
         /**

--- a/test/aria/utils/DateTestCase.js
+++ b/test/aria/utils/DateTestCase.js
@@ -64,28 +64,22 @@ Aria.classDefinition({
             for (var index = -366; index < 367; index++) {
                 testDate = new Date(date.getTime() + index * 3600 * 1000 * 24);
 
-                if (index === 366) {
-                    this.assertTrue(ariaDateUtil.interpret("+" + index) === null);
-                } else if (index === -366) {
-                    this.assertTrue(ariaDateUtil.interpret("" + index) === null);
+                if (index >= 0) {
+                    this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("+" + index), testDate), " + special case  2 failed for +"
+                            + index);
+                    this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("-" + index, testDate), date), " + special case  2 failed for +"
+                            + index + " with reference date passed");
                 } else {
-                    if (index >= 0) {
-                        this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("+" + index), testDate), " + special case  2 failed for +"
-                                + index);
-                        this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("-" + index, testDate), date), " + special case  2 failed for +"
-                                + index + " with reference date passed");
-                    } else {
-                        this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("" + index), testDate), " - special case  2 failed for "
-                                + index);
-                        this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("+" + Math.abs(index), testDate), date), " - special case  2 failed for -"
-                                + index + " with reference date passed");
-                    }
+                    this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("" + index), testDate), " - special case  2 failed for "
+                            + index);
+                    this.assertTrue(ariaDateUtil.isSameDay(ariaDateUtil.interpret("+" + Math.abs(index), testDate), date), " - special case  2 failed for -"
+                            + index + " with reference date passed");
                 }
 
             }
 
             // special case 3: 12DEC/+10
-            this.assertTrue(!ariaDateUtil.interpret("12DEC/-370"));
+            this.assertTrue(!ariaDateUtil.interpret("12DEC/-37000000000000"));
             var dec12 = ariaDateUtil.interpret("12DEC/-10");
             var dec2 = ariaDateUtil.interpret("2DEC");
             this.assertEquals(dec12.getDate(), dec2.getDate());

--- a/test/aria/utils/TypeTestCase.js
+++ b/test/aria/utils/TypeTestCase.js
@@ -181,7 +181,32 @@ Aria.classDefinition({
             this.assertTrue(typeUtils.isNumber(21.21));
             this.assertTrue(typeUtils.isNumber(Infinity));
         },
-
+        testIsInteger : function () {
+            var typeUtils = aria.utils.Type;
+            this.assertTrue(typeUtils.isInteger(0));
+            this.assertTrue(typeUtils.isInteger(-1));
+            this.assertTrue(typeUtils.isInteger(1));
+            this.assertTrue(typeUtils.isInteger(-5));
+            this.assertTrue(typeUtils.isInteger(5));
+            this.assertTrue(typeUtils.isInteger(-21));
+            this.assertTrue(typeUtils.isInteger(21));
+            this.assertFalse(typeUtils.isInteger(NaN));
+            this.assertFalse(typeUtils.isInteger(Infinity));
+            this.assertFalse(typeUtils.isInteger(-Infinity));
+            this.assertFalse(typeUtils.isInteger(21.21));
+            this.assertFalse(typeUtils.isInteger(-21.21));
+            this.assertFalse(typeUtils.isInteger(true));
+            this.assertFalse(typeUtils.isInteger(undefined));
+            this.assertFalse(typeUtils.isInteger(false));
+            this.assertFalse(typeUtils.isInteger(1e+50));
+            this.assertFalse(typeUtils.isInteger(-1e+50));
+        },
+        testIsValidDate: function () {
+            var typeUtils = aria.utils.Type;
+            this.assertTrue(typeUtils.isValidDate(new Date()));
+            this.assertTrue(typeUtils.isValidDate(new Date(2016,8,26)));
+            this.assertFalse(typeUtils.isValidDate(new Date(1e+50)));
+        },
         _myTestMethod : function () {}
     }
 });


### PR DESCRIPTION
Before this commit:

```js
aria.utils.Date.interpret("-365"); // returns today - 365 days
aria.utils.Date.interpret("+365"); // returns today + 365 days
aria.utils.Date.interpret("-366"); // returns null
aria.utils.Date.interpret("+366"); // returns null
aria.utils.Date.interpret("1SEP2016/-365"); // returns Wed Sep 02 2015
aria.utils.Date.interpret("1SEP2016/+365"); // returns Fri Sep 01 2017
aria.utils.Date.interpret("1SEP2016/-366"); // returns null
aria.utils.Date.interpret("1SEP2016/+366"); // returns null
```

After this commit:

```js
aria.utils.Date.interpret("-365"); // still returns today - 365 days
aria.utils.Date.interpret("+365"); // still returns today + 365 days
aria.utils.Date.interpret("-366"); // now returns today - 366 days
aria.utils.Date.interpret("+366"); // now returns today + 366 days
aria.utils.Date.interpret("1SEP2016/-365"); // still returns Wed Sep 02 2015
aria.utils.Date.interpret("1SEP2016/+365"); // still returns Fri Sep 01 2017
aria.utils.Date.interpret("1SEP2016/-366"); // now returns Tue Sep 01 2015
aria.utils.Date.interpret("1SEP2016/+366"); // now returns Sat Sep 02 2017
```

The arbitrary limit of +/- 365 is now removed.
It is possible to add or remove any number of days to the reference date.
The new limit is the date range supported by the javascript `Date` object.