### PR TITLE
Skip updating manually hidden dialogs on viewport resize

### DIFF
--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -187,8 +187,9 @@ module.exports = Aria.classDefinition({
          */
         _onViewportResized : function (event) {
             var containerSize = this._popupContainer.getClientSize();
-            if (containerSize.width <= 0 || containerSize.height <= 0) {
+            if (!this._popup.isOpen || containerSize.width <= 0 || containerSize.height <= 0) {
                 // do nothing if the container is not visible
+                // or if the popup was manually hidden from external code
                 return;
             }
 

--- a/test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCase.js
+++ b/test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCase.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.hiddenViewportResize.HiddenDialogViewportResizeTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {};
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.hiddenViewportResize.HiddenDialogViewportResizeTestCaseTpl",
+            iframe: true,
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.json = this.templateCtxt._tpl.$json;
+            this.json.setValue(this.data, "dialogVisible", true);
+            this.waitFor({
+                condition: function () {
+                    if (!this.myItem) {
+                        this.myItem = this.getElementById("myItem");
+                    }
+                    if (this.myItem && !this.myPopup) {
+                        this.myPopup = this.testWindow.aria.popups.PopupManager.findParentPopup(this.myItem);
+                    }
+                    if (this.myPopup) {
+                        this.myPopupGeometry = this.testWindow.aria.utils.Dom.getGeometry(this.myPopup.domElement);
+                    }
+                    return !!this.myPopupGeometry;
+                },
+                callback: this._step1
+            });
+        },
+
+        _step1: function () {
+            this.myPopup.domElement.style.display = "none";
+            this.myPopup.isOpen = false;
+            this.currentWidth = this.testWindow.aria.templates.Layout.viewportSize.width;
+            this.testIframe.style.width = (this.testIframe.offsetWidth - 50) + "px";
+            this.waitFor({
+                condition: function () {
+                    return this.testWindow.aria.templates.Layout.viewportSize.width !== this.currentWidth;
+                },
+                callback: this._step2
+            });
+        },
+
+        _step2: function () {
+            this.myPopup.domElement.style.display = "block";
+            this.myPopup.isOpen = true;
+            var newGeometry = this.testWindow.aria.utils.Dom.getGeometry(this.myPopup.domElement);
+            this.assertEquals(newGeometry.width, this.myPopupGeometry.width);
+            this.assertEquals(newGeometry.height, this.myPopupGeometry.height);
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCaseTpl.tpl
+++ b/test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCaseTpl.tpl
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: "test.aria.widgets.container.dialog.hiddenViewportResize.HiddenDialogViewportResizeTestCaseTpl",
+}}
+
+    {macro main()}
+        {@aria:Dialog {
+            bind: {
+                visible : {
+                    to : "dialogVisible",
+                    inside : data
+                }
+            },
+            macro : "dialogMacro"
+        }/}
+    {/macro}
+
+    {macro dialogMacro()}
+        <div {id "myItem"/} style="width: 300px; height: 300px;">The content of the sub macro is not important</div>
+    {/macro}
+
+{/Template}

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -60,6 +60,7 @@ var phantomjsExcludesPatterns = [
     "test/aria/widgets/container/dialog/movable/test5/MovableDialogFiveRobotTestCase.js",
     "test/aria/widgets/container/dialog/container/*TestCase.js",
     "test/aria/widgets/wai/popup/dialog/modal/SecondRobotTestCase.js",
+    "test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCase.js",
     // Excluded because it often randomly fails with PhantomJS on travis-ci:
     "test/aria/widgets/container/tooltip/TooltipRobotTestCase.js"
 ];


### PR DESCRIPTION
If a dialog is manually hidden (by setting its `display` CSS property to `none` and by updating the corresponding `isOpen` boolean on the popup object), its size will no longer be updated on viewport resize.
This avoids setting the size of the popup to 0 (as offsetWidth and offsetHeight can return 0 for elements which are not visible on the screen).