### PR TITLE
Improving reliability of DataModelOnChangeRobotTestCase

### DIFF
--- a/test/aria/html/select/onchange/DataModelOnChangeRobotTestCase.js
+++ b/test/aria/html/select/onchange/DataModelOnChangeRobotTestCase.js
@@ -36,14 +36,25 @@ Aria.classDefinition({
 
             this.assertEquals(selectWidget.selectedIndex, 0, "The selected Index should be %2 but was %1");
 
-            this.synEvent.execute([["click", selectWidget], ["type", null, "[down][down][enter]\t"]], {
-                fn : this.afterChange,
+            this.synEvent.execute([
+                ["click", selectWidget],
+                ["waitFocus", selectWidget],
+                ["type", null, "[down][down][enter]\t"]
+            ], {
+                fn : function () {
+                    this.waitFor({
+                        condition: function () {
+                            return this.data.onChangeCalls > 0;
+                        },
+                        callback: this.afterChange
+                    });
+                },
                 scope : this
             });
         },
 
         afterChange : function () {
-            this.assertEquals(this.data.onChangeCalls, 1, "onchange should have been called exactly once");
+            this.assertEquals(this.data.onChangeCalls, 1, "onchange should have been called exactly once, but was called %1 time(s)");
             this.assertEquals(this.data.selectedOption, "POUND", "Selected Option should be %2  but was %1");
             this.assertEquals(this.data.onChangeOption, "POUND", "Changed Option should be %2  but was %1");
             this.end();


### PR DESCRIPTION
This PR improves the reliability of `DataModelOnChangeRobotTestCase` by waiting for the focus and adding a pause after typing. This fixes the test on Safari with robot-server.
