### PR TITLE
Slowing down BindableRobotTestCase to make it more reliable

### DIFF
--- a/test/aria/html/textarea/bind/BindableRobotTestCase.js
+++ b/test/aria/html/textarea/bind/BindableRobotTestCase.js
@@ -43,7 +43,14 @@ Aria.classDefinition({
         },
 
         afterFirstClick : function (_, element) {
-            this.synEvent.type(element, "japan", {
+            this.synEvent.execute([
+                ["waitFocus", element],
+                ["type", null, "j"], ["pause", 50],
+                ["type", null, "a"], ["pause", 50],
+                ["type", null, "p"], ["pause", 50],
+                ["type", null, "a"], ["pause", 50],
+                ["type", null, "n"], ["pause", 50]
+            ], {
                 fn : this.afterType,
                 scope : this,
                 args : element

--- a/test/aria/html/textinput/bind/BindableRobotTestCase.js
+++ b/test/aria/html/textinput/bind/BindableRobotTestCase.js
@@ -43,7 +43,14 @@ Aria.classDefinition({
         },
 
         afterFirstClick : function (_, element) {
-            this.synEvent.type(element, "japan", {
+            this.synEvent.execute([
+                ["waitFocus", element],
+                ["type", null, "j"], ["pause", 50],
+                ["type", null, "a"], ["pause", 50],
+                ["type", null, "p"], ["pause", 50],
+                ["type", null, "a"], ["pause", 50],
+                ["type", null, "n"], ["pause", 50]
+            ], {
                 fn : this.afterType,
                 scope : this,
                 args : element


### PR DESCRIPTION
Depending on how fast the robot implementation is, `test.aria.html.textarea.bind.BindableRobotTestCase` and `test.aria.html.textinput.bind.BindableRobotTestCase` could fail in case the keys are typed quicker than the delay we use to simulate the type event.
This PR adds some pause between each character so that the corresponding type events do not combine several letters together.
Especially, this commit fixes both tests with the robot-server on Safari.