### PR TITLE
aria.utils.Json.diff and update to the Assert.assertJsonEquals method

### DIFF
--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -434,16 +434,19 @@ var ariaUtilsJson = require("../utils/Json");
              * @param {String} optMsg optional message to add to the failure description
              */
             assertJsonEquals : function (obj1, obj2, optMsg) {
-                if (!optMsg) {
+                var diff1 = ariaUtilsJson.diff(obj1, obj2);
+                var diff2 = ariaUtilsJson.diff(obj2, obj1);
+                var equal = (diff1 === null && diff2 === null);
+                if (!equal && !optMsg) {
                     var jsonOptions = {
                         indent : "   "
                     };
-                    var s1 = ariaUtilsJson.convertToJsonString(ariaUtilsJson.diff(obj1, obj2), jsonOptions);
-                    var s2 = ariaUtilsJson.convertToJsonString(ariaUtilsJson.diff(obj2, obj1), jsonOptions);
+                    var s1 = ariaUtilsJson.convertToJsonString(diff1, jsonOptions);
+                    var s2 = ariaUtilsJson.convertToJsonString(diff2, jsonOptions);
                     optMsg = "JSON comparison failed. First object diff:<br><code><pre>" + s1
                             + "</pre></code><br>Second object diff:<br><code><pre>" + s2 + "</pre></code>";
                 }
-                this.assertTrue(ariaUtilsJson.equals(obj1, obj2), optMsg);
+                this.assertTrue(equal, optMsg);
             },
 
             /**

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -434,19 +434,18 @@ var ariaUtilsJson = require("../utils/Json");
              * @param {String} optMsg optional message to add to the failure description
              */
             assertJsonEquals : function (obj1, obj2, optMsg) {
-                var diff1 = ariaUtilsJson.diff(obj1, obj2);
-                var diff2 = ariaUtilsJson.diff(obj2, obj1);
-                var equal = (diff1 === null && diff2 === null);
-                if (!equal && !optMsg) {
+                var diff = ariaUtilsJson.equalsDiff(obj1, obj2);
+                var equals = diff.equals;
+                if (!equals && !optMsg) {
                     var jsonOptions = {
                         indent : "   "
                     };
-                    var s1 = ariaUtilsJson.convertToJsonString(diff1, jsonOptions);
-                    var s2 = ariaUtilsJson.convertToJsonString(diff2, jsonOptions);
+                    var s1 = ariaUtilsJson.convertToJsonString(diff.left, jsonOptions);
+                    var s2 = ariaUtilsJson.convertToJsonString(diff.right, jsonOptions);
                     optMsg = "JSON comparison failed. First object diff:<br><code><pre>" + s1
                             + "</pre></code><br>Second object diff:<br><code><pre>" + s2 + "</pre></code>";
                 }
-                this.assertTrue(equal, optMsg);
+                this.assertTrue(equals, optMsg);
             },
 
             /**

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -438,10 +438,10 @@ var ariaUtilsJson = require("../utils/Json");
                     var jsonOptions = {
                         indent : "   "
                     };
-                    var s1 = ariaUtilsJson.convertToJsonString(obj1, jsonOptions);
-                    var s2 = ariaUtilsJson.convertToJsonString(obj2, jsonOptions);
-                    optMsg = "JSON comparison failed. First object:<br><code><pre>" + s1
-                            + "</pre></code> differs from the second:<br><code><pre>" + s2 + "</pre></code>";
+                    var s1 = ariaUtilsJson.convertToJsonString(ariaUtilsJson.diff(obj1, obj2), jsonOptions);
+                    var s2 = ariaUtilsJson.convertToJsonString(ariaUtilsJson.diff(obj2, obj1), jsonOptions);
+                    optMsg = "JSON comparison failed. First object diff:<br><code><pre>" + s1
+                            + "</pre></code><br>Second object diff:<br><code><pre>" + s2 + "</pre></code>";
                 }
                 this.assertTrue(ariaUtilsJson.equals(obj1, obj2), optMsg);
             },

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1032,7 +1032,7 @@ var ariaUtilsObject = require("./Object");
                 var __arrayToObject = function(array) {
                         var object = {};
                         arrayUtils.forEach( array, function( item, index ) {
-                            object[index] = item;
+                            object[ index ] = this.copy( item );
                         });
                         return object;
                     },
@@ -1091,7 +1091,7 @@ var ariaUtilsObject = require("./Object");
                                 // if either the item or refItem is empty.
                                 if ( isOneEmpty( arrayUtils ) ) {
                                     // then transform the item array into an object with the keys being the indices.
-                                    _result[ property ] = __arrayToObject( this.copy( item ) );
+                                    _result[ property ] = __arrayToObject.call( this, item );
                                 } else {
                                     // process the array providing a function that will perform the loop.
                                     arrayOrObject.call(this, function( eachItemFn ) {

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1019,10 +1019,11 @@ var ariaUtilsObject = require("./Object");
                 return clone;
             },
             /**
-             * Creates a diff object of all those items in an left that are different from the right. If there are any
-             * extra properties that are found in the right but not in the left, the left will have those properties set 
-             * to null. Also any Array sub lefts will be converted to lefts and only those indicies that have changed will be 
-             * present in the left.  
+             * Will determine whether two objects are equal and if not will provide the differences between the two.
+             * A return object contains three properties, a boolean equals, an object left and an object right. If the
+             * equals is true, the left and right objects will be null. If not, it will provide all the properties that
+             * are in the left object and not in the right under the left property, and the similarly for right. If comparing
+             * Arrays, they will be converted to Objects and only those indices that are different will be present in the results.  
              * 
              * @param {Object} left - creates a diff of this object
              * @param {Object} right - the reference object to be used to check against 
@@ -1042,11 +1043,11 @@ var ariaUtilsObject = require("./Object");
                         var key, diff;
                         for (var i = 0, l = list.length; i < l; i++) {
                             key = __getKey(i, list);
-                            if (left[key] !== undefined || right[key] !== undefined) {
-                                diff = this.equalsDiff(left[key], right[key]);
-                                if (diff.equals) {
-                                    continue;
-                                }
+                            if ( key.match(/:/) || (left[key] === undefined && right[key] === undefined) ) {
+                                continue;
+                            }
+                            diff = this.equalsDiff(left[key], right[key]);
+                            if (!diff.equals) {
                                 if (!leftDiff && !rightDiff) {
                                     leftDiff = {};
                                     rightDiff = {};
@@ -1065,7 +1066,8 @@ var ariaUtilsObject = require("./Object");
                     };
                 }
                 else if (isLeftArray && isRightArray) {
-                    __processContainer.call(this, left.length > right.length ? left : right, function(i) { return i; });
+                    var longerList = left.length > right.length ? left : right;
+                    __processContainer.call(this, longerList, function(i) { return i; });
                     return {
                         equals : leftDiff === null && rightDiff === null,
                         left : leftDiff,
@@ -1073,10 +1075,12 @@ var ariaUtilsObject = require("./Object");
                     };
                 } else if (isLeftObject && isRightObject) {
                     var allKeys = this.keys(left),
-                        rightKeys = this.keys(right);
+                        rightKeys = this.keys(right),
+                        key;
                     for (var i = 0, l = rightKeys.length; i < l; i++) {
-                        if (left[rightKeys[i]] === undefined) {
-                            allKeys.push(rightKeys[i]);
+                        key = rightKeys[i];
+                        if (left[key] === undefined) {
+                            allKeys.push(key);
                         }
                     }
                     __processContainer.call(this, allKeys, function(i, keys) { return keys[i]; } );

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1043,7 +1043,7 @@ var ariaUtilsObject = require("./Object");
                         var key, diff;
                         for (var i = 0, l = list.length; i < l; i++) {
                             key = __getKey(i, list);
-                            if ( key.match(/:/) || (left[key] === undefined && right[key] === undefined) ) {
+                            if ( (key.match && key.match(/:/)) || (left[key] === undefined && right[key] === undefined) ) {
                                 continue;
                             }
                             diff = this.equalsDiff(left[key], right[key]);

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1096,7 +1096,7 @@ var ariaUtilsObject = require("./Object");
                 // as arrays can be converted to objects.
                 __diff.call(this, copy, {'OBJECT' : this.copy(referenceObject)});
                 //remember to return the nested OBJECT
-                return copy.OBJECT;
+                return copy.OBJECT === undefined ? null : copy.OBJECT;
             }
         }
     });

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1061,7 +1061,7 @@ var ariaUtilsObject = require("./Object");
                                 if (refItem) {
                                     // remember whether the original was an empty object or not
                                     originalWasEmpty = ariaUtilsObject.isEmpty(item);
-                                    // recursively create the diff for the sub class
+                                    // recursively create the diff for the sub object
                                     __diff.call(this, item, refItem);
                                     // if the object has now become empty, then delete it. This takes into account whether the original
                                     // was empty and whether the referenceItem is empty.                                      

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1033,7 +1033,7 @@ var ariaUtilsObject = require("./Object");
                     isObjectObject = typeUtils.isObject(object),
                     isReferenceArray = typeUtils.isArray(referenceObject),
                     isReferenceObject = typeUtils.isObject(referenceObject),
-                    result = null, diff,
+                    result = null,
                     __processContainer = function(list, __getKey) {
                         var key, diff;
                         for(var i = 0, l = list.length; i < l; i++) {
@@ -1057,8 +1057,8 @@ var ariaUtilsObject = require("./Object");
                     }
                     return result;
                 } else if (isReferenceObject && isObjectObject) {
-                    var keys = this.keys(object);
-                    __processContainer.call(this, keys, function(i) {return keys[i]});
+                    var keys = this.keys(object), key;
+                    __processContainer.call(this, keys, function(i) {return keys[i];});
                     keys = this.keys(referenceObject);
                     for (var i = 0, l = keys.length; i < l; i++) {
                         key = keys[i];

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1042,17 +1042,30 @@ var ariaUtilsObject = require("./Object");
                             var item = _obj[property],
                                 refItem = _refObj[property],
                                 isContainer = typeUtils.isContainer(item),
+                                isArray = typeUtils.isArray(item),
+                                isArrayRef = typeUtils.isArray(refItem),
                                 originalWasEmpty;
+                            
+                            // if the types are not the same return
+                            if (typeof item !== typeof refItem || (isArray && !isArrayRef) || (!isArray && isArrayRef)) {
+                                return;
+                            }
+                            // handle dates
+                            else if (typeUtils.isDate(item) && typeUtils.isDate(refItem)) {
+                                if (item.getTime() === refItem.getTime()) {
+                                    delete(_obj[property]);
+                                }
+                            }
                             // if it an object or an array...
-                            if (isContainer) {
+                            else if (isContainer) {
                                 // if it is an array, transform it to an object. This is so that only those indices
                                 // that have changed can be kept in the diff object.
-                                if (typeUtils.isArray(item)) {
+                                if (isArray) {
                                     // convert the array to an object.
                                     _obj[property] = __arrayToObject(item);
                                     item = _obj[property];
                                     // if the reference item is also an array, then convert that to an object.
-                                    if (typeUtils.isArray(refItem)) {
+                                    if (isArrayRef) {
                                         _refObj[property] = __arrayToObject(refItem);
                                         refItem = _refObj[property];
                                     }

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1017,6 +1017,73 @@ var ariaUtilsObject = require("./Object");
                     }
                 }
                 return clone;
+            },
+            /**
+             * Creates a diff object of all those items in an object that are different from the referenceObject. It will not
+             * take into account any extra properties that are found in the referenceObject but not in the object. Also any
+             * Array sub objects will be converted to Objects and only those indicies that have changed will be present in the Object.  
+             * 
+             * @param {Object} object - creates a diff of this object
+             * @param {Object} referenceObject - the reference object to be used to check against 
+             * @return {Object} 
+             */
+            diff : function( object, referenceObject ) {
+                // this private function will convert an Array to an Object, with the object keys being the Array indices.
+                var __arrayToObject = function(array) {
+                        var object = {};
+                        arrayUtils.forEach(array, function(item, index) {
+                            object[index] = item;
+                        });
+                        return object;
+                    },
+                    // this will create a diff on a given object compared against a reference object.
+                    __diff = function(_obj, _refObj) {
+                        arrayUtils.forEach(ariaUtilsObject.keys(_obj), function(property) {
+                            var item = _obj[property],
+                                refItem = _refObj[property],
+                                isContainer = typeUtils.isContainer(item),
+                                originalWasEmpty;
+                            // if it an object or an array...
+                            if (isContainer) {
+                                // if it is an array, transform it to an object. This is so that only those indices
+                                // that have changed can be kept in the diff object.
+                                if (typeUtils.isArray(item)) {
+                                    // convert the array to an object.
+                                    _obj[property] = __arrayToObject(item);
+                                    item = _obj[property];
+                                    // if the reference item is also an array, then convert that to an object.
+                                    if (typeUtils.isArray(refItem)) {
+                                        _refObj[property] = __arrayToObject(refItem);
+                                        refItem = _refObj[property];
+                                    }
+                                }
+                                // if there is no refItem then we know something has changed, so do nothing.
+                                if (refItem) {
+                                    // remember whether the original was an empty object or not
+                                    originalWasEmpty = ariaUtilsObject.isEmpty(item);
+                                    // recursively create the diff for the sub class
+                                    __diff.call(this, item, refItem);
+                                    // if the object has now become empty, then delete it. This takes into account whether the original
+                                    // was empty and whether the referenceItem is empty.                                      
+                                    if (ariaUtilsObject.isEmpty(item) && (!originalWasEmpty || ariaUtilsObject.isEmpty(refItem))) {
+                                        delete(_obj[property]);
+                                    }
+                                }
+                            } else if (item === refItem) {
+                                // if the items are simple types: dates, strings, integers, etc
+                                // and they are the same, then delete them from the diff object.
+                                delete(_obj[property]);
+                            }
+                        }, this);
+                    },
+                    // create a copy that can be modified into the diff and nest this inside and object with key OBJECT. 
+                    // This OBJECT nesting is so that this works for any type of input.
+                    copy = {'OBJECT' : this.copy(object)};
+                // create the diff of the copy. Also nest and take a copy of the referenceObject. A copy is needed for the referenceObject
+                // as arrays can be converted to objects.
+                __diff.call(this, copy, {'OBJECT' : this.copy(referenceObject)});
+                //remember to return the nested OBJECT
+                return copy.OBJECT;
             }
         }
     });

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -1123,8 +1123,7 @@ var ariaUtilsObject = require("./Object");
                     // create a result object that will be populated with any differences. It is initialized to {'OBJECT':undefined}.  
                     // This OBJECT nesting is so that this works for any type of input.
                     result = __nest();
