### PR TITLE
Removing `aria:parent` properties when they are no longer useful

### DIFF
--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1452,6 +1452,36 @@ Aria.classDefinition({
                 fn : function () {}
             });
             this.assertJsonEquals(['mykey'], aria.utils.Json.keys(listened));
+        },
+
+        testRemoveBackRefs : function () {
+            var jsonUtils = aria.utils.Json;
+            var parProp = jsonUtils.OBJECT_PARENT_PROPERTY;
+            var d = {};
+            var b = {
+                d: d
+            };
+            var c = {};
+            var a = {
+                b: b,
+                c: c
+            };
+            var listener = {
+                fn: function () {},
+                scope: this
+            };
+            jsonUtils.addListener(a, null, listener, false, true);
+            this.assertTrue(b[parProp] != null);
+            this.assertTrue(c[parProp] != null);
+            this.assertTrue(d[parProp] != null);
+            jsonUtils.setValue(a, "b", null);
+            this.assertTrue(b[parProp] == null);
+            this.assertTrue(c[parProp] != null);
+            this.assertTrue(d[parProp] == null);
+            jsonUtils.removeListener(a, null, listener, true);
+            this.assertTrue(b[parProp] == null);
+            this.assertTrue(c[parProp] == null);
+            this.assertTrue(d[parProp] == null);
         }
     }
 });


### PR DESCRIPTION
This commit adds some checks to remove `aria:parent` properties on an object when that object no longer has any recursive listener and no longer has any parent in `aria:parent`. This fixes some memory leaks which can occur in case some parts of the data model are reused inside new containers and old containers are no longer used but still pointing to the reused parts of the data model (so the `aria:parent` properties on the reused parts of the data model still pointed to the old objects, even though there was no recursive listener any more in that old part of the data model).