### PR TITLE
Adding a focusable element at the top of the TabPanel widget

### DIFF
--- a/src/aria/widgets/container/TabPanelStyle.tpl.css
+++ b/src/aria/widgets/container/TabPanelStyle.tpl.css
@@ -19,5 +19,17 @@
 }}
     {var skinnableClassName="TabPanel"/}
     {var useFrame=true/}
+
+    {macro main()}
+        .xTabPanelZone {
+            position: absolute;
+            left: 0px;
+            top: 0px;
+            right: 0px;
+            bottom: 0px;
+        }
+
+        {call $WidgetStyle.main()/}
+    {/macro}
     
 {/CSSTemplate}

--- a/test/aria/widgets/wai/tabs/TabsJawsTestCase.js
+++ b/test/aria/widgets/wai/tabs/TabsJawsTestCase.js
@@ -73,8 +73,7 @@ module.exports = Aria.classDefinition({
             // glitch: since the focus is immediately moved (see next comment), the state of the Tab can not be read
 
             // selecting a Tab means focusing the first element inside the TabPanel
-            'Edit',
-            'Type in text.',
+            'Tab 2',
 
             // simple traversal with a Tab selected ----------------------------
 
@@ -89,6 +88,7 @@ module.exports = Aria.classDefinition({
 
             // TabPanel: now the title of the controlling Tab is read
             'tab panel start Tab 2',
+            'Tab 2',
             'WaiAria activated: true',
             'Edit',
             'tab panel end'
@@ -168,7 +168,7 @@ module.exports = Aria.classDefinition({
                 }
 
                 function goThroughTabpanel() {
-                    ariaUtilsAlgo.times(5, down);
+                    ariaUtilsAlgo.times(7, down);
                 }
 
                 // -------------------------------------------------- processing


### PR DESCRIPTION
This focusable element is only added when `waiAria` is true, and has the same `aria-labelledby` attribute as the root element of the tab panel, so that, when focusing the tab panel, the title of the currently selected tab is read by screen readers.
