### PR TITLE
feat #1721 WAI-ARIA - ActionWidget - Implement aria-hidden (waiLabelHidden)

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1201,6 +1201,11 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "Sets aria-labelledby on the widget, value will be used as the attribute's value"
                 },
+                "waiLabelHidden" : {
+                    $type : "json:Boolean",
+                    $description : "Sets aria-hidden on the label when set to true",
+                    $default : false
+                },
                 "waiHasPopup" : {
                     $type : "json:Boolean",
                     $description : "If true, sets aria-haspopup=\"true\" on the widget. Only used if waiAria is true."

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -208,6 +208,7 @@ module.exports = Aria.classDefinition({
          */
         _widgetMarkup : function (out) {
             var cfg = this._cfg;
+
             var tabIndexString = (cfg.tabIndex != null ? ' tabindex="' + this._calculateTabIndex() + '" ' : '');
             var isIE7 = ariaCoreBrowser.isIE7;
             var ariaTestMode = (Aria.testMode) ? ' id="' + this._domId + '_button" ' : '';
@@ -215,6 +216,7 @@ module.exports = Aria.classDefinition({
 
             var waiAriaAttributes = this._getWaiAriaMarkup();
             var disableMarkup = cfg.disabled ? " disabled='disabled' " : "";
+
             if (this._simpleHTML) {
                 var styleMarkup = cfg.width != "-1" ? " style='width:" + cfg.width + "px;' " : "";
 
@@ -275,7 +277,14 @@ module.exports = Aria.classDefinition({
          * @protected
          */
         _widgetMarkupContent : function (out) {
-            out.write(ariaUtilsString.escapeHTML(this._cfg.label));
+            var cfg = this._cfg;
+            var waiLabelHidden = cfg.waiLabelHidden;
+
+            out.write([
+                (waiLabelHidden ? '<span aria-hidden="true">' : ''),
+                    ariaUtilsString.escapeHTML(this._cfg.label),
+                (waiLabelHidden ? '</span>' : '')
+            ].join(''));
         },
 
         /**

--- a/src/aria/widgets/action/Link.js
+++ b/src/aria/widgets/action/Link.js
@@ -60,6 +60,8 @@ module.exports = Aria.classDefinition({
          */
         _widgetMarkup : function (out) {
             var cfg = this._cfg;
+            var waiLabelHidden = cfg.waiLabelHidden;
+
             var linkClass = "xLink_" + cfg.sclass;
             if (cfg.disabled) {
                 linkClass = "xLink_" + cfg.sclass + "_disabled xLink_disabled";
@@ -74,7 +76,9 @@ module.exports = Aria.classDefinition({
                     this._getWaiAriaMarkup(),
                     cfg.disabled ? ' disabled ' : '',
                 '>',
-                    ariaUtilsString.escapeHTML(cfg.label),
+                    (waiLabelHidden ? '<span aria-hidden="true">' : ''),
+                        ariaUtilsString.escapeHTML(cfg.label),
+                    (waiLabelHidden ? '</span>' : ''),
                 '</a>'
             ].join(''));
             cfg = null;

--- a/test/aria/widgets/wai/input/actionWidget/ariaHidden/ActionWidgetHiddenJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/ariaHidden/ActionWidgetHiddenJawsTestCase.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsAlgo = require('ariatemplates/utils/Algo');
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+var EnhancedJawsTestCase = require('test/EnhancedJawsBase');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath : 'test.aria.widgets.wai.input.actionWidget.ariaHidden.ActionWidgetHiddenJawsTestCase',
+    $extends : EnhancedJawsTestCase,
+
+    $constructor : function () {
+        this.$EnhancedJawsBase.constructor.call(this);
+
+        this._expectedHistory = [
+            'Link waiAria link',
+            'waiAria button', 'Button',
+            'waiAria button (simple)', 'Button',
+            'waiAria iconButton', 'Button',
+            'Link waiAria sortIndicator'
+        ].join('\n');
+
+        this.setTestEnv({
+            template : 'test.aria.widgets.wai.input.actionWidget.ariaHidden.Tpl',
+            data: {}
+        });
+    },
+
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    $prototype : {
+        skipRemoveDuplicates: true,
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        // Tests
+        ////////////////////////////////////////////////////////////////////////
+
+        runTemplateTest : function () {
+            var regexps = [];
+            regexps.push(this._createLineRegExp('focus me.*'));
+            regexps.push(this._createLineRegExp('AT tests.*'));
+
+            this._filter = function (content) {
+                return this._applyRegExps(regexps, content);
+            };
+
+            this._localAsyncSequence(function (add) {
+                add('_test');
+                add('_checkHistory');
+            }, this.end);
+        },
+
+
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        _test : function (callback) {
+            // --------------------------------------------------- destructuring
+
+            var document = Aria.$window.document;
+
+            var expectedHistory = this._expectedHistory;
+
+            var data = this._getData();
+            var elementBefore = data.elements.before;
+            var widgetsList = data.widgetsList;
+
+            // ------------------------------------------------------ processing
+
+            this._executeStepsAndWriteHistory(callback, function (api) {
+                // ----------------------------------------------- destructuring
+
+                var step = api.step;
+                var says = api.says;
+                var down = api.down;
+
+                // -------------------------------------------------- processing
+
+                step(['click', document.getElementById(elementBefore.id)]);
+                ariaUtilsAlgo.times(widgetsList.length, down);
+                says(expectedHistory);
+            });
+        }
+    }
+});
+

--- a/test/aria/widgets/wai/input/actionWidget/ariaHidden/Tpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/ariaHidden/Tpl.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath: 'test.aria.widgets.wai.input.actionWidget.ariaHidden.Tpl',
+	$hasScript: true
+}}
+
+{createView view on [] /}
+
+{macro main()}
+	<div class='user_focus' tabindex='0' id='${this.data.elements.before.id}'>${this.data.elements.before.content}</div>
+
+	{@aria:Link this.data.widgets.link.configuration /}
+	{@aria:Button this.data.widgets.button.configuration /}
+	{@aria:Button this.data.widgets.simpleButton.configuration /}
+	{@aria:IconButton this.data.widgets.iconButton.configuration /}
+	{@aria:SortIndicator this.data.widgets.sortIndicator.configuration /}
+{/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/actionWidget/ariaHidden/TplScript.js
+++ b/test/aria/widgets/wai/input/actionWidget/ariaHidden/TplScript.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var ariaUtilsArray = require('ariatemplates/utils/Array');
+
+
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath: 'test.aria.widgets.wai.input.actionWidget.ariaHidden.TplScript',
+    $destructor: function () {
+        this.view.$dispose();
+    },
+    $prototype: {
+        $dataReady: function() {
+            // -----------------------------------------------------------------
+
+            var data = this.data;
+
+            // -----------------------------------------------------------------
+
+            var elementBefore = {
+                id: 'element_before',
+                content: 'focus me'
+            };
+            var elements = {
+                before: elementBefore
+            };
+            data.elements = elements;
+
+            // -----------------------------------------------------------------
+
+            var widgetsList = [];
+
+            widgetsList.push({
+                key: 'link',
+                label: 'link'
+            });
+
+            widgetsList.push({
+                key: 'button',
+                label: 'button'
+            });
+
+            widgetsList.push({
+                key: 'simpleButton',
+                label: 'button (simple)',
+                configuration: {
+                    sclass: 'simple'
+                }
+            });
+
+            widgetsList.push({
+                key: 'iconButton',
+                label: 'iconButton',
+                onlyWaiLabel: true,
+                configuration: {
+                    icon: 'std:confirm',
+                    block: true,
+                    width: 150
+                }
+            });
+
+            widgetsList.push({
+                key: 'sortIndicator',
+                label: 'sortIndicator',
+                configuration: {
+                    sortName: 'SortByName',
+                    view: this.view
+                }
+            });
+
+            var widgetsMap = {};
+            ariaUtilsArray.forEach(widgetsList, function (widget) {
+                var key = widget.key;
+                var label = widget.label;
+                var onlyWaiLabel = widget.onlyWaiLabel;
+                var configuration = widget.configuration;
+                if (configuration == null) {
+                    configuration = {};
+                    widget.configuration = configuration;
+                }
+
+                configuration.waiAria = true;
+                configuration.waiLabelHidden = true;
+                if (!onlyWaiLabel) {
+                    configuration.label = label;
+                }
+                configuration.waiLabel = 'waiAria ' + label;
+
+                widgetsMap[key] = {
+                    widget: widget,
+                    configuration: configuration
+                };
+            });
+            data.widgets = widgetsMap;
+            data.widgetsList = widgetsList;
+        }
+    }
+});


### PR DESCRIPTION
Now it is possible to set `waiLabelHidden` for all `ActionWidget` based widgets, in order to put the attribute aria-hidden around their actual (visual) label element.

AT-1571
PTR 12373188
