### PR TITLE
fix #1726 - WAI-ARIA - DatePicker - Date was read even with keystrokes not changing text

### DIFF
--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -69,7 +69,7 @@ module.exports = Aria.classDefinition({
                     previousText: null
                 },
                 onStart: function (state) {
-                    state.inputText = self.getTextInputField().value;
+                    state.previousText = self.getTextInputField().value;
                 },
                 onEnd: function (state) {
                     var text = self.getTextInputField().value;

--- a/test/aria/widgets/wai/datePicker/readDate/DatePickerReadDateJawsTestCase.js
+++ b/test/aria/widgets/wai/datePicker/readDate/DatePickerReadDateJawsTestCase.js
@@ -88,6 +88,7 @@ module.exports = Aria.classDefinition({
                 var says = api.says;
                 var delay = api.delay;
                 var key = api.key;
+                var specialKey = api.specialKey;
 
                 var down = api.down;
                 var enter = api.enter;
@@ -141,6 +142,12 @@ module.exports = Aria.classDefinition({
                 key('[backspace]5');
                 says('6'); // says removed letter, but not the one typed in
                 says('Monday 7 September 2015'); // date is read
+
+                // -------------------------------------------------------------
+                // Checking that keystrokes not changing text don't trigger a read
+
+                specialKey('left');
+                says('5');
             });
         }
     }


### PR DESCRIPTION
An internal variable was not properly used to implement the feature, the fix was trivial. Test has been enhanced to check this use case.
