### PR TITLE
fix #1710 Fixed test.aria.widgets.wai.popup.dialog.titleTag.DialogTitleTagJawsTestCase

### DIFF
--- a/src/aria/utils/DomNavigationManager.js
+++ b/src/aria/utils/DomNavigationManager.js
@@ -688,6 +688,9 @@ function ElementNavigationInterceptor(element, loop) {
             // --------------------------------------------------- destructuring
 
             var target = event.target;
+            if (target == null) {
+                target = event.srcElement;
+            }
 
             // ------------------------------------------------------ processing
 

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -745,12 +745,6 @@ module.exports = Aria.classDefinition({
                 this._previouslyFocusedElement = Aria.$window.document.activeElement;
             }
 
-            // hiddenElements --------------------------------------------------
-
-            if (modal && waiAria) {
-                this._showBack = DomNavigationManager.hidingManager.hideOthers(this._domElt);
-            }
-
             // optionsBeforeMaximize -------------------------------------------
             // store current options to reapply them when unmaximized
 
@@ -801,6 +795,15 @@ module.exports = Aria.classDefinition({
                 labelId: modal ? this.__getLabelId() : null,
                 waiAria: waiAria
             });
+
+            // hiddenElements --------------------------------------------------
+
+            if (modal && waiAria) {
+                var container = popupContainer.getContainerElt();
+                this._showBack = DomNavigationManager.hidingManager.hideOthers(popup.domElement, function (element) {
+                     return element != null && element !== container;
+                });
+            }
 
             // -----------------------------------------------------------------
 

--- a/test/aria/utils/domNavigationManager/CSS.tpl.css
+++ b/test/aria/utils/domNavigationManager/CSS.tpl.css
@@ -14,11 +14,11 @@
  */
 
 {CSSTemplate {
-	$classpath: 'test.aria.utils.domNavigationManager.CSS',
+	$classpath: 'test.aria.utils.domNavigationManager.CSS'
 }}
 
 {macro main()}
-	:focus {
+	*:focus {
 		outline: 1px red solid !important;
 	}
 
@@ -41,7 +41,6 @@
 	.node[aria-hidden][data-hide-requests-count] {
 		border-color: red;
 	}
-
 {/macro}
 
 {/CSSTemplate}

--- a/test/aria/utils/domNavigationManager/DomNavigationManagerJawsTestCase.js
+++ b/test/aria/utils/domNavigationManager/DomNavigationManagerJawsTestCase.js
@@ -19,6 +19,7 @@ var DomNavigationManager = require('ariatemplates/utils/DomNavigationManager');
 
 var ariaUtilsArray = require('ariatemplates/utils/Array');
 var ariaUtilsFunction = require('ariatemplates/utils/Function');
+var ariaUtilsDom = require('ariatemplates/utils/Dom');
 
 
 
@@ -210,7 +211,7 @@ module.exports = Aria.classDefinition({
         },
 
         _getNodeNameElement : function (node) {
-            return node.getElementsByClassName('node_name')[0];
+            return ariaUtilsDom.getElementsByClassName(node, 'node_name')[0];
         },
 
         _getClickTargets : function () {

--- a/test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js
+++ b/test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js
@@ -124,7 +124,7 @@ module.exports = Aria.classDefinition({
 
             // -----------------------------------------------------------------
 
-            var nodeName = node.getElementsByClassName('node_name')[0];
+            var nodeName = ariaUtilsDom.getElementsByClassName(node, 'node_name')[0];
             nodeName.focus();
 
             // ---------------------------------------------------------- return
@@ -173,7 +173,7 @@ module.exports = Aria.classDefinition({
 
             var document = Aria.$window.document;
             var focusedElement = document.activeElement;
-            var textContent = focusedElement.textContent;
+            var textContent = focusedElement.textContent || focusedElement.innerText;
 
             // ------------------------------------------------------ processing
 
@@ -187,9 +187,9 @@ module.exports = Aria.classDefinition({
 
             var subtitution;
             if (shouldBeContained) {
-                subtitution = '';
+                subtitution = ' ';
             } else {
-                subtitution = 'not';
+                subtitution = ' not ';
                 result = !result;
             }
 

--- a/test/aria/utils/domNavigationManager/Tpl.tpl
+++ b/test/aria/utils/domNavigationManager/Tpl.tpl
@@ -27,6 +27,12 @@
 {/macro}
 
 {macro buildElement(node)}
+	{if node.insertIndependentHiddenElement}
+		<div aria-hidden='true'>
+			Must not say this (above ${node.name})
+		</div>
+	{/if}
+
 	<div {id node.name /} class='node'>
 		<span class='node_name' tabindex='0'>${node.name}</span>
 

--- a/test/aria/utils/domNavigationManager/TplScript.js
+++ b/test/aria/utils/domNavigationManager/TplScript.js
@@ -55,26 +55,27 @@ module.exports = Aria.tplScriptDefinition({
                         children: [
                             {
                                 name: '1.1',
+                                insertIndependentHiddenElement: true,
                                 children: [
-                                    {name: '1.1.1', children: []},
-                                    {name: '1.1.2', children: []},
-                                    {name: '1.1.3', children: []}
+                                    {name: '1.1.1'},
+                                    {name: '1.1.2'},
+                                    {name: '1.1.3'}
                                 ]
                             },
                             {
                                 name: '1.2',
                                 children: [
-                                    {name: '1.2.1', children: []},
-                                    {name: '1.2.2', children: []},
-                                    {name: '1.2.3', children: []}
+                                    {name: '1.2.1'},
+                                    {name: '1.2.2'},
+                                    {name: '1.2.3'}
                                 ]
                             },
                             {
                                 name: '1.3',
                                 children: [
-                                    {name: '1.3.1', children: []},
-                                    {name: '1.3.2', children: []},
-                                    {name: '1.3.3', children: []}
+                                    {name: '1.3.1'},
+                                    {name: '1.3.2'},
+                                    {name: '1.3.3'}
                                 ]
                             }
                         ]
@@ -85,54 +86,25 @@ module.exports = Aria.tplScriptDefinition({
                             {
                                 name: '2.1',
                                 children: [
-                                    {name: '2.1.1', children: []},
-                                    {name: '2.1.2', children: []},
-                                    {name: '2.1.3', children: []}
+                                    {name: '2.1.1'},
+                                    {name: '2.1.2'},
+                                    {name: '2.1.3'}
                                 ]
                             },
                             {
                                 name: '2.2',
                                 children: [
-                                    {name: '2.2.1', children: []},
-                                    {name: '2.2.2', children: []},
-                                    {name: '2.2.3', children: []}
+                                    {name: '2.2.1'},
+                                    {name: '2.2.2'},
+                                    {name: '2.2.3'}
                                 ]
                             },
                             {
                                 name: '2.3',
                                 children: [
-                                    {name: '2.3.1', children: []},
-                                    {name: '2.3.2', children: []},
-                                    {name: '2.3.3', children: []}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        name: '3',
-                        children: [
-                            {
-                                name: '3.1',
-                                children: [
-                                    {name: '3.1.1', children: []},
-                                    {name: '3.1.2', children: []},
-                                    {name: '3.1.3', children: []}
-                                ]
-                            },
-                            {
-                                name: '3.2',
-                                children: [
-                                    {name: '3.2.1', children: []},
-                                    {name: '3.2.2', children: []},
-                                    {name: '3.2.3', children: []}
-                                ]
-                            },
-                            {
-                                name: '3.3',
-                                children: [
-                                    {name: '3.3.1', children: []},
-                                    {name: '3.3.2', children: []},
-                                    {name: '3.3.3', children: []}
+                                    {name: '2.3.1'},
+                                    {name: '2.3.2'},
+                                    {name: '2.3.3'}
                                 ]
                             }
                         ]


### PR DESCRIPTION
The dialog did not use properly the new utility to hide other elements: it was using wrong reference elements.

Also improved the aria.utils.DomNavigationManager by not touching elements whose hidden state is managed by other entities (i.e. which have a aria-hidden without a registered request counter).