### PR TITLE
Reducing the number of phantomjs instances on travis

### DIFF
--- a/test/ciLauncher.yml
+++ b/test/ciLauncher.yml
@@ -6,7 +6,7 @@ launchers:
 browsers:
     PhantomJS:
         $launcher: $phantomjs
-        $maxInstances: 6
+        $maxInstances: 4
     Firefox:
         $launcher: localWebdriver
         capabilities:


### PR DESCRIPTION
This increases the stability of the travis build.