### PR TITLE
Updating ua-parser-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "jade": "1.1.5",
     "mocha": "2.3.3",
     "robot-server": "0.0.4",
-    "ua-parser-js": "git+https://github.com/ariatemplates/ua-parser-js#latest"
+    "ua-parser-js": "0.7.10"
   }
 }


### PR DESCRIPTION
It is no longer useful to rely on our fork of ua-parser-js, now that our changes have been integrated:
 - https://github.com/faisalman/ua-parser-js/pull/122
 - https://github.com/faisalman/ua-parser-js/pull/139