### PR TITLE
Using mouseenter/mouseleave instead of mouseover/mouseout in widgets

### DIFF
--- a/src/aria/widgets/Text.js
+++ b/src/aria/widgets/Text.js
@@ -173,12 +173,12 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Internal method to handle the mouse over event
+         * Internal method to handle the mouse enter event
          * @protected
          * @param {aria.DomEvent} event
          */
-        _dom_onmouseover : function (event) {
-            this.$Widget._dom_onmouseover.call(this, event);
+        _dom_onmouseenter : function (event) {
+            this.$Widget._dom_onmouseenter.call(this, event);
             if (this._ellipsis && this._ellipsis.ellipsesNeeded) {
                 this._hasMouseOver = true;
                 this._ellipsis.displayFullText({
@@ -193,8 +193,8 @@ module.exports = Aria.classDefinition({
          * @param {aria.DomEvent} event
          * @protected
          */
-        _dom_onmouseout : function (event) {
-            this.$Widget._dom_onmouseout.call(this, event);
+        _dom_onmouseleave : function (event) {
+            this.$Widget._dom_onmouseleave.call(this, event);
             if (this._ellipsis && this._ellipsis.ellipsesNeeded) {
                 if (this._hasFocus === false && this._hasMouseOver === true) {
                     this._hasMouseOver = false;

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -20,7 +20,7 @@ var ariaUtilsString = require("../../utils/String");
 var ariaWidgetsActionButtonStyle = require("./ButtonStyle.tpl.css");
 var ariaWidgetsActionActionWidget = require("./ActionWidget");
 var ariaCoreBrowser = require("../../core/Browser");
-
+var actionOnMouseUp = ariaCoreBrowser.isWebkit;
 
 /**
  * Class definition for the button widget.
@@ -76,12 +76,6 @@ module.exports = Aria.classDefinition({
         this._customTabIndexProvided = true;
 
         /**
-         * Pointer used to store the target on mousedown/mouseup
-         * @type HTMLElement
-         */
-        this.currTarget = null;
-
-        /**
          * Skin configutation for simpleHTML
          * @type Object
          * @protected
@@ -107,7 +101,6 @@ module.exports = Aria.classDefinition({
         }
     },
     $destructor : function () {
-        this.currTarget = null;
         if (this._frame) {
             this._frame.$dispose();
             this._frame = null;
@@ -286,23 +279,23 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * React to delegated mouse over events
+         * React to delegated mouse enter events
          * @protected
          * @param {aria.DomEvent} domEvt Event
          */
-        _dom_onmouseover : function (domEvt) {
-            this.$ActionWidget._dom_onmouseover.call(this, domEvt);
+        _dom_onmouseenter : function (domEvt) {
+            this.$ActionWidget._dom_onmouseenter.call(this, domEvt);
             this._mouseOver = true;
             this._updateState();
         },
 
         /**
-         * React to delegated mouse out events
+         * React to delegated mouse leave events
          * @protected
          * @param {aria.DomEvent} domEvt Event
          */
-        _dom_onmouseout : function (domEvt) {
-            this.$ActionWidget._dom_onmouseout.call(this, domEvt);
+        _dom_onmouseleave : function (domEvt) {
+            this.$ActionWidget._dom_onmouseleave.call(this, domEvt);
             this._mouseOver = false;
             this._mousePressed = false;
             this._updateState();
@@ -318,10 +311,6 @@ module.exports = Aria.classDefinition({
             this._mouseOver = true;
             this._mousePressed = true;
             this._updateState();
-
-            if (ariaCoreBrowser.isChrome || ariaCoreBrowser.isOpera || ariaCoreBrowser.isSafari) {
-                this.currTarget = domEvt.currentTarget;
-            }
         },
 
         /**
@@ -333,12 +322,9 @@ module.exports = Aria.classDefinition({
             // TODO: this method should also be called when the mouse button is released, not depending on where it is
             // released
 
-            if (ariaCoreBrowser.isChrome || ariaCoreBrowser.isOpera || ariaCoreBrowser.isSafari) {
-                if (this._mousePressed && domEvt.currentTarget == this.currTarget) {
-                    // handle an onclick event
-                    this._performAction(domEvt);
-                }
-                this.currTarget = null;
+            if (this._mousePressed && actionOnMouseUp) {
+                // handle an onclick event
+                this._performAction(domEvt);
             }
 
             if (this._cfg) { // this._cfg can become null if e.g. the button triggers a template substitution
@@ -371,7 +357,7 @@ module.exports = Aria.classDefinition({
          * @method
          * @private
          */
-        _dom_onclick : (ariaCoreBrowser.isChrome || ariaCoreBrowser.isOpera || ariaCoreBrowser.isSafari) ? function (domEvent) {
+        _dom_onclick : actionOnMouseUp ? function (domEvent) {
             // we don't catch onclick's for buttons on chrome & safari. we catch mouseup's instead
         } : function (domEvent) {
             if (!this._keyPressed) {

--- a/src/aria/widgets/action/SortIndicator.js
+++ b/src/aria/widgets/action/SortIndicator.js
@@ -315,12 +315,12 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Internal method to handle the mouse over event
+         * Internal method to handle the mouse enter event
          * @protected
          * @param {aria.DomEvent} domEvt Mouse over event
          */
-        _dom_onmouseover : function (domEvt) {
-            this.$ActionWidget._dom_onmouseover.call(this, domEvt);
+        _dom_onmouseenter : function (domEvt) {
+            this.$ActionWidget._dom_onmouseenter.call(this, domEvt);
             if (this._ellipsis) {
                 var mouseOverTime = new Date();
 
@@ -364,8 +364,8 @@ module.exports = Aria.classDefinition({
          * @param {aria.DomEvent} domEvt Mouse out event
          * @protected
          */
-        _dom_onmouseout : function (domEvt) {
-            this.$ActionWidget._dom_onmouseout.call(this, domEvt);
+        _dom_onmouseleave : function (domEvt) {
+            this.$ActionWidget._dom_onmouseleave.call(this, domEvt);
             if (this._ellipsis) {
 
                 if (this._hasFocus === false && this._hasMouseOver === true) {

--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -527,24 +527,24 @@ module.exports = Aria.classDefinition({
         },
 
         /**
-         * Internal method to handle the mouse over event
+         * Internal method to handle the mouse enter event
          * @protected
          * @param {aria.DomEvent} domEvt
          */
-        _dom_onmouseover : function (domEvt) {
-            this.$Container._dom_onmouseover.call(this, domEvt);
+        _dom_onmouseenter : function (domEvt) {
+            this.$Container._dom_onmouseenter.call(this, domEvt);
             this._mouseOver = true;
             this._updateState();
 
         },
 
         /**
-         * Internal method to handle the mouse out event
+         * Internal method to handle the mouse leave event
          * @protected
          * @param {aria.DomEvent} domEvt
          */
-        _dom_onmouseout : function (domEvt) {
-            this.$Container._dom_onmouseout.call(this, domEvt);
+        _dom_onmouseleave : function (domEvt) {
+            this.$Container._dom_onmouseleave.call(this, domEvt);
             this._mouseOver = false;
             this._updateState();
 

--- a/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCase.js
+++ b/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCase.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.action.button.clickNotWorking.ButtonClickNotWorkingRobotTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Dom"],
+    $prototype : {
+        runTemplateTest : function () {
+            var myBtn = this.getWidgetInstance("myBtn");
+            myBtn.getDom(); // make sure the button is linked to DOM
+            var span = myBtn._frame._childRootElt;
+            var spanGeometry = aria.utils.Dom.getGeometry(span);
+            this.synEvent.execute([["click", {
+                x: spanGeometry.x + spanGeometry.width / 2,
+                y: spanGeometry.y + 1
+            }], ["pause", 1000]], {
+                scope: this,
+                fn: function () {
+                    this.assertEquals(this.templateCtxt.data.buttonClickCalled, 1);
+                    this.end();
+                }
+            });
+
+        }
+    }
+});

--- a/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCaseTpl.tpl
+++ b/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCaseTpl.tpl
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "test.aria.widgets.action.button.clickNotWorking.ButtonClickNotWorkingRobotTestCaseTpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        {@aria:Button {
+            id: "myBtn",
+            label: "Click on me!!",
+            onclick: buttonClick
+        } /}<br><br>
+        Clicks: {@aria:Text {
+            bind: {
+                text: {
+                    to: "buttonClickCalled",
+                    inside: data
+                }
+            }
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCaseTplScript.js
+++ b/test/aria/widgets/action/button/clickNotWorking/ButtonClickNotWorkingRobotTestCaseTplScript.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.action.button.clickNotWorking.ButtonClickNotWorkingRobotTestCaseTplScript",
+    $prototype : {
+        $dataReady: function () {
+            if (isNaN(+this.data.buttonClickCalled)) {
+                this.$json.setValue(this.data, "buttonClickCalled", 0);
+            }
+        },
+
+        buttonClick : function (evt) {
+            this.$json.setValue(this.data, "buttonClickCalled", this.data.buttonClickCalled + 1);
+        }
+    }
+});


### PR DESCRIPTION
This commit adds support for mouseenter/mouseleave events in aria widgets (by simulating those events in all browsers from the mouseover/mouseout events).
This fixes an issue which prevented the button from working on some browsers (including Chrome) when clicking right at the top of the &lt;span&gt; element (inside the larger &lt;button&gt; element) because that element moves down when clicking, leading to a mouseout event on the span but there is no mouseleave event on the larger &lt;button&gt; element.