### PR TITLE
fix/test #1729 Fixed test.aria.utils.accessibility.AccessibilityJawsTestCase

### DIFF
--- a/test/aria/utils/accessibility/AccessibilityJawsTestCase.js
+++ b/test/aria/utils/accessibility/AccessibilityJawsTestCase.js
@@ -97,6 +97,7 @@ module.exports = Aria.classDefinition({
             this._localAsyncSequence(function (add) {
                 add(readText('Hello', true));
                 add(readText('World', false));
+                add('_delay', 3000);
             }, callback);
         }
     }


### PR DESCRIPTION
In some testing environments, the screen reader has to read multiple things, so it's better to wait longer so that everything is read properly.