### PR TITLE
Fixing LinkDisabledTestCase on IE 8 (by making it a robot test)

### DIFF
--- a/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCase.js
+++ b/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCase.js
@@ -14,12 +14,9 @@
  */
 
 Aria.classDefinition({
-    $classpath : "test.aria.widgets.action.link.disabled.LinkDisabledTestCase",
-    $extends : "aria.jsunit.TemplateTestCase",
+    $classpath : "test.aria.widgets.action.link.disabled.LinkDisabledRobotTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
     $dependencies : ["aria.utils.Dom", "aria.widgets.AriaSkinNormalization"],
-    $constructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
-    },
     $prototype : {
 
         setUp : function () {

--- a/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCaseTpl.tpl
+++ b/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCaseTpl.tpl
@@ -14,7 +14,7 @@
  */
 
 {Template {
-	$classpath: "test.aria.widgets.action.link.disabled.LinkDisabledTestCaseTpl",
+	$classpath: "test.aria.widgets.action.link.disabled.LinkDisabledRobotTestCaseTpl",
 	$hasScript: true
 }}
 	{var data = {link1Disabled : false, link2Disabled : true, clicksNumber1: 0, clicksNumber2: 0}/}

--- a/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCaseTplScript.js
+++ b/test/aria/widgets/action/link/disabled/LinkDisabledRobotTestCaseTplScript.js
@@ -14,7 +14,7 @@
  */
 
 Aria.tplScriptDefinition({
-    $classpath : "test.aria.widgets.action.link.disabled.LinkDisabledTestCaseTplScript",
+    $classpath : "test.aria.widgets.action.link.disabled.LinkDisabledRobotTestCaseTplScript",
     $prototype : {
 
         onToggleDisabledClick : function (evt) {


### PR DESCRIPTION
Now that `@aria:Link` widgets really have the disabled attribute when they are disabled, it seems IE 8 raises an error when aria.utils.SynEvent tries to click on them. This commit fixes this issue by using the robot implementation of SynEvent (aria.jsunit.SynEvent) instead of aria.utils.SynEvent.
