### PR TITLE
feat #1695 Added a set of generic utilities

### DIFF
--- a/build/config/files-bootstrap.json
+++ b/build/config/files-bootstrap.json
@@ -1,6 +1,7 @@
 [
     "aria/Aria.js",
     "aria/core/JsObject.js",
+    "aria/utils/Algo.js",
     "aria/utils/Type.js",
     "aria/utils/String.js",
     "aria/core/log/DefaultAppender.js",

--- a/build/config/files-prod.json
+++ b/build/config/files-prod.json
@@ -6,6 +6,7 @@
             "aria/core/log/*",
             "!aria/core/log/DefaultAppender.js",
             "aria/utils/**/*",
+            "!aria/utils/Algo.js",
             "!aria/utils/Array.js",
             "!aria/utils/Json.js",
             "!aria/utils/Object.js",

--- a/src/aria/jsunit/TestCase.js
+++ b/src/aria/jsunit/TestCase.js
@@ -480,6 +480,10 @@ module.exports = Aria.classDefinition({
             }
         },
 
+        end : function () {
+            this.notifyTestEnd();
+        },
+
         /**
          * This function should be called when testing an asynchronous method i.e. one that takes as input a callback
          * object

--- a/src/aria/utils/Algo.js
+++ b/src/aria/utils/Algo.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("../Aria");
+
+
+
+var self;
+
+/**
+ * @class aria.utils.Algo Utilities for writing algorithms
+ * @extends aria.core.JsObject
+ * @singleton
+ */
+module.exports = Aria.classDefinition({
+    $classpath : 'aria.utils.Algo',
+    $singleton : true,
+
+    $constructor : function () {
+        self = this;
+    },
+    $destructor : function () {
+        self = null;
+    },
+
+    $prototype : {
+        times : function (count, callback, thisArg) {
+            var results = [];
+            var index = 0;
+            while (index < count) {
+                results.push(callback.call(thisArg, index, count));
+                index++;
+            }
+            return results;
+        }
+    }
+});

--- a/src/aria/utils/Array.js
+++ b/src/aria/utils/Array.js
@@ -14,194 +14,378 @@
  */
 var Aria = require("../Aria");
 
+var ariaUtilsAlgo = require("./Algo");
+var ariaUtilsType = require("./Type");
 
-(function () {
-    var arrayPrototype = Array.prototype;
-    var arrayUtils;
 
-    /**
-     * @class aria.utils.Array Utilities for manipulating javascript arrays
-     * @extends aria.core.JsObject
-     * @singleton
-     */
-    module.exports = Aria.classDefinition({
-        $classpath : 'aria.utils.Array',
-        $singleton : true,
-        $constructor : function () {
-            arrayUtils = this;
-        },
-        $destructor : function () {
-            arrayPrototype = null;
-            arrayUtils = null;
-        },
-        $prototype : {
 
-            /**
-             * Returns the first (least) index of an element within the array equal to the specified value, or -1 if
-             * none is found.
-             * @param {Array} array Array to be searched.
-             * @param {Object} element Element for which we are searching.
-             * @return {Number} Index of the first matching array element.
-             */
-            indexOf : (!arrayPrototype.indexOf) ? (function (array, element) {
-                var length = array.length;
-                for (var i = 0; i < length; i++) {
-                    if (i in array && array[i] === element) {
-                        return i;
-                    }
+var arrayPrototype = Array.prototype;
+var arrayUtils;
+
+/**
+ * @class aria.utils.Array Utilities for manipulating javascript arrays
+ * @extends aria.core.JsObject
+ * @singleton
+ */
+module.exports = Aria.classDefinition({
+    $classpath : 'aria.utils.Array',
+    $singleton : true,
+    $constructor : function () {
+        arrayUtils = this;
+    },
+    $destructor : function () {
+        arrayPrototype = null;
+        arrayUtils = null;
+    },
+    $prototype : {
+        /**
+         * Ensures to return an array from the given value: if it is already an array it is returned as is, otherwise if it is void it returns an empty array, and eventually in any other case it returns the value wrapped in an array.
+         *
+         * @param value Any value. See full description for more details.
+         *
+         * @return {Array} An array. See full description for more details.
+         */
+        ensureWrap : function (value) {
+            if (!ariaUtilsType.isArray(value)) {
+                if (value == null) {
+                    value = [];
+                } else {
+                    value = [value];
                 }
-
-                return -1;
-            }) : function (array, element) {
-                return array.indexOf(element);
-            },
-
-            /**
-             * Test if the array contains the given object.
-             * @param {Array} array Array to test for the presence of the element
-             * @param {Object} element Element for which to test
-             * @return {Boolean} true if element is present.
-             */
-            contains : function (array, element) {
-                return arrayUtils.indexOf(array, element) != -1;
-            },
-
-            /**
-             * Returns a copy of the given array. The cloned array can be modified without impacting the original array.
-             * @param {Array} array The array to clone
-             * @return {Array} The cloned array
-             */
-            clone : function (array) {
-                var clonedArray = array.slice(0);
-                return clonedArray;
-            },
-
-            /**
-             * Removes the first occurrence of a particular value from an array.
-             * @param {Array} array : Array from which to remove element
-             * @param {Object} element : Element to remove
-             * @return {Boolean} True if an element was removed.
-             */
-            remove : function (array, element) {
-                var index = arrayUtils.indexOf(array, element);
-                if (index > -1) {
-                    arrayUtils.removeAt(array, index);
-                    return true;
-                }
-                return false;
-            },
-
-            /**
-             * Removes from an array the element at index i
-             * @param {Array} array Array from which to remove element.
-             * @param {Number} i The index to remove.
-             * @return {Boolean} True if an element was removed.
-             */
-            removeAt : function (array, index) {
-                return array.splice(index, 1).length == 1;
-            },
-
-            /**
-             * Wether the array is empty of not
-             * @param {Array} array Array from which to test
-             * @return {Boolean} True if the array is empty
-             */
-            isEmpty : function (array) {
-                return array.length === 0;
-            },
-
-            /**
-             * Filter elements of an array according to the result of callback
-             * @param {Array} array Array to filter.
-             * @param {Function} Function to test each element of the array. This function receive as arguments the
-             * value, the index and the array.
-             * @param {Object} thisObject Object to use as this when executing callback.
-             * @return {Array} array
-             */
-            filter : (!arrayPrototype.filter) ? function (array, callback, thisObject) {
-
-                // clone array to avoid mutation when executing the callback
-                var workArray = arrayUtils.clone(array);
-
-                var res = [];
-                thisObject = thisObject || array;
-                var len = workArray.length;
-                for (var i = 0; i < len; i++) {
-                    var val = workArray[i];
-                    if (callback.call(thisObject, val, i, array)) {
-                        res.push(val);
-                    }
-                }
-                return res;
-            } : function (array, callback, thisObject) {
-                return array.filter(callback, thisObject);
-            },
-
-            /**
-             * Call a function on each element of the array
-             * @param {Array} array Array to filter.
-             * @param {Function} Function to test each element of the array. This function receive as arguments the
-             * value, the index and the array.
-             * @param {Object} thisObject Object to use as this when executing callback.
-             */
-            forEach : (!arrayPrototype.forEach) ? function (array, callback, thisObject) {
-
-                // clone array to avoid mutation when executing the callback
-                var workArray = arrayUtils.clone(array);
-
-                var res = [];
-                thisObject = thisObject || array;
-                var len = workArray.length;
-                for (var i = 0; i < len; i++) {
-                    callback.call(thisObject, workArray[i], i, array);
-                }
-                return res;
-            } : function (array, callback, thisObject) {
-                return array.forEach(callback, thisObject);
-            },
-
-            /**
-             * Return an array with the values contained in the given map.
-             * @param {Object} map
-             * @return {Array}
-             */
-            extractValuesFromMap : function (map) {
-                var output = [];
-                for (var k in map) {
-                    if (map.hasOwnProperty(k)) {
-                        output.push(map[k]);
-                    }
-                }
-                return output;
-            },
-            /**
-             * This tests whether all elements in the array pass the predicate given by the callback function. 
-             * As long as the predicate (callback) returns truthy values, the loop will continue. However, as soon as a falsy
-             * value is returned, the function will return without analyzing the rest of the elements.
-             * @param {Array}    array      - Array to process.
-             * @param {Function} callback   - Function to test each element of the array. This function receives as arguments 
-             *                                value, the index and the array.
-             * @param {Object}   thisObject - Object to use as this when executing callback. The default value, when thisObject 
-             *                                is falsy, will be the given array.
-             * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback) 
-             *                   false if at least one element returns a falsy value for the predicate (callback)
-             */
-            every : (!arrayPrototype.every) ? function(array, callback, thisObject) {
-                // clone array to prevent being impacted by possible mutations of the array in the callback
-                var workArray = arrayUtils.clone(array);
-
-                thisObject = thisObject || array;
-                var arrayLength = workArray.length;
-                for (var arrayIndex = 0; arrayIndex < arrayLength; arrayIndex++) {
-                    if ( !callback.call(thisObject, workArray[arrayIndex], arrayIndex, array) ) {
-                        return false;
-                    }
-                }
-                return true;
-            } : function(array, callback, thisObject) {
-                return array.every(callback, thisObject);
             }
-        }
-    });
 
-})();
+            return value;
+        },
+
+        /**
+         * Returns the first (least) index of an element within the array equal to the specified value, or -1 if
+         * none is found.
+         * @param {Array} array Array to be searched.
+         * @param {Object} element Element for which we are searching.
+         * @return {Number} Index of the first matching array element.
+         */
+        indexOf : (!arrayPrototype.indexOf) ? (function (array, element) {
+            var length = array.length;
+            for (var i = 0; i < length; i++) {
+                if (i in array && array[i] === element) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }) : function (array, element) {
+            return array.indexOf(element);
+        },
+
+        /**
+         * Test if the array contains the given object.
+         * @param {Array} array Array to test for the presence of the element
+         * @param {Object} element Element for which to test
+         * @return {Boolean} true if element is present.
+         */
+        contains : function (array, element) {
+            return arrayUtils.indexOf(array, element) != -1;
+        },
+
+        /**
+         * Returns a copy of the given array. The cloned array can be modified without impacting the original array.
+         * @param {Array} array The array to clone
+         * @return {Array} The cloned array
+         */
+        clone : function (array) {
+            var clonedArray = Array.prototype.slice.call(array);
+            return clonedArray;
+        },
+
+         /**
+         * Repeats an item a certain number of times to build an array. This results of an array whose size corresponds to the number of times the item was repeated.
+         *
+         * @param {Number} times The number of times to repeat the item.
+         *
+         * @return {Array} The array with the same item repeated the given number of times.
+         */
+        repeatValue : function (item, times) {
+            var result = [];
+
+            for (var index = 0; index < times; index++) {
+                result.push(item);
+            }
+
+            return result;
+        },
+
+        /**
+         * Repeats the items of an array item a certain number of times to build a new array. This results of an array whose size corresponds to the size of the repeated array, times the given number.
+         *
+         * @param {Number} times The number of times to repeat the items of the array.
+         *
+         * @return {Array} The array with the items of the given array repeated the given number of times.
+         */
+        repeatArray : function (array, times) {
+            array = arrayUtils.repeatValue(array, times);
+            array = arrayUtils.flatten(array);
+            return array;
+        },
+
+        /**
+         * Removes the first occurrence of a particular value from an array.
+         * @param {Array} array : Array from which to remove element
+         * @param {Object} element : Element to remove
+         * @return {Boolean} True if an element was removed.
+         */
+        remove : function (array, element) {
+            var index = arrayUtils.indexOf(array, element);
+            if (index > -1) {
+                arrayUtils.removeAt(array, index);
+                return true;
+            }
+            return false;
+        },
+
+        /**
+         * Removes from an array the element at index i
+         * @param {Array} array Array from which to remove element.
+         * @param {Number} i The index to remove.
+         * @return {Boolean} True if an element was removed.
+         */
+        removeAt : function (array, index) {
+            return array.splice(index, 1).length == 1;
+        },
+
+        /**
+         * Wether the array is empty of not
+         * @param {Array} array Array from which to test
+         * @return {Boolean} True if the array is empty
+         */
+        isEmpty : function (array) {
+            return array.length === 0;
+        },
+
+        /**
+         * Filter elements of an array according to the result of callback
+         * @param {Array} array Array to filter.
+         * @param {Function} Function to test each element of the array. This function receive as arguments the
+         * value, the index and the array.
+         * @param {Object} thisArg Object to use as this when executing callback.
+         * @return {Array} array
+         */
+        filter : (!arrayPrototype.filter) ? function (array, callback, thisArg) {
+
+            // clone array to avoid mutation when executing the callback
+            var workArray = arrayUtils.clone(array);
+
+            var res = [];
+            thisArg = thisArg || array;
+            var len = workArray.length;
+            for (var i = 0; i < len; i++) {
+                var val = workArray[i];
+                if (callback.call(thisArg, val, i, array)) {
+                    res.push(val);
+                }
+            }
+            return res;
+        } : function (array, callback, thisArg) {
+            return array.filter(callback, thisArg);
+        },
+
+        /**
+         * Call a function on each element of the array
+         * @param {Array} array Array to filter.
+         * @param {Function} Function to test each element of the array. This function receive as arguments the
+         * value, the index and the array.
+         * @param {Object} thisArg Object to use as this when executing callback.
+         */
+        forEach : (!arrayPrototype.forEach) ? function (array, callback, thisArg) {
+
+            // clone array to avoid mutation when executing the callback
+            var workArray = arrayUtils.clone(array);
+
+            var res = [];
+            thisArg = thisArg || array;
+            var len = workArray.length;
+            for (var i = 0; i < len; i++) {
+                callback.call(thisArg, workArray[i], i, array);
+            }
+            return res;
+        } : function (array, callback, thisArg) {
+            return array.forEach(callback, thisArg);
+        },
+
+        /**
+         * Iterates over the elements of an array and applies the given callback on each of them, collecting the result of each iteration and returning the array of results.
+         *
+         * <p>
+         * The callback called at each iteration receives the following parameters: "item", "index", "array". It also has "thisArg" as the value of "this".
+         * </p>
+         *
+         * @param {Array} array The array to map
+         * @param {Function} callback The function to call at each iteration (see more information in description)
+         * @param {Any} thisArg The value of "this" for the callback
+         *
+         * @return {Array} The array of results of the callback for each iteration
+         */
+        map : (arrayPrototype.map == null) ? function (array, callback, thisArg) {
+            var result = [];
+            arrayUtils.forEach(array, function(item, index, array) {
+                result.push(callback.call(this, item, index, array));
+            }, thisArg);
+
+            return result;
+        } : function (array, callback, thisArg) {
+            return array.map(callback, thisArg);
+        },
+
+        /**
+         * Return an array with the values contained in the given map.
+         * @param {Object} map
+         * @return {Array}
+         */
+        extractValuesFromMap : function (map) {
+            var output = [];
+            for (var k in map) {
+                if (map.hasOwnProperty(k)) {
+                    output.push(map[k]);
+                }
+            }
+            return output;
+        },
+
+        /**
+         * This tests whether all elements in the array pass the predicate given by the callback function.
+         * As long as the predicate (callback) returns truthy values, the loop will continue. However, as soon as a falsy
+         * value is returned, the function will return without analyzing the rest of the elements.
+         * @param {Array} array Array to process.
+         * @param {Function} callback Function to test each element of the array. This function receives as arguments value, the index and the array.
+         * @param {Object} thisArg Object to use as this when executing callback. The default value, when thisArg is falsy, will be the given array.
+         * @return {Boolean} true if every element in the given array returns truthy values for the predicate (callback), false if at least one element returns a falsy value for the predicate (callback)
+         */
+        every : (!arrayPrototype.every) ? function(array, callback, thisArg) {
+            // clone array to prevent being impacted by possible mutations of the array in the callback
+            var workArray = arrayUtils.clone(array);
+
+            thisArg = thisArg || array;
+            var arrayLength = workArray.length;
+            for (var arrayIndex = 0; arrayIndex < arrayLength; arrayIndex++) {
+                if ( !callback.call(thisArg, workArray[arrayIndex], arrayIndex, array) ) {
+                    return false;
+                }
+            }
+            return true;
+        } : function(array, callback, thisArg) {
+            return array.every(callback, thisArg);
+        },
+
+        /**
+         * Flattens the given array on one level.
+         *
+         * @param {Array} array The array to flatten
+         *
+         * @return {Array} The flattened array
+         */
+        flatten : function (array) {
+            var result = [];
+            return result.concat.apply(result, array);
+        },
+
+        /**
+         * Deeply flattens the given array, removing any presence of array.
+         *
+         * @param {Array} value The array to flatten
+         *
+         * @return {Array} The flattened array
+         */
+        flattenDeep : function (value) {
+            if (!ariaUtilsType.isArray(value)) {
+                return [value];
+            }
+
+            var output = [];
+            arrayUtils.forEach(value, function (item) {
+                arrayUtils.pushAll(output, arrayUtils.flattenDeep(item));
+            });
+
+            return output;
+        },
+
+        /**
+         * Reduces the given array to a single value, by applying the given binary function.
+         *
+         * The binary function takes the accumulated result as first parameter, and the current array item as second parameter. It must return the new accumulated result.
+         *
+         * @param {Array} array
+         * @param {Function} callback
+         * @param {Any} initialResult
+         */
+        reduce : function (array, callback, initialResult) {
+            // ------------------------------------------- early termination
+
+            if (array.length === 0) {
+                return initialResult;
+            }
+
+            // ---------------------------------- input arguments processing
+
+            if (initialResult === undefined) {
+                initialResult = array.shift();
+            }
+
+            // -------------------------------------------------- processing
+
+            var currentResult = initialResult;
+            arrayUtils.forEach(array, function (item) {
+                currentResult = callback(currentResult, item);
+            });
+
+            // ------------------------------------------------------ return
+
+            return currentResult;
+        },
+
+        /**
+         * Pushes all given elements to the end of the array (inplace mutation).
+         *
+         * @param {Array} array The array to push elements to
+         * @param {Array} elements The elements to push to the array
+         *
+         * @return {Array} The given array
+         */
+        pushAll : function (array, elements) {
+            array.push.apply(array, elements);
+            return array;
+        },
+
+        /**
+         * Inserts the given item at the given index into the given array.
+         *
+         * <p>
+         * If the given index is negative, it will index in reverse order from the end of the array, with -1 being after the current last element. If it designates an index beyond the last element of the array, undefined values will be pushed to fill in the gap, and then the given value will be pushed.
+         * </p>
+         *
+         * @param {Array} The array to modify
+         * @param item The item to insert.
+         * @param {Number} index The index at which to insert the item.
+         *
+         * @return {Array} The modified array
+         */
+        insert : function (array, item, index) {
+            if (index == null) {
+                index = array.length;
+            }
+
+            if (index < 0) {
+                index = array.length + 1 + index;
+            }
+
+            if (index < array.length) {
+                Array.prototype.splice.call(array, index, 0, item);
+            } else {
+                ariaUtilsAlgo.times(index - array.length, function() {
+                    Array.prototype.push.call(array, undefined);
+                });
+                Array.prototype.push.call(array, item);
+            }
+
+            return array;
+        }
+    }
+});

--- a/src/aria/utils/Function.js
+++ b/src/aria/utils/Function.js
@@ -75,7 +75,17 @@ module.exports = Aria.classDefinition({
             return function () {
                 return self.$callback(cb, arguments);
             };
-        }
+        },
 
+        /**
+         * Calls the given function. This is mainly useful for functional programming.
+         *
+         * @param callback {Function} The function to call
+         *
+         * @return {Any} The return value of the callback
+         */
+        call : function (callback) {
+            return callback();
+        }
     }
 });

--- a/src/aria/utils/Object.js
+++ b/src/aria/utils/Object.js
@@ -12,9 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 var Aria = require("../Aria");
 var ariaUtilsType = require("./Type");
+var ariaUtilsArray = require("./Array");
 
+
+
+var objectUtils;
 
 /**
  * Utils for general Objects/Map
@@ -23,7 +28,33 @@ var ariaUtilsType = require("./Type");
 module.exports = Aria.classDefinition({
     $classpath : "aria.utils.Object",
     $singleton : true,
+    $constructor : function () {
+        objectUtils = this;
+    },
+    $destructor : function () {
+        objectUtils = null;
+    },
     $prototype : {
+        /**
+         * Iterates over the own keys of the given object, passing to the callback the following arguments: the current key, the current index (iteration number), the given object.
+         *
+         * @param {Object} object The object to iterate over
+         * @param {Function} callback The function to call at each iteration
+         * @param {Any} thisArg The value to use as "this" for the given callback
+         *
+         * @return {Object} The given object
+         */
+        forOwnKeys : function (object, callback, thisArg) {
+            var index = 0;
+            for (var key in object) {
+                if (object.hasOwnProperty(key)) {
+                    callback.call(thisArg, key, index, object);
+                }
+                index++;
+            }
+            return object;
+        },
+
         /**
          * Returns an array of all own enumerable properties found upon a given object, in the same order as that provided by a for-in loop.
          * @public
@@ -41,11 +72,9 @@ module.exports = Aria.classDefinition({
                 return [];
             }
             var enumKeys = [];
-            for (var key in object) {
-                if (object.hasOwnProperty(key)) {
-                    enumKeys.push(key);
-                }
-            }
+            objectUtils.forOwnKeys(object, function(key) {
+                enumKeys.push(key);
+            });
             return enumKeys;
         },
 
@@ -56,8 +85,65 @@ module.exports = Aria.classDefinition({
          * @return {Boolean}
          */
         isEmpty : function (object) {
-            var keys = this.keys(object);
+            var keys = objectUtils.keys(object);
             return keys.length === 0;
+        },
+
+        /**
+         * Iterates over all the given source objects and over all of their own keys to call the given callback with the following arguments: the given object, the current source object, the current key of the current source.
+         *
+         * @param {Object} object The target object (this is the constant in each iteration)
+         * @param {Function} callback The function to call at each iteration
+         * @param {Object} ...sources The sources to iterate over
+         *
+         * @return {Object} The given object
+         *
+         * @private
+         */
+        _sourcesToTarget : function (object, callback, sources) {
+            ariaUtilsArray.forEach(sources, function (source) {
+                objectUtils.forOwnKeys(source, function (key) {
+                    callback(object, source, key);
+                });
+            });
+
+            return object;
+        },
+
+        /**
+         * Assigns the own properties of each given source to the given destination object.
+         *
+         * @param {Object} destination The object to assign to
+         * @param {Object} ...sources The objects to take the properties from
+         *
+         * @return {Object} The given destination object
+         */
+        assign : (Object.assign != null) ? function () {
+            return Object.assign.apply(Object, arguments);
+        } : function (object) {
+            var sources = Array.prototype.slice.call(arguments, 1);
+
+            return objectUtils._sourcesToTarget(object, function (object, source, key) {
+                object[key] = source[key];
+            }, sources);
+        },
+
+        /**
+         * Applies default values to the properties of the given object. A property is considered to have no value - and thus eligible to be applied the default value - if accessing it resolves to the value "undefined".
+         *
+         * @param {Object} object The object to apply default values to
+         * @param {Object} ...sources The source objects containing the default values
+         *
+         * @return {Object} The given object
+         */
+        defaults : function (object) {
+            var sources = Array.prototype.slice.call(arguments, 1);
+
+            return objectUtils._sourcesToTarget(object, function (object, source, key) {
+                if (object[key] === undefined) {
+                    object[key] = source[key];
+                }
+            }, sources);
         }
     }
 });

