### PR TITLE
fix #1715 Fixed test.aria.utils.domNavigationManager.DomNavigationManagerRobotTestCase for IE 7, 8, 9

### DIFF
--- a/test/EnhancedRobotBase.js
+++ b/test/EnhancedRobotBase.js
@@ -86,6 +86,14 @@ var prototype = {
     // DOM
     ////////////////////////////////////////////////////////////////////////////
 
+    _ensureElementReference : function (element) {
+        if (!ariaUtilsType.isHTMLElement(element)) {
+            element = this.getElementById('' + element);
+        }
+
+        return element;
+    },
+
     _getActiveElement : function () {
         return this.testDocument.activeElement;
     },
@@ -320,13 +328,13 @@ var prototype = {
     // Robot: navigation
     ////////////////////////////////////////////////////////////////////////////
 
-    _focusElement : function (callback, id) {
-        var element = this.getElementById(id);
+    _focusElement : function (callback, element) {
+        element = this._ensureElementReference(element);
 
         this._localAsyncSequence(function (add) {
             add('_delay');
             add('_click', element);
-            add('_waitForElementFocus', id);
+            add('_waitForElementFocus', element);
         }, callback);
     },
 
@@ -342,8 +350,8 @@ var prototype = {
         }, callback);
     },
 
-    _waitForElementFocus : function (callback, id) {
-        var element = this.getElementById(id);
+    _waitForElementFocus : function (callback, element) {
+        element = this._ensureElementReference(element);
         this._waitForFocus(callback, element);
     },
 
@@ -415,8 +423,9 @@ var prototype = {
         this._checkAttribute(id, element, attributeName, expected, strict);
     },
 
-    _checkElementAttribute : function (id, attributeName, expected, strict) {
-        var element = this.getElementById(id);
+    _checkElementAttribute : function (element, attributeName, expected, strict) {
+        element = this._ensureElementReference(element);
+        var id = element.id;
         this._checkAttribute(id, element, attributeName, expected, strict);
     },
 
@@ -448,8 +457,8 @@ var prototype = {
         return this._isFocused(element, false);
     },
 
-    _checkElementIsFocused : function (callback, id) {
-        var element = this.getElementById(id);
+    _checkElementIsFocused : function (callback, element) {
+        element = this._ensureElementReference(element);
 
         this.waitFor({
             callback: callback,

--- a/test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js
+++ b/test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js
@@ -125,11 +125,7 @@ module.exports = Aria.classDefinition({
             // -----------------------------------------------------------------
 
             var nodeName = ariaUtilsDom.getElementsByClassName(node, 'node_name')[0];
-            nodeName.focus();
-
-            // ---------------------------------------------------------- return
-
-            next();
+            this._focusElement(next, nodeName);
         },
 
         _destroy : function (next) {

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -108,6 +108,9 @@ var generalBrowserExcludes = {
         "test/aria/utils/mouse/MouseDragKoRobotTestCase.js"
     ],
     "Safari": [],
+    "IE 7": [
+        "test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js"
+    ],
     "IE 8": [
         "test/aria/html/textinput/placeholder/PlaceholderTestCase.js",
         "test/aria/map/Google3MapProviderTestCase.js",
@@ -126,7 +129,6 @@ var generalBrowserExcludes = {
     ],
     "IE 9": [
         "test/aria/utils/bridge/BridgeTestCase.js",
-        "test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js",
         "test/aria/utils/hashManager/HashManagerOneTestCase.js",
         "test/aria/utils/mouse/MouseDragKoRobotTestCase.js",
         "test/aria/widgets/wai/dropdown/DatePickerDropdownTogglingRobotTestCase.js",


### PR DESCRIPTION
Was using the method "focus" instead of triggering a user click.

Also improved a bit the test.EnhancedRobotBase class to accept both id or element as input for some functions.
