### PR TITLE
Removing the "tab" role

### DIFF
--- a/src/aria/widgets/container/TabStyle.tpl.css
+++ b/src/aria/widgets/container/TabStyle.tpl.css
@@ -20,6 +20,15 @@
     {var skinnableClassName="Tab"/}
     {var useFrame=true/}
 
+    {macro main()}
+        a.xTabLink {
+            text-decoration: inherit;
+            color: inherit;
+            cursor: inherit;
+        }
+        {call $WidgetStyle.main()/}
+    {/macro}
+
     {macro writeStateOfTableFrame(info)}
         {call $WidgetStyle.writeStateOfTableFrame(info) /}
         {var prefix = cssPrefix(info)/}

--- a/test/aria/widgets/wai/tabs/TabsJawsTestCase.js
+++ b/test/aria/widgets/wai/tabs/TabsJawsTestCase.js
@@ -46,16 +46,13 @@ module.exports = Aria.classDefinition({
             // simple traversal with no selection ------------------------------
 
             // Tab 0
-            'Tab 0',
-            'Tab closed collapsed',
+            'Link collapsed Tab 0',
 
             // Tab 1
-            'Tab 1',
-            'Tab Unavailable closed collapsed',
+            'Link Unavailable collapsed Tab 1',
 
             // Tab 2
-            'Tab 2',
-            'Tab closed collapsed',
+            'Link collapsed Tab 2',
 
             // TabPanel
             'tab panel start',
@@ -66,16 +63,13 @@ module.exports = Aria.classDefinition({
             // selecting last Tab ----------------------------------------------
 
             // Tab 0
-            'Tab 0',
-            'Tab closed collapsed',
+            'Link collapsed Tab 0',
 
             // Tab 1
-            'Tab 1',
-            'Tab Unavailable closed collapsed',
+            'Link Unavailable collapsed Tab 1',
 
             // Tab 2
-            'Tab 2',
-            'Tab closed collapsed',
+            'Link collapsed Tab 2',
             // glitch: since the focus is immediately moved (see next comment), the state of the Tab can not be read
 
             // selecting a Tab means focusing the first element inside the TabPanel
@@ -85,16 +79,13 @@ module.exports = Aria.classDefinition({
             // simple traversal with a Tab selected ----------------------------
 
             // Tab 0
-            'Tab 0',
-            'Tab closed collapsed',
+            'Link collapsed Tab 0',
 
             // Tab 1
-            'Tab 1',
-            'Tab Unavailable closed collapsed',
+            'Link Unavailable collapsed Tab 1',
 
             // Tab 2
-            'Tab 2',
-            'Tab open expanded',
+            'Link expanded Tab 2',
 
             // TabPanel: now the title of the controlling Tab is read
             'tab panel start Tab 2',

--- a/test/aria/widgets/wai/tabs/update1/TabsUpdate1JawsTestCase.js
+++ b/test/aria/widgets/wai/tabs/update1/TabsUpdate1JawsTestCase.js
@@ -215,48 +215,30 @@ module.exports = Aria.classDefinition({
                 }
 
                 function getTabDescription(tab, useJawsNavigation) {
-                    // ---------------------------------------------------------
-
                     var description = [];
-
-                    // ---------------------------------------------------------
-
                     if (useJawsNavigation) {
                         if (tab.wrapper != null) {
                             description.push(tab.wrapperText);
+                        }
+                        description.push('Link collapsed');
+                        if (!tab.labelId) {
+                            description.push(tab.title);
                         } else {
-                            says(tab.textContent);
+                            description.push(tab.textContent);
                         }
                     } else {
                         description.push(tab.title);
-                    }
-
-                    // ---------------------------------------------------------
-
-                    description.push('Tab');
-                    if (useJawsNavigation) {
-                        description.push('closed');
-                    }
-                    description.push('collapsed');
-                    if (!useJawsNavigation) {
-                        description.push('Use JawsKey+Alt+R to read descriptive text');
-                    }
-                    if (useJawsNavigation && tab.wrapper != null) {
-                        description.push(tab.textContent);
+                        if (tab.wrapper != null) {
+                            description.push(tab.wrapperText);
+                            description.push('Link collapsed');
+                        } else {
+                            description.push('collapsed Link');
+                        }
                     }
                     says(description.join(' '));
-
-                    // ---------------------------------------------------------
-
-                    if (!useJawsNavigation) {
-                        if (tab.labelId) {
-                            says(tab.textContent);
-                        }
-
-                        if (tab.description != null) {
-                            says(tab.description);
-                        }
-                        says('To activate tab page press Spacebar.');
+                    
+                    if (!useJawsNavigation && tab.description != null) {
+                        says(tab.description);
                     }
                 }
 
@@ -264,7 +246,10 @@ module.exports = Aria.classDefinition({
                     var stepForward = useJawsNavigation ? down : tabulation;
 
                     ariaUtilsArray.forEach(tabs, function (tab, index) {
-                        if (useJawsNavigation && tab.hidden) {
+                        if (tab.hidden) {
+                            if (!useJawsNavigation) {
+                                stepForward();
+                            }
                             return;
                         }
 


### PR DESCRIPTION
Blind users do not like the "tab" role because, just as the "application" role, it prevents them from using their navigation shortcuts. This commit simply removes the role attribute for tabs, and also adds the href attribute on the anchors so that tabs are recognized as links.