### PR TITLE
isSafari, isIE and isOpera were not true on the mobile versions

### DIFF
--- a/src/aria/core/Browser.js
+++ b/src/aria/core/Browser.js
@@ -958,15 +958,16 @@ module.exports = Aria.classDefinition({
                     case "androidbrowser":
                         this._setFlag(output, "AndroidBrowser");
                         break;
+                    case "iemobile":
+                        this._setFlag(output, "IEMobile");
+                        this._setFlag(output, "IE");
+                        break;
                     default:
                         maybeOtherBrowser = true;
                 }
 
-                if (ariaUtilsArray.contains(["Firefox", "Chrome", "IE", "Opera", "IEMobile", "Edge", "PhantomJS"], name)) {
+                if (ariaUtilsArray.contains(["Firefox", "Chrome", "IE", "Opera", "Edge", "PhantomJS"], name)) {
                     this._setFlag(output, name);
-                    if (name === "IEMobile") {
-                        this._setFlag(output, "IE");
-                    }
                     maybeOtherBrowser = false;
                 }
             } else {

--- a/src/aria/core/Browser.js
+++ b/src/aria/core/Browser.js
@@ -937,13 +937,16 @@ module.exports = Aria.classDefinition({
                             this._setFlag(output, "BlackBerryBrowser");
                         } else {
                             this._setFlag(output, "SafariMobile");
+                            this._setFlag(output, "Safari");
                         }
                         break;
                     case "operamini":
                         this._setFlag(output, "OperaMini");
+                        this._setFlag(output, "Opera");
                         break;
                     case "operamobi":
                         this._setFlag(output, "OperaMobile");
+                        this._setFlag(output, "Opera");
                         break;
                     case "safari":
                         if (output.isSymbian) {
@@ -961,6 +964,9 @@ module.exports = Aria.classDefinition({
 
                 if (ariaUtilsArray.contains(["Firefox", "Chrome", "IE", "Opera", "IEMobile", "Edge", "PhantomJS"], name)) {
                     this._setFlag(output, name);
+                    if (name === "IEMobile") {
+                        this._setFlag(output, "IE");
+                    }
                     maybeOtherBrowser = false;
                 }
             } else {

--- a/test/aria/core/useragent/BrowserAndDeviceTestCase.js
+++ b/test/aria/core/useragent/BrowserAndDeviceTestCase.js
@@ -361,8 +361,8 @@ Aria.classDefinition({
                 // ------------------------------------------------------- tests
 
                 var checkFunction = function(expectedValue) {
-                    return function(falseFlag) {
-                        var propertyName = Browser._buildFlagName(falseFlag);
+                    return function(flag) {
+                        var propertyName = Browser._buildFlagName(flag);
                         var message = 'Flag "' + propertyName + '" should be ' + expectedValue + '. ' +
                         'Additional information: ' + useCase.id + ', ua: ' + useCase.ua;
                         this.assertEquals(actualValues[propertyName], expectedValue, message);

--- a/test/aria/core/useragent/BrowserAndDeviceTestCase.js
+++ b/test/aria/core/useragent/BrowserAndDeviceTestCase.js
@@ -330,6 +330,7 @@ Aria.classDefinition({
 
         _testFlags : function (spec) {
             var forEach = aria.utils.Array.forEach;
+            var isArray = aria.utils.Type.isArray;
             var Browser = aria.core.Browser;
 
             // ----------------------------------------- arguments destructuring
@@ -346,30 +347,30 @@ Aria.classDefinition({
             forEach(specifications, function(specification) {
                 // -------------------------------------------------- flags sets
 
-                var trueFlag;
+                var trueFlags = [];
                 var falseFlags = [].concat(specification.flags);
 
                 var expectedFlagName = expectedValues[specification.category];
                 if (expectedFlagName != null) {
-                    trueFlag = expectedFlagName;
-                    falseFlags.splice(aria.utils.Array.indexOf(falseFlags, trueFlag), 1);
+                    trueFlags = isArray(expectedFlagName) ? expectedFlagName : [expectedFlagName];
+                    forEach(trueFlags, function(trueFlag) {
+                        falseFlags.splice(aria.utils.Array.indexOf(falseFlags, trueFlag), 1);
+                    });
                 }
 
                 // ------------------------------------------------------- tests
 
-                if (trueFlag != null) {
-                    var propertyName = Browser._buildFlagName(trueFlag);
-                    var message = 'Flag "' + propertyName + '" should be true. ' +
-                    'Browser: ' + useCase.id + ', ua: ' + useCase.ua;
-                    this.assertTrue(actualValues[propertyName], message);
-                }
+                var checkFunction = function(expectedValue) {
+                    return function(falseFlag) {
+                        var propertyName = Browser._buildFlagName(falseFlag);
+                        var message = 'Flag "' + propertyName + '" should be ' + expectedValue + '. ' +
+                        'Additional information: ' + useCase.id + ', ua: ' + useCase.ua;
+                        this.assertEquals(actualValues[propertyName], expectedValue, message);
+                    };
+                };
 
-                forEach(falseFlags, function(falseFlag) {
-                    var propertyName = Browser._buildFlagName(falseFlag);
-                    var message = 'Flag "' + propertyName + '" should be false. ' +
-                    'Additional information: ' + useCase.id + ', ua: ' + useCase.ua;
-                    this.assertFalse(actualValues[propertyName], message);
-                }, this);
+                forEach(trueFlags, checkFunction(true), this);
+                forEach(falseFlags, checkFunction(false), this);
             }, this);
         }
         /* BACKWARD-COMPATIBILITY-BEGIN (GitHub #1397) */

--- a/test/aria/core/useragent/UseCases.js
+++ b/test/aria/core/useragent/UseCases.js
@@ -284,7 +284,7 @@ Aria.classDefinition({
                 osVersion : "WCE"
             },
             flags: {
-                browser: "OperaMobile",
+                browser: ["OperaMobile", "Opera"],
                 os: "WindowsPhone"
             }
         },
@@ -312,7 +312,7 @@ Aria.classDefinition({
                 osVersion : ""
             },
             flags: {
-                browser: "OperaMobile",
+                browser: ["OperaMobile", "Opera"],
                 os: "Symbian"
             }
         },
@@ -340,7 +340,7 @@ Aria.classDefinition({
                 osVersion : ""
             },
             flags: {
-                browser: "OperaMini",
+                browser: ["OperaMini", "Opera"],
                 os: "BlackBerry"
             }
         },
@@ -435,7 +435,7 @@ Aria.classDefinition({
             },
             flags: {
                 engine: "Webkit",
-                browser: "SafariMobile",
+                browser: ["SafariMobile", "Safari"],
                 os: "IOS"
             }
         },
@@ -464,7 +464,7 @@ Aria.classDefinition({
             },
             flags: {
                 engine: "Webkit",
-                browser: "SafariMobile",
+                browser: ["SafariMobile", "Safari"],
                 os: "IOS"
             }
         },
@@ -496,7 +496,7 @@ Aria.classDefinition({
                 osVersion : "7.5"
             },
             flags: {
-                browser: "IEMobile",
+                browser: ["IEMobile", "IE"],
                 os: "WindowsPhone"
             }
         },
@@ -524,7 +524,7 @@ Aria.classDefinition({
                 osVersion : "CE"
             },
             flags: {
-                browser: "IEMobile",
+                browser: ["IEMobile", "IE"],
                 os: "Windows"
             }
         },
@@ -552,7 +552,7 @@ Aria.classDefinition({
                 osVersion : "7.0"
             },
             flags: {
-                browser: "IEMobile",
+                browser: ["IEMobile", "IE"],
                 os: "WindowsPhone"
             }
         },


### PR DESCRIPTION
The following properties of aria.core.Browser were true only on the desktop version of the corresponding browsers:
- isSafari
- isIE
- isOpera

They are now true both on the desktop and mobile versions.
