### PR TITLE
fix/test #1707 test.aria.core.CSSPrefixTestCase

### DIFF
--- a/src/aria/utils/Delegate.js
+++ b/src/aria/utils/Delegate.js
@@ -64,7 +64,7 @@ module.exports = Aria.classDefinition({
             // In non-browser environment document might be null
             if (Aria.$window && Aria.$window.document) {
                 var div = Aria.$window.document.createElement("div");
-                var prefixes = ["ms", "O", "Webkit", "Moz", ""];
+                var prefixes = ["ms", "O", "Moz", "Webkit", ""];
                 for (var i = 0; i < prefixes.length; i += 1) {
                     var prefix = prefixes[i];
                     if (div.style[prefix + "Transition"] !== undefined) {

--- a/test/aria/core/CSSPrefixTestCase.js
+++ b/test/aria/core/CSSPrefixTestCase.js
@@ -18,17 +18,19 @@ Aria.classDefinition({
     $extends : "aria.jsunit.TestCase",
     $prototype : {
         testAgainstBrowser : function () {
+            var vendorPrefix = aria.utils.Delegate.vendorPrefix;
+            Aria.$global.console.log("Vendor prefix: " + vendorPrefix);
             if (aria.core.Browser.isChrome) {
-                this.assertEquals(aria.utils.Delegate.vendorPrefix, "Webkit", "The CSS Prefix went wrong for Chrome");
+                this.assertEquals(vendorPrefix, "Webkit", "The CSS Prefix went wrong for Chrome");
             }
             if (aria.core.Browser.isFirefox) {
                 // FF3 doesn't support animations
                 if (aria.core.Browser.majorVersion !== 3) {
-                    this.assertEquals(aria.utils.Delegate.vendorPrefix, "Moz", "The CSS Prefix went wrong for FireFox");
+                    this.assertEquals(vendorPrefix, "Moz", "The CSS Prefix went wrong for FireFox");
                 }
             }
-            if (aria.core.Browser.isIE10) {
-                this.assertEquals(aria.utils.Delegate.vendorPrefix, "ms", "The CSS Prefix went wrong for IE10");
+            if (aria.core.Browser.isIE10 || aria.core.Browser.isIE11) {
+                this.assertEquals(vendorPrefix, "ms", "The CSS Prefix went wrong for IE");
             }
         }
     }


### PR DESCRIPTION
This PR fixes `CSSPrefixTestCase` on Firefox 49 by changing the order in which prefixes are tested. `Moz` is now tested before `Webkit`, so that, on Firefox, `Moz` is chosen rather than `Webkit` (now that both seem to be supported on Firefox 49).