### PR TITLE
Adding the focusableWhenDisabled parameter on aria:Button widgets

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1239,6 +1239,11 @@ module.exports = Aria.beanDefinitions({
                 "tabIndex" : {
                     $type : "WidgetCfg.tabIndex",
                     $default : 0
+                },
+                "focusableWhenDisabled" : {
+                    $type : "json:Boolean",
+                    $description : "Whether the button can be focused when it is disabled.",
+                    $default : false
                 }
             }
         },

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -144,25 +144,19 @@ module.exports = Aria.classDefinition({
                 this.getDom();
                 if (!this._simpleHTML) {
                     this._frame.changeState(this._state);
-                    var ie8plus = ariaCoreBrowser.isOldIE && ariaCoreBrowser.majorVersion >= 8;
                     if (state == "disabled") {
                         this._focusElt.className = "xButton xButtonDisabled";
-                        if (ie8plus) {
-                            this._focusElt.onfocusin = function () {
-                                this.blur();
-                            };
-                        }
                     } else {
                         this._focusElt.className = "xButton";
-                        if (ie8plus) {
-                            this._focusElt.onfocusin = null;
-                        }
                     }
                 }
-                if (state == "disabled") {
-                    this._focusElt.setAttribute("disabled", "disabled");
-                } else {
-                    this._focusElt.removeAttribute("disabled");
+                var disabledAttribute = cfg.focusableWhenDisabled ? (cfg.waiAria ? "aria-disabled" : null) : "disabled";
+                if (disabledAttribute) {
+                    if (state == "disabled") {
+                        this._focusElt.setAttribute(disabledAttribute, "true");
+                    } else {
+                        this._focusElt.removeAttribute(disabledAttribute);
+                    }
                 }
             }
         },
@@ -214,7 +208,14 @@ module.exports = Aria.classDefinition({
             var buttonClass = cfg.disabled ? "xButton xButtonDisabled" : "xButton";
 
             var waiAriaAttributes = this._getWaiAriaMarkup();
-            var disableMarkup = cfg.disabled ? " disabled='disabled' " : "";
+            var disableMarkup = "";
+            if (cfg.disabled) {
+                if (!cfg.focusableWhenDisabled) {
+                    disableMarkup = " disabled ";
+                } else if (cfg.waiAria) {
+                    disableMarkup = " aria-disabled='true' ";
+                }
+            }
             if (this._simpleHTML) {
                 var styleMarkup = cfg.width != "-1" ? " style='width:" + cfg.width + "px;' " : "";
 
@@ -239,17 +240,11 @@ module.exports = Aria.classDefinition({
                     out.write(['<span class="' + buttonClass + '" style="margin: 0;"', waiAriaAttributes, tabIndexString, ariaTestMode,
                             '>'].join(''));
                 } else {
-                    // PTR 05613372: prevent 'clickability' of greyed out button. Adding "disabled" makes adjusting the
-                    // text color impossible in IE, thus onfocusin used (more suitable for this use case than onfocus)
-                    var onFocusInString = (ariaCoreBrowser.isOldIE && cfg.disabled)
-                            ? " onfocusin='this.blur()' "
-                            : "";
                     out.write([
                         '<button',
                         ' type="button"',
                         ' class="' + buttonClass + '"',
                         waiAriaAttributes,
-                        onFocusInString,
                         tabIndexString,
                         ariaTestMode,
                         disableMarkup,

--- a/src/aria/widgets/action/ButtonStyle.tpl.css
+++ b/src/aria/widgets/action/ButtonStyle.tpl.css
@@ -49,6 +49,10 @@
             cursor:default;
         }
 
+        .xButtonDisabled:focus {
+            outline: 1px dotted black;
+        }
+
         {call startLooping()/}
     {/macro}
 

--- a/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCase.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var ariaUtilsJson = require("ariatemplates/utils/Json");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.actionWidget.buttonFocusableWhenDisabled.FocusableDisabledButtonJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $prototype : {
+        runTemplateTest : function () {
+            var data = this.templateCtxt.data;
+            this.noiseRegExps.push(/^Type/i);
+
+            this.assertFalsy(data.firstButtonNbClicks),
+            this.assertFalsy(data.secondButtonNbClicks),
+            this.assertFalsy(data.thirdButtonNbClicks),
+            this.assertFalsy(data.fourthButtonNbClicks),
+
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                ["type", null, "[tab]"], ["pause", 200]
+            ], {
+                fn: function () {
+                    this.assertEquals(Aria.$window.document.activeElement, this.getElementById("tf2"));
+                    this.assertFalsy(data.firstButtonNbClicks),
+                    this.assertEquals(data.secondButtonNbClicks, 1),
+                    this.assertFalsy(data.thirdButtonNbClicks),
+                    this.assertEquals(data.fourthButtonNbClicks, 1),
+                    ariaUtilsJson.setValue(data, "firstButtonDisabled", false);
+                    ariaUtilsJson.setValue(data, "secondButtonDisabled", true);
+                    ariaUtilsJson.setValue(data, "thirdButtonDisabled", false);
+                    ariaUtilsJson.setValue(data, "fourthButtonDisabled", true);
+                    this.synEvent.execute([
+                        ["click", this.getElementById("tf1")], ["pause", 100],
+                        ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                        ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                        ["type", null, "[tab]"], ["pause", 200], ["type", null, "[space]"], ["pause", 200],
+                        ["type", null, "[tab]"], ["pause", 200]
+                    ], {
+                        fn: function () {
+                            this.assertEquals(Aria.$window.document.activeElement, this.getElementById("tf2"));
+                            this.assertEquals(data.firstButtonNbClicks, 1),
+                            this.assertEquals(data.secondButtonNbClicks, 1),
+                            this.assertEquals(data.thirdButtonNbClicks, 1),
+                            this.assertEquals(data.fourthButtonNbClicks, 1),
+                            this.assertJawsHistoryEquals([
+                                "First field Edit",
+                                "First button Button Unavailable",
+                                "Second button Button",
+                                "Fourth button Button",
+                                "Last field Edit",
+                                "First field Edit",
+                                "First button Button",
+                                "Second button Button Unavailable",
+                                "Third button Button",
+                                "Last field Edit"
+                            ].join("\n"), this.end);
+                        },
+                        scope: this
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCaseTpl.tpl
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath: "test.aria.widgets.wai.input.actionWidget.buttonFocusableWhenDisabled.FocusableDisabledButtonJawsTestCaseTpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        <div style="margin:10px;">
+            <input {id "tf1"/} aria-label="First field"><br>
+            {@aria:Button {
+                waiAria: true,
+                focusableWhenDisabled: true,
+                disabled: true,
+                label: "First button",
+                bind: {
+                    disabled: {
+                        to: "firstButtonDisabled",
+                        inside: data
+                    }
+                },
+                onclick: {
+                    fn: buttonClicked,
+                    scope: this,
+                    args: "firstButton"
+                }
+            } /}<br>
+            {@aria:Button {
+                waiAria: true,
+                focusableWhenDisabled: true,
+                label: "Second button",
+                bind: {
+                    disabled: {
+                        to: "secondButtonDisabled",
+                        inside: data
+                    }
+                },
+                onclick: {
+                    fn: buttonClicked,
+                    scope: this,
+                    args: "secondButton"
+                }
+            } /}<br>
+            {@aria:Button {
+                waiAria: true,
+                // not focusable when disabled
+                disabled: true,
+                label: "Third button",
+                bind: {
+                    disabled: {
+                        to: "thirdButtonDisabled",
+                        inside: data
+                    }
+                },
+                onclick: {
+                    fn: buttonClicked,
+                    scope: this,
+                    args: "thirdButton"
+                }
+            } /}<br>
+            {@aria:Button {
+                waiAria: true,
+                // not focusable when disabled
+                label: "Fourth button",
+                bind: {
+                    disabled: {
+                        to: "fourthButtonDisabled",
+                        inside: data
+                    }
+                },
+                onclick: {
+                    fn: buttonClicked,
+                    scope: this,
+                    args: "fourthButton"
+                }
+            } /}<br>
+            <input {id "tf2"/} aria-label="Last field"><br>
+            {@aria:CheckBox {
+                label: "First button disabled",
+                bind: {
+                    value: {
+                        to: "firstButtonDisabled",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            {@aria:CheckBox {
+                label: "Second button disabled",
+                bind: {
+                    value: {
+                        to: "secondButtonDisabled",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            {@aria:CheckBox {
+                label: "Third button disabled",
+                bind: {
+                    value: {
+                        to: "thirdButtonDisabled",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            {@aria:CheckBox {
+                label: "Fourth button disabled",
+                bind: {
+                    value: {
+                        to: "fourthButtonDisabled",
+                        inside: data
+                    }
+                }
+            }/}<br><br>
+            {section {
+                macro: "buttonClickCounters",
+                bindRefreshTo: [
+                    {
+                        to: "firstButtonNbClicks",
+                        inside: data,
+                        recursive: false
+                    },
+                    {
+                        to: "secondButtonNbClicks",
+                        inside: data,
+                        recursive: false
+                    },
+                    {
+                        to: "thirdButtonNbClicks",
+                        inside: data,
+                        recursive: false
+                    },
+                    {
+                        to: "fourthButtonNbClicks",
+                        inside: data,
+                        recursive: false
+                    }
+                ]
+            } /}
+        </div>
+    {/macro}
+
+    {macro buttonClickCounters()}
+        First button was clicked ${data.firstButtonNbClicks|default:0} time(s)<br>
+        Second button was clicked ${data.secondButtonNbClicks|default:0} time(s)<br>
+        Third button was clicked ${data.thirdButtonNbClicks|default:0} time(s)<br>
+        Fourth button was clicked ${data.fourthButtonNbClicks|default:0} time(s)<br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCaseTplScript.js
+++ b/test/aria/widgets/wai/input/actionWidget/buttonFocusableWhenDisabled/FocusableDisabledButtonJawsTestCaseTplScript.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath: "test.aria.widgets.wai.input.actionWidget.buttonFocusableWhenDisabled.FocusableDisabledButtonJawsTestCaseTplScript",
+    $prototype: {
+        buttonClicked: function (evt, buttonName) {
+            var propertyName = buttonName + "NbClicks";
+            var value = this.data[propertyName] || 0;
+            this.$json.setValue(this.data, propertyName, value + 1);
+        }
+    }
+});


### PR DESCRIPTION
Blind users often navigate in a page with tab, which means they cannot notice disabled widgets, which are not focusable.
When those widgets are essential to understand the page, this is a problem, especially for buttons. This commit allows important buttons to be focusable when they are disabled, by setting the `focusableWhenDisabled` parameter to `true`.