--- a/src/aria/utils/String.js
+++ b/src/aria/utils/String.js
@@ -14,6 +14,7 @@
  */
 var Aria = require("../Aria");
 var ariaUtilsType = require("./Type");
+var ariaUtilsArray = require("./Array");
 
 
 /**
@@ -25,15 +26,13 @@ module.exports = Aria.classDefinition({
     $prototype : {
         /**
          * Substitute %n parameters in a string
-         * @param {String} string The source string to substitue %n occurences in
-         * @param {Array|String} params The parameters to use for the substitution. Index 0 will replace %1, index 1, %2
-         * and so on. If a string is passed, only %1 will be replaced
-         * @return {String} The final string, with %n occurences replaced with their equivalent
+         * @param {String} string The source string to substitute %n occurrences in
+         * @param {Array|String} ...params All the remaining parameters, that can form from one simple string to deeply nested arrays of strings, will be resolved to a single list of strings. These strings will be used for the substitutions. Index 0 will replace %1, index 1, %2 and so on.
+         * @return {String} The final string, with %n occurrences replaced with their equivalent
          */
-        substitute : function (string, params) {
-            if (!ariaUtilsType.isArray(params)) {
-                params = [params];
-            }
+        substitute : function (string) {
+            var params = Array.prototype.slice.call(arguments, 1);
+            params = ariaUtilsArray.flattenDeep(params);
 
             string = string.replace(/%[0-9]+/g, function (token) {
                 var replacement = params[parseInt(token.substring(1), 10) - 1];
@@ -466,6 +465,18 @@ module.exports = Aria.classDefinition({
             return str.replace(/-([a-z])/ig, function (match, letter) {
                 return letter.toUpperCase();
             });
+        },
+
+        /**
+         * Wraps the given string with the given wrapper. This concretely means that the wrapper is put before and after the given string.
+         *
+         * @param {String} The string to wrap with the given wrapper
+         * @param {String} The wrapper string
+         *
+         * @return {String} The wrapped string
+         */
+        wrap : function (string, wrapper) {
+            return wrapper + string + wrapper;
         }
     }
 });

--- a/src/aria/utils/async/Debouncer.js
+++ b/src/aria/utils/async/Debouncer.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('../../Aria');
+
+var ariaUtilsFunction = require('../Function');
+var nop = ariaUtilsFunction.empty;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////////////
+
+function assignPropertyWithDefault(destination, source, property, defaultValue) {
+    var value = source[property];
+
+    if (value == null) {
+        value = defaultValue;
+    }
+
+    destination[property] = value;
+
+    return value;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Model: Debouncer
+////////////////////////////////////////////////////////////////////////////////
+
+ module.exports = Aria.classDefinition({
+    $classpath : 'aria.utils.async.Debouncer',
+
+    $constructor : function (spec) {
+        this.delay = spec.delay;
+        this.state = spec.state;
+
+        assignPropertyWithDefault(this, spec, 'onStart', nop);
+        assignPropertyWithDefault(this, spec, 'onEnd', nop);
+
+        this._currentTimeout = null;
+    },
+    $destructor : function () {
+        this._stopWaitingForTimeout();
+    },
+
+    $prototype : {
+        run : function () {
+            var state = this.state;
+            var onStart = this.onStart;
+
+            if (!this._isWaitingForTimeout()) {
+                onStart(state);
+            }
+
+            this._stopWaitingForTimeout();
+            this._startWaitingForTimeout();
+        },
+
+        _isWaitingForTimeout : function () {
+            return this._currentTimeout != null;
+        },
+
+        _stopWaitingForTimeout : function () {
+            if (this._isWaitingForTimeout()) {
+                clearTimeout(this._currentTimeout);
+                this._currentTimeout = null;
+            }
+        },
+
+        _startWaitingForTimeout : function () {
+            this._currentTimeout = setTimeout(
+                ariaUtilsFunction.bind(this._afterTimeout, this),
+                this.delay
+            );
+        },
+
+        _afterTimeout : function () {
+            var state = this.state;
+            var onEnd = this.onEnd;
+
+            this._currentTimeout = null;
+            onEnd(state);
+        }
+    }
+});

--- a/test/aria/utils/AlgoTestCase.js
+++ b/test/aria/utils/AlgoTestCase.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+var ariaJsunitTestCase = require('ariatemplates/jsunit/TestCase');
+var ariaUtilsAlgo = require('ariatemplates/utils/Algo');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.utils.AlgoTestCase',
+    $extends : ariaJsunitTestCase,
+
+    $prototype : {
+        test_times : function () {
+            // -----------------------------------------------------------------
+
+            var times = ariaUtilsAlgo.times;
+
+            // -----------------------------------------------------------------
+
+            var self = this;
+
+            var callback = function (index) {
+                this.executed = true;
+                return index;
+            };
+
+            var test = function (count, expectedResult) {
+                var thisArg = {
+                    executed: false
+                };
+
+                var result = times(count, callback, thisArg);
+
+                if (count > 0) {
+                    self.assertTrue(thisArg.executed, 'Function was not executed with the proper "this" value.');
+                }
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // -----------------------------------------------------------------
+
+            test(-1, []);
+            test(0, []);
+            test(1, [0]);
+            test(5, [0, 1, 2, 3, 4]);
+        }
+    }
+});

--- a/test/aria/utils/ArrayTestCase.js
+++ b/test/aria/utils/ArrayTestCase.js
@@ -13,21 +13,50 @@
  * limitations under the License.
  */
 
+var Aria = require('ariatemplates/Aria');
+var TestCase = require('ariatemplates/jsunit/TestCase');
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+
+
 /**
- * Test case for aria.widgets.form.Input
+ * Test case for aria.utils.Array
  */
-Aria.classDefinition({
+module.exports = Aria.classDefinition({
     $classpath : "test.aria.utils.ArrayTestCase",
-    $extends : "aria.jsunit.TestCase",
-    $dependencies : ["aria.utils.Array"],
+    $extends : TestCase,
     $prototype : {
+        testEnsureWrap : function () {
+            // common ----------------------------------------------------------
+
+            var ensureWrap = ariaUtilsArray.ensureWrap;
+
+            var self = this;
+
+            var test = function(input, expectedResult) {
+                var result = ensureWrap(input);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test(null, []);
+            test(undefined, []);
+
+            test(1, [1]);
+            test('1', ['1']);
+
+            test([], []);
+            test(['1'], ['1']);
+        },
 
         /**
          * Test case on the aria.utils.Array.indexOf method
          */
         testIndexOf : function () {
             // Shortcut on indexOf
-            var arrayIndexOf = aria.utils.Array.indexOf;
+            var arrayIndexOf = ariaUtilsArray.indexOf;
 
             var obj = {
                 a : "a"
@@ -45,7 +74,7 @@ Aria.classDefinition({
          */
         testContains : function () {
             // Shortcut on contains
-            var arrayContains = aria.utils.Array.contains;
+            var arrayContains = ariaUtilsArray.contains;
 
             var obj = {
                 a : "a"
@@ -60,7 +89,7 @@ Aria.classDefinition({
 
         testIsEmpty : function () {
             // Shortcut on isEmpty
-            var arrayIsEmpty = aria.utils.Array.isEmpty;
+            var arrayIsEmpty = ariaUtilsArray.isEmpty;
 
             var emptyArray = [];
             var filledArray = [0];
@@ -76,13 +105,13 @@ Aria.classDefinition({
          */
         testRemoveAt : function () {
             // Shortcut on indexOf
-            var arrayIndexOf = aria.utils.Array.indexOf;
+            var arrayIndexOf = ariaUtilsArray.indexOf;
             // Shortcut on contains
-            var arrayContains = aria.utils.Array.contains;
+            var arrayContains = ariaUtilsArray.contains;
             // Shortcut on remove
-            var arrayRemoveAt = aria.utils.Array.removeAt;
+            var arrayRemoveAt = ariaUtilsArray.removeAt;
             // Shortcut on isEmpty
-            var arrayIsEmpty = aria.utils.Array.isEmpty;
+            var arrayIsEmpty = ariaUtilsArray.isEmpty;
 
             var obj = {
                 a : "a"
@@ -129,13 +158,13 @@ Aria.classDefinition({
          */
         testRemove : function () {
             // Shortcut on indexOf
-            var arrayIndexOf = aria.utils.Array.indexOf;
+            var arrayIndexOf = ariaUtilsArray.indexOf;
             // Shortcut on contains
-            var arrayContains = aria.utils.Array.contains;
+            var arrayContains = ariaUtilsArray.contains;
             // Shortcut on remove
-            var arrayRemove = aria.utils.Array.remove;
+            var arrayRemove = ariaUtilsArray.remove;
             // Shortcut on isEmpty
-            var arrayIsEmpty = aria.utils.Array.isEmpty;
+            var arrayIsEmpty = ariaUtilsArray.isEmpty;
 
             var obj = {
                 a : "a"
@@ -173,13 +202,13 @@ Aria.classDefinition({
          */
         testClone : function () {
             // Shortcut on indexOf
-            var arrayIndexOf = aria.utils.Array.indexOf;
+            var arrayIndexOf = ariaUtilsArray.indexOf;
             // Shortcut on contains
-            var arrayContains = aria.utils.Array.contains;
+            var arrayContains = ariaUtilsArray.contains;
             // Shortcut on remove
-            var arrayRemove = aria.utils.Array.remove;
+            var arrayRemove = ariaUtilsArray.remove;
             // Shortcut on clone
-            var arrayClone = aria.utils.Array.clone;
+            var arrayClone = ariaUtilsArray.clone;
 
             var obj = {
                 a : "a"
@@ -201,9 +230,57 @@ Aria.classDefinition({
             this.assertTrue(arrayContains(clonedArray, 0), "clonedArray has been changed by a modification on the original array");
         },
 
+        testRepeatValue : function () {
+            // common ----------------------------------------------------------
+
+            var repeatValue = ariaUtilsArray.repeatValue;
+
+            var self = this;
+
+            var test = function(input, times, expectedResult) {
+                var result = repeatValue(input, times);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test(1, -1, []);
+            test(1, 0, []);
+            test(1, 1, [1]);
+            test(1, 3, [1, 1, 1]);
+            test([1, 2], 2, [[1, 2], [1, 2]]);
+        },
+
+        testRepeatArray : function () {
+            // common ----------------------------------------------------------
+
+            var repeatArray = ariaUtilsArray.repeatArray;
+
+            var self = this;
+
+            var test = function(input, times, expectedResult) {
+                var result = repeatArray(input, times);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test(1, -1, []);
+            test(1, 0, []);
+            test(1, 1, [1]);
+
+            test([1], 1, [1]);
+            test([1], 3, [1, 1, 1]);
+
+            test([1, 2], 2, [1, 2, 1, 2]);
+            test([[1, 2]], 2, [[1, 2], [1, 2]]);
+        },
+
         testFilter : function () {
             // shortcut
-            var filter = aria.utils.Array.filter;
+            var filter = ariaUtilsArray.filter;
 
             // doing nothing returns empty array
             this.assertTrue(filter([], function () {}) !== null);
@@ -220,7 +297,7 @@ Aria.classDefinition({
 
         testForEach : function () {
             // shortcut
-            var forEach = aria.utils.Array.forEach;
+            var forEach = ariaUtilsArray.forEach;
 
             // doing stuff on empty array should do nothing
             var count = 0;
@@ -241,7 +318,7 @@ Aria.classDefinition({
 
         testEvery : function () {
             // shortcut
-            var every = aria.utils.Array.every;
+            var every = ariaUtilsArray.every;
 
             // doing stuff on empty array should do nothing
             var count = 0;
@@ -270,6 +347,161 @@ Aria.classDefinition({
                 return true;
             }, this));
             this.assertTrue(result === "123459");
+        },
+
+        testMap : function () {
+            // common ----------------------------------------------------------
+
+            var map = ariaUtilsArray.map;
+
+            var self = this;
+
+            var callback = function (item) {
+                return item * 2;
+            };
+            var test = function(input, expectedResult) {
+                var result = map(input, callback);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test([], []);
+            test([1], [2]);
+            test([1, 2, 3, 4], [2, 4, 6, 8]);
+        },
+
+        testFlatten : function () {
+            // common ----------------------------------------------------------
+
+            var flatten = ariaUtilsArray.flatten;
+
+            var self = this;
+
+            var test = function(input, expectedResult) {
+                var result = flatten(input);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test([], []);
+            test([1], [1]);
+            test([1, 2], [1, 2]);
+
+            test([1, [2], 3], [1, 2, 3]);
+            test([1, [[2]], 3], [1, [2], 3]);
+        },
+
+        testFlattenDeep : function () {
+            // common ----------------------------------------------------------
+
+            var flattenDeep = ariaUtilsArray.flattenDeep;
+
+            var self = this;
+
+            var test = function(input, expectedResult) {
+                var result = flattenDeep(input);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test(1, [1]);
+
+            test([], []);
+            test([1], [1]);
+            test([1, 2], [1, 2]);
+
+            test([1, [2], 3], [1, 2, 3]);
+            test([1, [[2]], 3], [1, 2, 3]);
+        },
+
+        testReduce : function () {
+            // common ----------------------------------------------------------
+
+            var reduce = ariaUtilsArray.reduce;
+
+            var self = this;
+
+            var callback = function (a, b) {
+                return a + b;
+            };
+            var test = function(array, initialResult, expectedResult) {
+                var result = reduce(array, callback, initialResult);
+
+                self.assertJsonEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test([], undefined, undefined);
+            test([], null, null);
+            test([], 1, 1);
+
+            test([1], undefined, 1);
+            test([1], 2, 3);
+
+            test([1, 2], undefined, 3);
+            test([1, 2], 3, 6);
+        },
+
+        testPushAll : function () {
+            // common ----------------------------------------------------------
+
+            var pushAll = ariaUtilsArray.pushAll;
+
+            var self = this;
+
+            var test = function(array, addition, expectedResult) {
+                var result = pushAll(array, addition);
+
+                self.assertTrue(result === array, 'The original array instance should be returned');
+
+                self.assertJsonEquals(array, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test([], [], []);
+
+            test([], [1], [1]);
+            test([1], [], [1]);
+
+            test([], [1, 2], [1, 2]);
+            test([1, 2], [], [1, 2]);
+
+            test([1], [2, 3], [1, 2, 3]);
+            test([1, 2], [3], [1, 2, 3]);
+        },
+
+        testInsert : function () {
+            // common ----------------------------------------------------------
+
+            var insert = ariaUtilsArray.insert;
+
+            var self = this;
+
+            var test = function(array, item, index, expectedResult) {
+                var result = insert(array, item, index);
+
+                self.assertTrue(result === array, 'The original array instance should be returned');
+
+                self.assertJsonEquals(array, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test([1, 2], 0, 0, [0, 1, 2]);
+            test([0, 2], 1, 1, [0, 1, 2]);
+            test([0, 1], 2, 2, [0, 1, 2]);
+
+            test([0, 1], 2, -1, [0, 1, 2]);
+
+            test([0, 1], 3, 3, [0, 1, undefined, 3]);
         }
     }
 });

--- a/test/aria/utils/FunctionTestCase.js
+++ b/test/aria/utils/FunctionTestCase.js
@@ -13,13 +13,16 @@
  * limitations under the License.
  */
 
+var Aria = require('ariatemplates/Aria');
+var TestCase = require('ariatemplates/jsunit/TestCase');
+var ariaUtilsFunction = require('ariatemplates/utils/Function');
+
 /**
  * Test case for aria.utils.Function
  */
-Aria.classDefinition({
+module.exports = Aria.classDefinition({
     $classpath : "test.aria.utils.FunctionTestCase",
-    $extends : "aria.jsunit.TestCase",
-    $dependencies : ["aria.utils.Function"],
+    $extends : TestCase,
     $prototype : {
 
         /**
@@ -47,13 +50,35 @@ Aria.classDefinition({
             };
 
             // creates the binded function
-            var binded = aria.utils.Function.bind(myFunction, scope, 1, 2);
+            var binded = ariaUtilsFunction.bind(myFunction, scope, 1, 2);
 
             // call it several time to be sure parameters are still ok
             binded(3, 4);
             binded(3, 4);
 
             this.assertTrue(executed);
+        },
+
+        test_call : function () {
+            // -----------------------------------------------------------------
+
+            var call = ariaUtilsFunction.call;
+
+            var expectedResult = {};
+            var expectedSideEffect = {};
+
+            var sideEffect = null;
+            var callback = function () {
+                sideEffect = expectedSideEffect;
+                return expectedResult;
+            };
+
+            // -----------------------------------------------------------------
+
+            var result = call(callback);
+
+            this.assertTrue(sideEffect === expectedSideEffect, 'The function was not properly called');
+            this.assertTrue(result === expectedResult, "The function's return value was not properly returned");
         }
     }
 });

--- a/test/aria/utils/StringTestCase.js
+++ b/test/aria/utils/StringTestCase.js
@@ -14,20 +14,27 @@
  * limitations under the License.
  */
 
+var Aria = require('ariatemplates/Aria');
+var TestCase = require('ariatemplates/jsunit/TestCase');
+var ariaUtilsString = require('ariatemplates/utils/String');
+
+var ariaUtilsJson = require('ariatemplates/utils/Json');
+
+
+
 /**
  * Test case for aria.utils.String
  */
-Aria.classDefinition({
+module.exports = Aria.classDefinition({
     $classpath : "test.aria.utils.StringTestCase",
-    $dependencies : ["aria.utils.String", "aria.utils.Json"],
-    $extends : "aria.jsunit.TestCase",
+    $extends : TestCase,
     $prototype : {
 
         /**
          * Test trim method
          */
         testTrim : function () {
-            var trimResult = aria.utils.String.trim("   \tthis is a test   \n");
+            var trimResult = ariaUtilsString.trim("   \tthis is a test   \n");
             this.assertTrue(trimResult === "this is a test", "Expected 'this is a test', Found '" + trimResult + "'");
         },
 
@@ -35,15 +42,15 @@ Aria.classDefinition({
          * Test trim method with null argument
          */
         testNullTrim : function () {
-            var trimResult = aria.utils.String.trim(null);
+            var trimResult = ariaUtilsString.trim(null);
             this.assertTrue(trimResult === null);
         },
-        
+
         /**
          * Test case for the isEscaped method
          */
         testIsEscaped : function () {
-            var pkg = aria.utils.String;
+            var pkg = ariaUtilsString;
             this.assertFalse(pkg.isEscaped("{", 0));
             this.assertTrue(pkg.isEscaped("\\{", 1));
             this.assertFalse(pkg.isEscaped("\\\\{", 2));
@@ -59,24 +66,24 @@ Aria.classDefinition({
          */
         testIndexOfNotEscaped : function () {
             var test = "abc \\\d \d de\fg";
-            this.assertTrue(aria.utils.String.indexOfNotEscaped(test, "a") === 0);
-            this.assertTrue(aria.utils.String.indexOfNotEscaped(test, "\\") === 4);
-            this.assertTrue(aria.utils.String.indexOfNotEscaped(test, "d") === 7);
-            this.assertTrue(aria.utils.String.indexOfNotEscaped(test, "f") === -1);
-            this.assertTrue(aria.utils.String.indexOfNotEscaped(test, "h") === -1);
+            this.assertTrue(ariaUtilsString.indexOfNotEscaped(test, "a") === 0);
+            this.assertTrue(ariaUtilsString.indexOfNotEscaped(test, "\\") === 4);
+            this.assertTrue(ariaUtilsString.indexOfNotEscaped(test, "d") === 7);
+            this.assertTrue(ariaUtilsString.indexOfNotEscaped(test, "f") === -1);
+            this.assertTrue(ariaUtilsString.indexOfNotEscaped(test, "h") === -1);
         },
 
         /**
          * Test escapeHTML method
          */
         testEscapeHTML : function () {
-            this.assertTrue(aria.utils.String.escapeHTML("<div> a & b </div>", "a") === "&lt;div&gt; a &amp; b &lt;/div&gt;", "Escape failed.");
+            this.assertTrue(ariaUtilsString.escapeHTML("<div> a & b </div>", "a") === "&lt;div&gt; a &amp; b &lt;/div&gt;", "Escape failed.");
         },
 
         testEscapeHTMLAttr : function () {
-            this.assertTrue(aria.utils.String.escapeHTMLAttr("'") === "&#x27;", "Attribute escape failed.");
-            this.assertTrue(aria.utils.String.escapeHTMLAttr('"') === "&quot;", "Attribute escape failed.");
-            this.assertTrue(aria.utils.String.escapeHTMLAttr("'\"") === "&#x27;&quot;", "Attribute escape failed.");
+            this.assertTrue(ariaUtilsString.escapeHTMLAttr("'") === "&#x27;", "Attribute escape failed.");
+            this.assertTrue(ariaUtilsString.escapeHTMLAttr('"') === "&quot;", "Attribute escape failed.");
+            this.assertTrue(ariaUtilsString.escapeHTMLAttr("'\"") === "&#x27;&quot;", "Attribute escape failed.");
         },
 
         testEscapeForHTML : function () {
@@ -85,27 +92,27 @@ Aria.classDefinition({
             var escapedForHTMLString = "&lt;div id='id' class=\"class\"&gt;&#x2F;&lt;&#x2F;div&gt;";
             var escapedForAllString = "&lt;div id=&#x27;id&#x27; class=&quot;class&quot;&gt;&#x2F;&lt;&#x2F;div&gt;";
 
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString) === escapedForAllString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, null) === escapedForAllString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, 5) === escapedForAllString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, '5') === escapedForAllString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, true) === escapedForAllString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, {
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString) === escapedForAllString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, null) === escapedForAllString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, 5) === escapedForAllString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, '5') === escapedForAllString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, true) === escapedForAllString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, {
                 text : true,
                 attr : true
             }) === escapedForAllString, "Full HTML escape failed.");
 
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, false) === originalString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, {
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, false) === originalString, "Full HTML escape failed.");
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, {
                 text : false,
                 attr : false
             }) === originalString, "Full HTML escape failed.");
 
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, {
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, {
                 text : false,
                 attr : true
             }) === escapedForAttrString, "Full HTML escape failed.");
-            this.assertTrue(aria.utils.String.escapeForHTML(originalString, {
+            this.assertTrue(ariaUtilsString.escapeForHTML(originalString, {
                 text : true,
                 attr : false
             }) === escapedForHTMLString, "Full HTML escape failed.");
@@ -115,7 +122,7 @@ Aria.classDefinition({
          * Test stripAccents method
          */
         testStripAccents : function () {
-            this.assertTrue(aria.utils.String.stripAccents("àébïuô") === "aebiuo", "Strip Accents failed failed.");
+            this.assertTrue(ariaUtilsString.stripAccents("àébïuô") === "aebiuo", "Strip Accents failed failed.");
         },
 
         /**
@@ -123,49 +130,49 @@ Aria.classDefinition({
          */
         testNextWhiteSpace : function () {
             var test = " abc def\tghi";
-            this.assertTrue(aria.utils.String.nextWhiteSpace(test, 0, 5) === 0);
-            this.assertTrue(aria.utils.String.nextWhiteSpace(test, 1, 5) === 4);
-            this.assertTrue(aria.utils.String.nextWhiteSpace(test, 5, 9) === 8);
-            this.assertTrue(aria.utils.String.nextWhiteSpace(test, 1, 3) === -1);
-            this.assertTrue(aria.utils.String.nextWhiteSpace('', 2, 5) === -1);
+            this.assertTrue(ariaUtilsString.nextWhiteSpace(test, 0, 5) === 0);
+            this.assertTrue(ariaUtilsString.nextWhiteSpace(test, 1, 5) === 4);
+            this.assertTrue(ariaUtilsString.nextWhiteSpace(test, 5, 9) === 8);
+            this.assertTrue(ariaUtilsString.nextWhiteSpace(test, 1, 3) === -1);
+            this.assertTrue(ariaUtilsString.nextWhiteSpace('', 2, 5) === -1);
         },
 
         /**
          * Test encodeForQuotedHTMLAttribute method
          */
         testEncodeForQuotedHTMLAttribute : function () {
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute(undefined), "");
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute(""), "");
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute("abc"), "abc");
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('"'), '&quot;');
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('"abc'), '&quot;abc');
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('a"b'), 'a&quot;b');
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('a"b"c"d'), 'a&quot;b&quot;c&quot;d');
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('"""'), '&quot;&quot;&quot;');
-            this.assertEquals(aria.utils.String.encodeForQuotedHTMLAttribute('&quot;'), '&quot;');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute(undefined), "");
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute(""), "");
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute("abc"), "abc");
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('"'), '&quot;');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('"abc'), '&quot;abc');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('a"b'), 'a&quot;b');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('a"b"c"d'), 'a&quot;b&quot;c&quot;d');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('"""'), '&quot;&quot;&quot;');
+            this.assertEquals(ariaUtilsString.encodeForQuotedHTMLAttribute('&quot;'), '&quot;');
         },
 
         /**
          * Test endsWith method
          */
         testEndsWith : function () {
-            this.assertTrue(aria.utils.String.endsWith("", ""));
-            this.assertFalse(aria.utils.String.endsWith("", "a"));
-            this.assertTrue(aria.utils.String.endsWith("a", "a"));
-            this.assertFalse(aria.utils.String.endsWith("ab", "a"));
-            this.assertTrue(aria.utils.String.endsWith("aba", "a"));
-            this.assertFalse(aria.utils.String.endsWith("aba", "b"));
-            this.assertTrue(aria.utils.String.endsWith("abc", ""));
-            this.assertTrue(aria.utils.String.endsWith("abc", "bc"));
-            this.assertTrue(aria.utils.String.endsWith("a b", " b"));
-            this.assertFalse(aria.utils.String.endsWith("a b", "a"));
+            this.assertTrue(ariaUtilsString.endsWith("", ""));
+            this.assertFalse(ariaUtilsString.endsWith("", "a"));
+            this.assertTrue(ariaUtilsString.endsWith("a", "a"));
+            this.assertFalse(ariaUtilsString.endsWith("ab", "a"));
+            this.assertTrue(ariaUtilsString.endsWith("aba", "a"));
+            this.assertFalse(ariaUtilsString.endsWith("aba", "b"));
+            this.assertTrue(ariaUtilsString.endsWith("abc", ""));
+            this.assertTrue(ariaUtilsString.endsWith("abc", "bc"));
+            this.assertTrue(ariaUtilsString.endsWith("a b", " b"));
+            this.assertFalse(ariaUtilsString.endsWith("a b", "a"));
         },
 
         /**
          * Test capitalize method
          */
         testCapitalize : function () {
-            var result = aria.utils.String.capitalize("this is a test");
+            var result = ariaUtilsString.capitalize("this is a test");
             this.assertTrue(result === "This is a test", "Expected 'This is a test', Found '" + result + "'");
         },
 
@@ -203,7 +210,7 @@ Aria.classDefinition({
                     for (size in toTest[initial]) {
                         if (toTest[initial].hasOwnProperty(size)) {
                             expected = toTest[initial][size];
-                            got = aria.utils.String.pad(initial, size, "a", true);
+                            got = ariaUtilsString.pad(initial, size, "a", true);
 
                             this.assertEquals(got, expected, "Padding " + initial + " size " + size
                                     + " got %1 expected %2");
@@ -239,7 +246,7 @@ Aria.classDefinition({
                     for (size in toTest[initial]) {
                         if (toTest[initial].hasOwnProperty(size)) {
                             expected = toTest[initial][size];
-                            got = aria.utils.String.pad(initial, size, "a", false);
+                            got = ariaUtilsString.pad(initial, size, "a", false);
 
                             this.assertEquals(got, expected, "Padding " + initial + " size " + size
                                     + " got %1 expected %2");
@@ -298,7 +305,7 @@ Aria.classDefinition({
                     for (var size in toTest[initial]) {
                         if (toTest[initial].hasOwnProperty(size)) {
                             var expected = toTest[initial][size];
-                            var got = aria.utils.String.crop(initial, size, "a", true);
+                            var got = ariaUtilsString.crop(initial, size, "a", true);
 
                             this.assertEquals(got, expected, "Cropping " + initial + " size " + size
                                     + " got %1 expected %2");
@@ -358,7 +365,7 @@ Aria.classDefinition({
                     for (var size in toTest[initial]) {
                         if (toTest[initial].hasOwnProperty(size)) {
                             var expected = toTest[initial][size];
-                            var got = aria.utils.String.crop(initial, size, "a", false);
+                            var got = ariaUtilsString.crop(initial, size, "a", false);
 
                             this.assertEquals(got, expected, "Cropping " + initial + " size " + size
                                     + " got %1 expected %2");
@@ -390,7 +397,7 @@ Aria.classDefinition({
                         var size = fromBegin[testing][i][0];
                         var expected = aria.utils.Json.convertToJsonString(fromBegin[testing][i][1]);
 
-                        var got = aria.utils.Json.convertToJsonString(aria.utils.String.chunk(testing, size, true));
+                        var got = aria.utils.Json.convertToJsonString(ariaUtilsString.chunk(testing, size, true));
 
                         this.assertEquals(expected, got, "Testing -" + testing + "- size " + size
                                 + " expected %1 got %2");
@@ -420,7 +427,7 @@ Aria.classDefinition({
                         var size = fromEnd[testing][i][0];
                         var expected = aria.utils.Json.convertToJsonString(fromEnd[testing][i][1]);
 
-                        var got = aria.utils.Json.convertToJsonString(aria.utils.String.chunk(testing, size, false));
+                        var got = aria.utils.Json.convertToJsonString(ariaUtilsString.chunk(testing, size, false));
 
                         this.assertEquals(expected, got, "Testing -" + testing + "- size " + size
                                 + " expected %1 got %2");
@@ -433,15 +440,15 @@ Aria.classDefinition({
          * Call chunk with the wrong parameters
          */
         testWrongChunk : function () {
-            var got = aria.utils.String.chunk(12, 2);
+            var got = ariaUtilsString.chunk(12, 2);
             this.assertEquals(got, null, "Cannot chunk numbers");
 
-            got = aria.utils.String.chunk(null, 3);
+            got = ariaUtilsString.chunk(null, 3);
             this.assertEquals(got, null, "Cannot chunk null");
         },
 
         /**
-         * Substitue a string using a string
+         * Substitute a string using a string
          */
         testSubstituteString : function () {
             var holders = {
@@ -456,7 +463,7 @@ Aria.classDefinition({
             var epxected = [];
             for (var key in holders) {
                 if (holders.hasOwnProperty(key)) {
-                    got = aria.utils.String.substitute(holders[key], "thisString");
+                    got = ariaUtilsString.substitute(holders[key], "thisString");
 
                     this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
@@ -479,7 +486,7 @@ Aria.classDefinition({
             var epxected = [];
             for (var key in holders) {
                 if (holders.hasOwnProperty(key)) {
-                    got = aria.utils.String.substitute(holders[key], ["thisString", "another"]);
+                    got = ariaUtilsString.substitute(holders[key], ["thisString", "another"]);
 
                     this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
@@ -501,15 +508,36 @@ Aria.classDefinition({
             var epxected = [];
             for (var key in holders) {
                 if (holders.hasOwnProperty(key)) {
-                    got = aria.utils.String.substitute(holders[key], ["one", "two"]);
+                    got = ariaUtilsString.substitute(holders[key], ["one", "two"]);
 
                     this.assertEquals(got, holders[key], "Expecting %2, got %1");
                 }
             }
         },
 
+        testSubstituteVarArgs : function () {
+            // common ----------------------------------------------------------
+
+            var substitute = ariaUtilsString.substitute;
+
+            var self = this;
+
+            var test = function(string, args, expectedResult) {
+                var result = substitute.apply(null, [string].concat(args));
+
+                self.assertEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test('%1%2%3%4', [[1, 2, 3, 4]], '1234');
+            test('%1%2%3%4', [[1, 2], [3, 4]], '1234');
+            test('%1%2%3%4', [1, [2], 3, [4]], '1234');
+            test('%1%2%3%4', [1, [2, [3], 4]], '1234');
+        },
+
         testCamelToDashed : function () {
-            var cc2d = aria.utils.String.camelToDashed;
+            var cc2d = ariaUtilsString.camelToDashed;
 
             // standard
             this.assertEquals(cc2d("fooBarBaz"), "foo-bar-baz");
@@ -524,12 +552,37 @@ Aria.classDefinition({
         },
 
         testDashedToCamel : function () {
-            var d2cc = aria.utils.String.dashedToCamel;
+            var d2cc = ariaUtilsString.dashedToCamel;
 
             this.assertEquals(d2cc("foo-bar-baz"), "fooBarBaz");
             this.assertEquals(d2cc("foo-bar-baz-n"), "fooBarBazN");
             this.assertEquals(d2cc("foo-a-bar-a-c-baz"), "fooABarACBaz");
             this.assertEquals(d2cc("a-b-c"), "aBC");
+        },
+
+        testWrap : function () {
+            // common ----------------------------------------------------------
+
+            var wrap = ariaUtilsString.wrap;
+
+            var self = this;
+
+            var test = function(string, wrapper, expectedResult) {
+                var result = wrap(string, wrapper);
+
+                self.assertEquals(result, expectedResult);
+            };
+
+            // tests -----------------------------------------------------------
+
+            test('', '', '');
+
+            test('base', '', 'base');
+            test('', '|', '||');
+
+            test('base', '|', '|base|');
+
+            test('base', 0, '0base0');
         }
     }
 });

--- a/test/aria/utils/async/DebouncerTestCase.js
+++ b/test/aria/utils/async/DebouncerTestCase.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+var ariaJsunitTestCase = require('ariatemplates/jsunit/TestCase');
+var Debouncer = require('ariatemplates/utils/async/Debouncer');
+
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+var ariaUtilsFunction = require('ariatemplates/utils/Function');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.utils.async.DebouncerTestCase',
+    $extends : ariaJsunitTestCase,
+
+    $prototype : {
+        _createDebounced : function (state) {
+            var self = this;
+
+            var debounced = new Debouncer({
+                state: state,
+                delay: state.delay,
+                onStart: function (receivedState) {
+                    self.assertTrue(receivedState === state, 'The state is not properly given to the callback');
+
+                    self.assertTrue(state.beforeFirstCall, 'onStart should be called synchronously after the first run');
+                    self.assertFalse(state.afterFirstCall, 'onStart should be called synchronously after the first run');
+
+                    self.assertFalse(state.onStartCalled, 'onStart should be called once, at the very beginning');
+
+                    state.onStartCalled = true;
+                },
+                onEnd: function (receivedState) {
+                    self.assertTrue(receivedState === state, 'The state is not properly given to the callback');
+
+                    self.assertTrue(state.beforeLastCall, 'onEnd should be called asynchronously after the last run');
+                    self.assertTrue(state.afterLastCall, 'onEnd should be called asynchronously after the last run');
+
+                    self.assertFalse(state.onEndCalled, 'onEnd should be called once, at the very end');
+
+                    state.onEndCalled = true;
+
+                    state.next();
+                }
+            });
+
+            return debounced;
+        },
+
+        _testDebouncedCall : function (next, debounced) {
+            // --------------------------------------------------- destructuring
+
+            var state = debounced.state;
+            var delay = state.delay;
+
+            // ------------------------------------------------------ processing
+
+            var self = this;
+
+            var queue = [
+                function (next, state) {
+                    state.beforeFirstCall = false;
+                    state.onStartCalled = false;
+                    state.afterFirstCall = false;
+
+                    state.beforeLastCall = false;
+                    state.onEndCalled = false;
+                    state.afterLastCall = false;
+
+                    next();
+                },
+
+                function(next, state) {
+                    state.beforeFirstCall = true;
+                    debounced.run();
+                    state.afterFirstCall = true;
+
+                    self.assertTrue(state.onStartCalled, 'onStart should be called synchronously after the first call');
+
+                    next();
+                },
+                function(next) {
+                    setTimeout(next, delay / 2);
+                },
+                function(next, state) {
+                    state.beforeLastCall = true;
+                    debounced.run();
+                    state.afterLastCall = true;
+
+                    self.assertFalse(state.onEndCalled, 'onEnd should be called asynchronously after the last run');
+
+                    next();
+                }
+            ];
+
+            state.next = next;
+            this._executeQueue(queue, state);
+        },
+
+        testAsync : function () {
+            // ------------------------------------------------------ processing
+
+            var self = this;
+
+            // -----------------------------------------------------------------
+
+            var state = {};
+            var delay = 100;
+            state.delay = delay;
+            var debounced = this._createDebounced(state);
+
+            // -----------------------------------------------------------------
+
+            // calling twice in a row must work (internal state properly updated)
+            this._testDebouncedCall(function () {
+                self._testDebouncedCall(function () {
+                    debounced.$dispose();
+                    self.end();
+                }, debounced);
+            }, debounced);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        _executeQueue : function(queue, state) {
+            queue = ariaUtilsArray.clone(queue);
+
+            var fn = queue.shift();
+            if (fn != null) {
+                fn(ariaUtilsFunction.bind(this._executeQueue, this, queue, state), state);
+            }
+        }
+    }
+});

--- a/test/nodeTestResources/testProject/build/config/files-bootstrap.json
+++ b/test/nodeTestResources/testProject/build/config/files-bootstrap.json
@@ -1,6 +1,7 @@
 [
     "aria/Aria.js",
     "aria/core/JsObject.js",
+    "aria/utils/Algo.js",
     "aria/utils/Type.js",
     "aria/utils/String.js",
     "aria/core/log/DefaultAppender.js",
@@ -10,6 +11,8 @@
     "aria/utils/json/JsonSerializer.js",
     "aria/utils/Json.js",
     "aria/utils/Object.js",
+    "aria/core/useragent/ua-parser.js",
+    "aria/core/useragent/UserAgent.js",
     "aria/core/Browser.js",
     "aria/dom/DomReady.js",
     "aria/core/Cache.js",

--- a/test/nodeTestResources/testProject/build/config/files-prod.json
+++ b/test/nodeTestResources/testProject/build/config/files-prod.json
@@ -6,6 +6,7 @@
             "aria/core/log/*",
             "!aria/core/log/DefaultAppender.js",
             "aria/utils/**/*",
+            "!aria/utils/Algo.js",
             "!aria/utils/Array.js",
             "!aria/utils/Json.js",
             "!aria/utils/Object.js",


### PR DESCRIPTION
- `aria.jsunit.TestCase`
	- aliased `notifyTestEnd` as `end`
- `aria.utils.Algo`
	- `times`: executes the given callbacks the specified number of times, returned the aggregated result
- aria.utils.String
	- `substitute` (changed): now accepts a variable number of arguments for substitutions, with any mix of string and arrays
	- `wrap`: wraps (prefix and suffix) the given string with another given string
- `aria.utils.Array`
	- `ensureWrap`: ensures to return an array from the given value: empty one as default, array with the one given element or the already given array
	- `repeatValue`: repeats the given value the given number of times to make an array
	- `repeatArray`: repeats the values of the given array the given number of times, to make an array of the same level of nesting (`repeatValue` only would gives an array of arrays)
	- `map`: applies a transformation function on each item of the given array and returns the array of results
	- `reduce`: applies a reducer function on each item of the array, in order to aggregate a result
	- `flatten`: flattens the given array on one level
	- `flattenDeep`: deeply flattens the given array, to have only one single top-level array
	- `pushAll`: concatenates inplace the given array into the given destination array
	- `insert`: inserts inplace the given item at the given index into the given array. Indexing is flexible: can make the array grow, can be indexed with negative numbers
- `aria.utils.Object`
	- `forOwnKeys`: iterates over the own keys of an object and calls the given callback function with each of them
	- `assign`: assign all own properties of given sources into the given destination object
	- `defaults`: assign all own properties of given sources into the given destination object only if they don't already exist (are not `null` or `undefined`) inside the resulting destination object
- `aria.utils.Function`
	- `call`: calls as is (without specific thisArg nor arguments) the given function (useful for simple functional programming)
- `aria.utils.async.Debouncer`: delays the execution of a function as long as it (its wrapper actually) is called