-                // create the diff of the copy. Also nest and take a copy of the referenceObject. A copy is needed for the referenceObject
-                // as arrays can be converted to objects.
+                // populate the result object with any differences. Need to nest them both so that any type of input is valid.
                 __diff.call( this, __nest( object ), __nest( referenceObject ), result );
                 //remember to return the nested OBJECT
                 return result.OBJECT === undefined ? null : result.OBJECT;

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1485,12 +1485,12 @@ Aria.classDefinition({
         },
         
         testDiff : function() {
-            this.assertJsonEquals(aria.utils.Json.diff(undefined, undefined), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff(undefined, undefined), null);
             this.assertJsonEquals(aria.utils.Json.diff({}, undefined), {});
-            this.assertJsonEquals(aria.utils.Json.diff(1, 1), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff(1, 1), null);
             this.assertJsonEquals(aria.utils.Json.diff(1, 2), 1);
             this.assertJsonEquals(aria.utils.Json.diff(1, '1'), 1);
-            this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), null);
             this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0 : 1, 1 :2});
             this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
 

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1493,16 +1493,16 @@ Aria.classDefinition({
             this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0 : 1, 1 :2});
             this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
 
-            object = {};
-            referenceObject = {
-                a : 1,
-                b : "two",
-                c : true,
-                d : {
-                    sub : 1
-                },
-                e : [1,2]
-            };
+            var object = {},
+                referenceObject = {
+                    a : 1,
+                    b : "two",
+                    c : true,
+                    d : {
+                        sub : 1
+                    },
+                    e : [1,2]
+                };
             this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {});
             
             object = {
@@ -1559,7 +1559,7 @@ Aria.classDefinition({
                 cc : false,
                 d : {
                     sub : 1
-                }, 
+                },
                 e : 'string',
                 f : {
                     'object' : true

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1491,8 +1491,10 @@ Aria.classDefinition({
             this.assertJsonEquals(aria.utils.Json.diff(1, 2), 1);
             this.assertJsonEquals(aria.utils.Json.diff(1, '1'), 1);
             this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), null);
-            this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0 : 1, 1 :2});
+            this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0:1, 1:2});
+            this.assertJsonEquals(aria.utils.Json.diff([1], [1,2]), {1:null});
             this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
