### PR TITLE
Disabling ViewportHugeShrinkTestCase

### DIFF
--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -15,7 +15,13 @@
 
 var disabledTestCasesPatterns = [
     // The following test fails, it needs to be fixed or removed:
-    "test/aria/pageEngine/siteRootModule/ModelBindingTestCase.js"
+    "test/aria/pageEngine/siteRootModule/ModelBindingTestCase.js",
+
+    // The following test fails in all browsers except PhantomJS...
+    // ... but PhantomJS is known not to correctly handle the viewport size,
+    // ... and this test seems to be linked to exactly that!
+    // The test needs to be fixed or removed.
+    "test/aria/widgets/container/dialog/viewportResize/ViewportHugeShrinkTestCase.js"
 ];
 
 var unpackagedOnlyPatterns = [


### PR DESCRIPTION
`test.aria.widgets.container.dialog.viewportResize.ViewportHugeShrinkTestCase` was present in the repository without being part of a test suite, and has not been run during the release test campaign for a long time. It fails in all browsers except PhantomJS, but PhantomJS is known not to properly handle the size of the viewport (and this test is related to it).

More investigation should be done on this test to either fix it or remove it.