### PR TITLE
Using CORS instead of Flash by default for cross-domain requests

### DIFF
--- a/src/aria/core/IO.js
+++ b/src/aria/core/IO.js
@@ -178,7 +178,7 @@ module.exports = Aria.classDefinition({
          * @type String class name and path.
          * @private
          */
-        this.__crossDomain = "aria.core.transport.XDR";
+        this.__crossDomain = "aria.core.transport.XHR";
 
         /**
          * Contains the transport to be used for JsonP requests.

--- a/test/aria/core/io/IOTransportTestCase.js
+++ b/test/aria/core/io/IOTransportTestCase.js
@@ -28,7 +28,7 @@ Aria.classDefinition({
         tearDown : function () {
             aria.core.IO.updateTransports({
                 "sameDomain" : "aria.core.transport.XHR",
-                "crossDomain" : "aria.core.transport.XDR",
+                "crossDomain" : "aria.core.transport.XHR",
                 "jsonp" : "aria.core.transport.JsonP",
                 "local" : "aria.core.transport.Local",
                 "iframe" : "aria.core.transport.IFrame"
@@ -123,7 +123,7 @@ Aria.classDefinition({
             // Test the default settings for transports in IO.
             var transports = aria.core.IO.getTransports();
             this.assertTrue(transports.sameDomain === "aria.core.transport.XHR");
-            this.assertTrue(transports.crossDomain === "aria.core.transport.XDR");
+            this.assertTrue(transports.crossDomain === "aria.core.transport.XHR");
             this.assertTrue(transports.jsonp === "aria.core.transport.JsonP");
             this.assertTrue(transports.local === "aria.core.transport.Local");
             this.assertTrue(transports.iframe === "aria.core.transport.IFrame");

--- a/test/aria/core/io/IOXDRTestCase.js
+++ b/test/aria/core/io/IOXDRTestCase.js
@@ -33,6 +33,10 @@ Aria.classDefinition({
         needVisibleDocument : true,
 
         setUp : function () {
+            this.savedTransports = aria.core.IO.getTransports();
+            aria.core.IO.updateTransports({
+                crossDomain: 'aria.core.transport.XDR'
+            });
             aria.core.IO.$on({
                 '*' : this.checkEvent,
                 'request' : this.onEvent,
@@ -46,6 +50,7 @@ Aria.classDefinition({
         },
         tearDown : function () {
             aria.core.IO.$unregisterListeners(this);
+            aria.core.IO.updateTransports(this.savedTransports);
             this.url = null;
             this.$IOBase.tearDown.call(this);
         },


### PR DESCRIPTION
Now that CORS is largely implemented in browsers, this commit changes the default implementation of cross-domain requests to use CORS instead of the Flash-based implementation.

The Flash-based implementation can still be re-enabled by calling the `aria.core.IO.updateTransports` method in the following way:

```js
  aria.core.IO.updateTransports({
     'crossDomain' : 'aria.core.transport.XDR'
  });
```

Note that this change is NOT backward compatible. Applications relying on the Flash-based implementation of cross-domain requests should use the above lines of code or migrate to CORS.