+            this.assertJsonEquals(aria.utils.Json.diff(null, 2), null);
 
             var object = {},
                 referenceObject = {
@@ -1504,7 +1506,13 @@ Aria.classDefinition({
                     },
                     e : [1,2]
                 };
-            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {});
+            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {
+                a : null,
+                b : null,
+                c : null,
+                d : null,
+                e : null
+            });
             
             object = {
                 a : 1,
@@ -1570,7 +1578,7 @@ Aria.classDefinition({
                     'object' : true
                 },
                 g : 0,
-                h: {},
+                h: {0 :null, 1 : null, 2 : null},
                 hhh : {1 : {b:2}},
                 hhhh : {},
                 ii : new Date(2011, 6, 16, 12, 33, 46, 4)

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1484,17 +1484,17 @@ Aria.classDefinition({
             this.assertTrue(d[parProp] == null);
         },
         
-        testDiff : function() {
-            this.assertJsonEquals(aria.utils.Json.diff(undefined, undefined), null);
-            this.assertJsonEquals(aria.utils.Json.diff({}, undefined), {});
-            this.assertJsonEquals(aria.utils.Json.diff(1, 1), null);
-            this.assertJsonEquals(aria.utils.Json.diff(1, 2), 1);
-            this.assertJsonEquals(aria.utils.Json.diff(1, '1'), 1);
-            this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), null);
-            this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0:1, 1:2});
-            this.assertJsonEquals(aria.utils.Json.diff([1], [1,2]), {1:null});
-            this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
-            this.assertJsonEquals(aria.utils.Json.diff(null, 2), null);
+        testEqualsDiff : function() {
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(undefined, undefined), {equals : true, left: null, right : null});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff({}, undefined), {equals : false, left : {}, right : undefined});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(1, 1), {equals : true, left : null, right : null});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(1, 2), {equals : false, left : 1, right : 2});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(1, '1'), {equals : false, left : 1, right : '1'});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff([1,2,3], [1,2,3]), {equals : true, left : null, right : null});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff([1,2], [2]), {equals : false, left : {0:1, 1:2}, right : {0:2}});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff([1], [1,2]), {equals : false, left : {}, right : {1 : 2}});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(false, true),{equals : false, left : false, right : true});
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(null, 2), {equals : false, left : null, right : 2});
 
             var object = {},
                 referenceObject = {
@@ -1506,12 +1506,18 @@ Aria.classDefinition({
                     },
                     e : [1,2]
                 };
-            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {
-                a : null,
-                b : null,
-                c : null,
-                d : null,
-                e : null
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(object, referenceObject), {
+                equals : false,
+                left : {},
+                right : {
+                    a : 1,
+                    b : "two",
+                    c : true,
+                    d : {
+                        sub : 1
+                    },
+                    e : [1,2]
+                }
             });
             
             object = {
@@ -1566,22 +1572,42 @@ Aria.classDefinition({
                 i : new Date(2010, 5, 15, 10, 32, 45, 3),
                 ii : new Date(2010, 5, 15, 10, 32, 45, 3)
             };
-            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {
-                aa : 2,
-                bb : 'twotwo',
-                cc : false,
-                d : {
-                    sub : 1
+            this.assertJsonEquals(aria.utils.Json.equalsDiff(object, referenceObject), {
+                equals : false,
+                left : {
+                    aa : 2,
+                    bb : 'twotwo',
+                    cc : false,
+                    d : {
+                        sub : 1
+                    },
+                    e : 'string',
+                    f : {
+                        'object' : true
+                    },
+                    g : 0,
+                    h : {},
+                    hhh : { 1 : {b:2} },
+                    hhhh : {},
+                    ii : new Date(2011, 6, 16, 12, 33, 46, 4)
                 },
-                e : 'string',
-                f : {
-                    'object' : true
-                },
-                g : 0,
-                h: {0 :null, 1 : null, 2 : null},
-                hhh : {1 : {b:2}},
-                hhhh : {},
-                ii : new Date(2011, 6, 16, 12, 33, 46, 4)
+                right : {
+                    aa : 1,
+                    bb : 'two',
+                    cc : 1,
+                    d : {
+                        sub : 2
+                    },
+                    e : {
+                        sub2 : true
+                    },
+                    f : 'notanobject',
+                    g : null,
+                    h : {0 : 1,1 : 2, 2: 3},
+                    hhh : {1: {b:4}},
+                    hhhh : [],
+                    ii : new Date(2010, 5, 15, 10, 32, 45, 3)
+                }
             });
         }
     }

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1518,12 +1518,12 @@ Aria.classDefinition({
                 dd : {
                     sub : 1
                 },
+                ddd: {},
                 e : 'string',
                 f : {
                     'object' : true
                 },
                 g : 0,
-                gg: {},
                 h : [],
                 hh : [1,2,3,4],
                 hhh : [{a:1}, {b:2}, {c:3}],
@@ -1542,12 +1542,12 @@ Aria.classDefinition({
                 dd : {
                     sub : 1
                 },
+                ddd : {},
                 e : {
                     sub2 : true
                 },
                 f : 'notanobject',
                 g : null,
-                gg : {},
                 h : [1,2,3],
                 hh : [1,2,3,4],
                 hhh : [{a:1}, {b:4}, {c:3}],

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1489,6 +1489,7 @@ Aria.classDefinition({
             this.assertJsonEquals(aria.utils.Json.diff({}, undefined), {});
             this.assertJsonEquals(aria.utils.Json.diff(1, 1), undefined);
             this.assertJsonEquals(aria.utils.Json.diff(1, 2), 1);
+            this.assertJsonEquals(aria.utils.Json.diff(1, '1'), 1);
             this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), undefined);
             this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0 : 1, 1 :2});
             this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
@@ -1527,7 +1528,9 @@ Aria.classDefinition({
                 h : [],
                 hh : [1,2,3,4],
                 hhh : [{a:1}, {b:2}, {c:3}],
-                hhhh : {}
+                hhhh : {},
+                i : new Date(2010, 5, 15, 10, 32, 45, 3),
+                ii : new Date(2011, 6, 16, 12, 33, 46, 4)
             };
             referenceObject = {
                 a : 1,
@@ -1551,7 +1554,9 @@ Aria.classDefinition({
                 h : [1,2,3],
                 hh : [1,2,3,4],
                 hhh : [{a:1}, {b:4}, {c:3}],
-                hhhh : []
+                hhhh : [],
+                i : new Date(2010, 5, 15, 10, 32, 45, 3),
+                ii : new Date(2010, 5, 15, 10, 32, 45, 3)
             };
             this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {
                 aa : 2,
@@ -1566,7 +1571,9 @@ Aria.classDefinition({
                 },
                 g : 0,
                 h: {},
-                hhh : {1 : {b:2}}
+                hhh : {1 : {b:2}},
+                hhhh : {},
+                ii : new Date(2011, 6, 16, 12, 33, 46, 4)
             });
         }
     }

--- a/test/aria/utils/JsonTestCase.js
+++ b/test/aria/utils/JsonTestCase.js
@@ -1482,6 +1482,92 @@ Aria.classDefinition({
             this.assertTrue(b[parProp] == null);
             this.assertTrue(c[parProp] == null);
             this.assertTrue(d[parProp] == null);
+        },
+        
+        testDiff : function() {
+            this.assertJsonEquals(aria.utils.Json.diff(undefined, undefined), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff({}, undefined), {});
+            this.assertJsonEquals(aria.utils.Json.diff(1, 1), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff(1, 2), 1);
+            this.assertJsonEquals(aria.utils.Json.diff([1,2,3], [1,2,3]), undefined);
+            this.assertJsonEquals(aria.utils.Json.diff([1,2], [2]), {0 : 1, 1 :2});
+            this.assertJsonEquals(aria.utils.Json.diff(false, true), false);
+
+            object = {};
+            referenceObject = {
+                a : 1,
+                b : "two",
+                c : true,
+                d : {
+                    sub : 1
+                },
+                e : [1,2]
+            };
+            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {});
+            
+            object = {
+                a : 1,
+                aa : 2,
+                b : 'two',
+                bb : 'twotwo',
+                c : true,
+                cc : false,
+                d : {
+                    sub : 1
+                },
+                dd : {
+                    sub : 1
+                },
+                e : 'string',
+                f : {
+                    'object' : true
+                },
+                g : 0,
+                gg: {},
+                h : [],
+                hh : [1,2,3,4],
+                hhh : [{a:1}, {b:2}, {c:3}],
+                hhhh : {}
+            };
+            referenceObject = {
+                a : 1,
+                aa : 1,
+                b : 'two',
+                bb : 'two',
+                c : true,
+                cc : 1,
+                d : {
+                    sub : 2
+                },
+                dd : {
+                    sub : 1
+                },
+                e : {
+                    sub2 : true
+                },
+                f : 'notanobject',
+                g : null,
+                gg : {},
+                h : [1,2,3],
+                hh : [1,2,3,4],
+                hhh : [{a:1}, {b:4}, {c:3}],
+                hhhh : []
+            };
+            this.assertJsonEquals(aria.utils.Json.diff(object, referenceObject), {
+                aa : 2,
+                bb : 'twotwo',
+                cc : false,
+                d : {
+                    sub : 1
+                }, 
+                e : 'string',
+                f : {
+                    'object' : true
+                },
+                g : 0,
+                h: {},
+                hhh : {1 : {b:2}}
+            });
         }
     }
 });


### PR DESCRIPTION
Hi, I would like to propose this change. The issue that this is trying to address is when using the this.assertJsonEquals method in the attester test cases, if the objects are large, then the output is very difficult to debug, as the entire objects are printed out. With this change, only the differences between the objects will be logged, meaning easier debugging. How this has been done is to add a new generic diff method to aria.utils.Json (with test cases provided, and detailed comments on this method), and then to update the Assert.js' assertJsonEquals method to use it.
