### PR TITLE
Removing role="button" and adding a tabindex on dropdown icons

### DIFF
--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -109,6 +109,13 @@ module.exports = Aria.classDefinition({
         _frame_events : function (evt) {
             if (evt.iconName == "dropdown" && !this._cfg.disabled) {
                 var evtName = evt.name;
+                if (evtName == "iconKeyDown") {
+                    var keyCode = evt.event.keyCode;
+                    if (keyCode == 13 || keyCode == 32) {
+                        evtName = "iconClick";
+                    }
+                }
+
                 if (evtName == "iconMouseDown") {
                     evt.event.preventDefault(true);
                 } else if (evtName == "iconClick") {

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -43,8 +43,11 @@ module.exports = Aria.classDefinition({
             "dropdown": 'unselectable="on"' + iconTooltip
         };
         if (cfg.waiAria) {
-            this._iconsAttributes.dropdown += ' role="button" aria-expanded="false" aria-haspopup="true"' +
-                (cfg.waiIconLabel ? ' aria-label="' + cfg.waiIconLabel + '"' : "");
+            var tabIndex = cfg.tabIndex != null ? this._calculateTabIndex() : "0";
+            this._iconsAttributes.dropdown += ' tabindex="' + tabIndex + '" aria-expanded="false" aria-haspopup="true"';
+            this._iconsWaiLabel = {
+                "dropdown": cfg.waiIconLabel || cfg.iconTooltip
+            };
         }
     },
     $destructor : function () {
@@ -240,7 +243,9 @@ module.exports = Aria.classDefinition({
         setCaretPosition : function () {
             this._updateFocusNoKeyboard();
             if (!this._focusNoKeyboard) {
-                this.$TextInput.setCaretPosition.apply(this, arguments);
+                if (Aria.$window.document.activeElement !== this._getDropdownIcon()) {
+                    this.$TextInput.setCaretPosition.apply(this, arguments);
+                }
             }
         },
 

--- a/src/aria/widgets/form/InputWithFrame.js
+++ b/src/aria/widgets/form/InputWithFrame.js
@@ -55,6 +55,11 @@ module.exports = Aria.classDefinition({
         this._iconsAttributes = null;
 
         /**
+         * Map of wai label for each icon name.
+         */
+        this._iconsWaiLabel = null;
+
+        /**
          * Flag for input that has to be displayed in full width
          * @type Boolean
          * @protected
@@ -126,6 +131,7 @@ module.exports = Aria.classDefinition({
                 scrollBarX : false,
                 scrollBarY : false,
                 iconsAttributes : this._iconsAttributes,
+                iconsWaiLabel : this._iconsWaiLabel,
                 hideIconNames : this._hideIconNames,
                 inlineBlock : true,
                 // used for table frame, defaults to false

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -21,7 +21,6 @@ var ariaWidgetsFormListListStyle = require("./list/ListStyle.tpl.css");
 var ariaWidgetsContainerDivStyle = require("../container/DivStyle.tpl.css");
 var ariaWidgetsFormCheckBoxStyle = require("./CheckBoxStyle.tpl.css");
 var ariaWidgetsFormDropDownTextInput = require("./DropDownTextInput");
-var ariaUtilsString = require("../../utils/String");
 var DomNavigationManager = require("../../utils/DomNavigationManager");
 
 /**
@@ -86,19 +85,6 @@ module.exports = Aria.classDefinition({
          * @type aria.widgets.form.list.List
          */
         this._dropDownList = null;
-
-        var isWaiAria = cfg.waiAria;
-        var iconTooltip = cfg.iconTooltip ? ' title="' + ariaUtilsString.escapeForHTML(cfg.iconTooltip) + '"' : '';
-        var tabIndex = isWaiAria ? (cfg.tabIndex != null ? this._calculateTabIndex() : "0") : "-1";
-        this._iconsAttributes = {
-            "dropdown": 'tabindex="' + tabIndex + '"' + iconTooltip
-        };
-
-        if (isWaiAria) {
-            var waiIconLabel = cfg.waiIconLabel;
-            this._iconsAttributes.dropdown += ' role="button" aria-expanded="false" aria-haspopup="true"  ' +
-               (waiIconLabel ? 'aria-label="' + waiIconLabel + '" ' : "");
-        }
     },
     $destructor : function () {
         this._dropDownOpen = null;
@@ -181,7 +167,7 @@ module.exports = Aria.classDefinition({
         _toggleDropdown : function () {
             this._updateFocusNoKeyboard(true);
             if (!this._hasFocus) {
-                this.focus();
+                this.focus(null, true);
             }
             this._keepFocus = false;
 

--- a/src/aria/widgets/frames/CfgBeans.js
+++ b/src/aria/widgets/frames/CfgBeans.js
@@ -109,6 +109,14 @@ module.exports = Aria.beanDefinitions({
                     },
                     $default : {}
                 },
+                "iconsWaiLabel" : {
+                    $type : "json:Map",
+                    $description : "Describes, for each icon name, the accessible label to set in the markup. It is inserted as a child span element with class xSROnly.",
+                    $contentType : {
+                        $type : "json:String"
+                    },
+                    $default : {}
+                },
                 "hideIconNames" : {
                     $type : "json:Array",
                     $description : "Array of icon names which will not be displayed. This property is taken into account only when calling aria.widgets.frames.FrameWithIcons.createFrame.",

--- a/src/aria/widgets/frames/FrameWithIcons.js
+++ b/src/aria/widgets/frames/FrameWithIcons.js
@@ -54,6 +54,7 @@ module.exports = Aria.classDefinition({
         this._tooltipLabels = cfg.tooltipLabels;
 
         this._iconsAttributes = cfg.iconsAttributes;
+        this._iconsWaiLabel = cfg.iconsWaiLabel;
 
         ariaUtilsArray.forEach(this._iconsLeft, this._initIcon, this);
         ariaUtilsArray.forEach(this._iconsRight, this._initIcon, this);
@@ -455,10 +456,14 @@ module.exports = Aria.classDefinition({
 
             var title = icon.tooltip ? ' title="' + ariaUtilsString.escapeForHTML(icon.tooltip) + '"' : '';
             var attributes = this._iconsAttributes[iconName] || 'tabIndex="-1"';
+            var waiLabel = this._iconsWaiLabel[iconName] || "";
+            if (waiLabel) {
+                waiLabel = '<span class="xSROnly">' + ariaUtilsString.escapeForHTML(waiLabel) + '</span>';
+            }
 
             out.write(['<span', Aria.testMode && this._baseId ? ' id="' + this._baseId + '_' + iconName + '"' : '',
                     ' class="', iconInfo.cssClass, '" style="', iconStyle,
-                    '" ', utilDelegate.getMarkup(delegateId), title, ' ', attributes, '>&nbsp;</span>'].join(''));
+                    '" ', utilDelegate.getMarkup(delegateId), title, ' ', attributes, '>', waiLabel, '&nbsp;</span>'].join(''));
         },
 
         _linkIconToDom : function (icon, param) {

--- a/test/aria/widgets/wai/datePicker/DatePicker1JawsTestCase.js
+++ b/test/aria/widgets/wai/datePicker/DatePicker1JawsTestCase.js
@@ -42,7 +42,7 @@ Aria.classDefinition({
                 ["pause", 1000]
             ], {
                 fn: function () {
-                    this.assertJawsHistoryEquals("Next field Edit\nType in text.\nNext field\nDisplay calendar button menu collapsed\nCalendar table. Use arrow keys to navigate and space to validate.\nFriday 1 January 2016\nFriday 8 January 2016\nFriday 15 January 2016\nTravel date Edit\n15/1/16\nType in text.", this.end);
+                    this.assertJawsHistoryEquals("Next field Edit\nType in text.\nNext field\nDisplay calendar\nCalendar table. Use arrow keys to navigate and space to validate.\nFriday 1 January 2016\nFriday 8 January 2016\nFriday 15 January 2016\nTravel date Edit\n15/1/16\nType in text.", this.end);
                 },
                 scope: this
             });

--- a/test/aria/widgets/wai/datePicker/readDate/DatePickerReadDateJawsTestCase.js
+++ b/test/aria/widgets/wai/datePicker/readDate/DatePickerReadDateJawsTestCase.js
@@ -114,7 +114,7 @@ module.exports = Aria.classDefinition({
                 down();
                 says('Edit 6/9/16');
                 down();
-                says('calendar one button', 'button menu collapsed');
+                says('calendar one button');
 
                 // -------------------------------------------------------------
                 // Opening calendar and selecting the next date

--- a/test/aria/widgets/wai/dropdown/icon/DropDownIconJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/icon/DropDownIconJawsTestCase.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.icon.DropDownIconJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.icon.Tpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/type/i);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500]
+            ];
+            for (var i = 0; i < 9; i++) {
+                actions.push(["type", null, "[tab]"], ["pause", 500]);
+            }
+            actions.push(["type", null, "[enter]"], ["pause", 500]);
+            actions.push(["type", null, "b"], ["pause", 500]); // buttons
+            actions.push(["type", null, "c"], ["pause", 500]); // controls
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel Edit",
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel Edit",
+                        "DropDownLabelForAutoComplete",
+                        "SelectBoxLabel Edit",
+                        "DropDownLabelForSelectBox",
+                        "MultiSelectLabel Edit",
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel Edit",
+                        "There are no Buttons on this page.",
+                        "There are no Selectable ARIA controls, comboboxes, listboxes or treeviews on this page."
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/icon/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/icon/Tpl.tpl
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.dropdown.icon.Tpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        <div class="root">
+            <input {id "firstItem"/} aria-label="FirstFieldLabel"> <br>
+            {@aria:DatePicker {
+                waiAria: true,
+                label: "DatePickerLabel",
+                waiIconLabel: "DropDownLabelForDatePicker",
+                id: "myDatePicker"
+            }/} <br>
+            {@aria:AutoComplete {
+                waiAria: true,
+                label: "AutoCompleteLabel",
+                waiIconLabel: "DropDownLabelForAutoComplete",
+                id: "myAutoCompleteWithExpandButton",
+                expandButton: true,
+                resourcesHandler: getAutoCompleteHandler()
+            }/} <br>
+            {@aria:SelectBox {
+                waiAria: true,
+                label: "SelectBoxLabel",
+                waiIconLabel: "DropDownLabelForSelectBox",
+                id: "mySelectBox",
+                options: items
+            }/} <br>
+            {@aria:MultiSelect {
+                waiAria: true,
+                label: "MultiSelectLabel",
+                waiIconLabel: "DropDownLabelForMultiSelect",
+                id: "myMultiSelect",
+                items: items
+            }/} <br>
+            <input {id "lastItem"/} aria-label="LastFieldLabel"> <br>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/dropdown/icon/TplScript.js
+++ b/test/aria/widgets/wai/dropdown/icon/TplScript.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.icon.TplScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        this.items = [{
+                    label : "Touch device",
+                    code : "Touch device",
+                    value : "Touch device"
+                }, {
+                    label : "Desktop device",
+                    code : "Desktop device",
+                    value : "Desktop device"
+                }];
+    },
+    $destructor : function () {
+        if (this.acHandler) {
+            this.acHandler.$dispose();
+            this.acHandler = null;
+        }
+    },
+    $prototype : {
+        getAutoCompleteHandler : function () {
+            if (!this.acHandler) {
+                var acHandler = new aria.resources.handlers.LCResourcesHandler();
+                acHandler.setSuggestions(this.items);
+                this.acHandler = acHandler;
+            }
+            return this.acHandler;
+        }
+    }
+});

--- a/test/aria/widgets/wai/iconLabel/IconLabelJawsTestCase.js
+++ b/test/aria/widgets/wai/iconLabel/IconLabelJawsTestCase.js
@@ -55,7 +55,7 @@ Aria.classDefinition({
             ], {
                 fn: function () {
                     this.assertJawsHistoryEquals(
-                        "First textfield Edit\nType in text.\nCity Edit\nType in text.\nPress space to open the autocomplete list button menu collapsed\nTravel date Edit\nType in text.\nPress space to open the calendar button menu collapsed\nMulti-select: Edit\nType in text.\nPress space to open the selection list button menu collapsed\nAll Countries: Edit\nType in text.\nPress space to open the selection list\nbutton menu collapsed",
+                        "First textfield Edit\nType in text.\nCity Edit\nType in text.\nPress space to open the autocomplete list\nTravel date Edit\nType in text.\nPress space to open the calendar\nMulti-select: Edit\nType in text.\nPress space to open the selection list\nAll Countries: Edit\nType in text.\nPress space to open the selection list",
                         this.end
                     );
                 },

--- a/test/aria/widgets/wai/input/label/DatePickerJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/DatePickerJawsTestCase.js
@@ -19,6 +19,9 @@ module.exports = Aria.classDefinition({
     $classpath : "test.aria.widgets.wai.input.label.DatePickerJawsTestCase",
     $extends : require("./LabelJawsBase"),
     $prototype : {
-        elementsToTest : "dpWaiEnabledStart"
+        elementsToTest : "dpWaiEnabledStart",
+
+        // The DatePicker needs extra tabs now that the icon is focusable:
+        nbTabs: 4
     }
 });

--- a/test/aria/widgets/wai/input/label/LabelJawsBase.js
+++ b/test/aria/widgets/wai/input/label/LabelJawsBase.js
@@ -23,13 +23,22 @@ Aria.classDefinition({
         });
     },
     $prototype : {
+        nbTabs: 2,
+
         runTemplateTest : function () {
             this._testElement();
         },
         _testElement : function () {
             var domElement = this.getElementById(this.elementsToTest);
-            this.synEvent.execute([["ensureVisible", domElement], ["click", domElement], ["pause", 1000],
-                    ["type", null, "[tab]"], ["pause", 1000], ["type", null, "[tab]"], ["pause", 1000]], {
+            var actions = [
+                ["ensureVisible", domElement],
+                ["click", domElement], ["pause", 1000]
+            ];
+            var nbTabs = this.nbTabs;
+            for (var i = 0 ; i < nbTabs ; i++) {
+                actions.push(["type", null, "[tab]"], ["pause", 1000]);
+            }
+            this.synEvent.execute(actions, {
                 fn : this._testValue,
                 scope : this
             });

--- a/test/aria/widgets/wai/input/label/MultiSelectJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/MultiSelectJawsTestCase.js
@@ -21,20 +21,7 @@ module.exports = Aria.classDefinition({
     $prototype : {
         elementsToTest : "msWaiEnabledStart",
 
-        _testElement : function () {
-            var domElement = this.getElementById(this.elementsToTest);
-            // The Multiselect needs extra tabs now that the icon is focusable:
-            this.synEvent.execute([
-                ["ensureVisible", domElement],
-                ["click", domElement], ["pause", 1000],
-                ["type", null, "[tab]"], ["pause", 1000],
-                ["type", null, "[tab]"], ["pause", 1000],
-                ["type", null, "[tab]"], ["pause", 1000],
-                ["type", null, "[tab]"], ["pause", 1000]
-            ], {
-                fn : this._testValue,
-                scope : this
-            });
-        }
+        // The Multiselect needs extra tabs now that the icon is focusable:
+        nbTabs: 4
     }
 });

--- a/test/aria/widgets/wai/input/label/SelectBoxJawsTestCase.js
+++ b/test/aria/widgets/wai/input/label/SelectBoxJawsTestCase.js
@@ -19,6 +19,9 @@ module.exports = Aria.classDefinition({
     $classpath : "test.aria.widgets.wai.input.label.SelectBoxJawsTestCase",
     $extends : require("./LabelJawsBase"),
     $prototype : {
-        elementsToTest : "sbWaiEnabledStart"
+        elementsToTest : "sbWaiEnabledStart",
+
+        // The SelectBox needs extra tabs now that the icon is focusable:
+        nbTabs: 4
     }
 });

--- a/test/aria/widgets/wai/multiselect/MultiSelectJawsTestCase.js
+++ b/test/aria/widgets/wai/multiselect/MultiSelectJawsTestCase.js
@@ -64,7 +64,7 @@ Aria.classDefinition({
             ], {
                 fn: function () {
                     this.assertJawsHistoryEquals(
-                        "Here is the default Multi-Select: Edit\nType in text.\nMy Multi-select:\nEdit\nAir Canada check box checked\nAir France check box not checked\nAir France check box checked\nAir New Zealand check box not checked\nBritish Airways check box not checked\nBritish Airways check box checked\nDelta Airlines check box not checked Unavailable\nMy Multi-select: Edit\nAir Canada,Air France,British Airways\nType in text.\nPress space to open the selection list button menu collapsed\nAir Canada check box checked",
+                        "Here is the default Multi-Select: Edit\nType in text.\nMy Multi-select:\nEdit\nAir Canada check box checked\nAir France check box not checked\nAir France check box checked\nAir New Zealand check box not checked\nBritish Airways check box not checked\nBritish Airways check box checked\nDelta Airlines check box not checked Unavailable\nMy Multi-select: Edit\nAir Canada,Air France,British Airways\nType in text.\nPress space to open the selection list\nAir Canada check box checked",
                     this.end,
                     function(response) {
                         return this.removeDuplicates(response.

--- a/test/aria/widgets/wai/multiselect/MultiSelectTabJawsTestCase.js
+++ b/test/aria/widgets/wai/multiselect/MultiSelectTabJawsTestCase.js
@@ -78,7 +78,7 @@ Aria.classDefinition({
             ], {
                 fn: function () {
                     this.assertJawsHistoryEquals(
-                        "Here is the default Multi-Select: Edit\nType in text.\nMy Multi-select:\nEdit\nAir Canada check box checked\nAir France check box not checked\nAir New Zealand check box not checked\nBritish Airways check box not checked\nDelta Airlines check box not checked\nSelect All Link\nDeselect All Link\nClose Link\nMy Multi-select: Edit\nAir Canada,Air France,British Airways\nType in text.\nPress space to open the selection list\nbutton menu collapsed\nAir Canada check box checked\nAir France check box checked\nAir France check box not checked\nMy Multi-select: Edit\nAir Canada,British Airways\nType in text.",
+                        "Here is the default Multi-Select: Edit\nType in text.\nMy Multi-select:\nEdit\nAir Canada check box checked\nAir France check box not checked\nAir New Zealand check box not checked\nBritish Airways check box not checked\nDelta Airlines check box not checked\nSelect All Link\nDeselect All Link\nClose Link\nMy Multi-select: Edit\nAir Canada,Air France,British Airways\nType in text.\nPress space to open the selection list\nAir Canada check box checked\nAir France check box checked\nAir France check box not checked\nMy Multi-select: Edit\nAir Canada,British Airways\nType in text.",
                     this.end,
                     function(response) {
                         return this.removeDuplicates(response.

--- a/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldJawsTestCase.js
+++ b/test/aria/widgets/wai/multiselect/readOnlyTextField/ReadOnlyTextFieldJawsTestCase.js
@@ -30,8 +30,6 @@ Aria.classDefinition({
          * This method is always the first entry point to a template test Start the test by focusing the first field
          */
         runTemplateTest : function () {
-            var checkedRegExp = /not checked\nchecked/g;
-            var notCheckedRegExp = /checked\nnot checked/g;
             var chechBoxStartingLineRegExp = /\ncheck box/g;
 
             this.synEvent.execute([
@@ -49,20 +47,15 @@ Aria.classDefinition({
                         "What do you need to be happy? read only edit",
                         "Press down then space to open the list of check boxes.",
                         "Press space to open the list of check boxes",
-                        "button menu collapsed",
                         "God check box not checked",
-                        "God check box checked",
+                        "checked",
                         "What do you need to be happy? read only edit",
                         "God",
                         "Press down then space to open the list of check boxes."
                     ].join("\n"),
                     this.end,
                     function(response) {
-                        return this.removeDuplicates(response.
-                            replace(chechBoxStartingLineRegExp, " check box").
-                            replace(checkedRegExp, "checked").
-                            replace(notCheckedRegExp, "not checked")
-                        );
+                        return this.removeDuplicates(response.replace(chechBoxStartingLineRegExp, " check box"));
                     });
                 },
                 scope: this


### PR DESCRIPTION
This commit removes the `role="button"` attribute and adds a `tabindex` on the dropdown icon of the widgets which extend `DropDownTextInput` (`DatePicker`, `MultiSelect`...), so that those icons are not included in the list of buttons displayed by screen readers and become focusable by tab.