### PR TITLE
Injecting DomEventWrapper in TextInput:onclick

### DIFF
--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -216,7 +216,7 @@ module.exports = Aria.classDefinition({
          * DOM Event raised when a click is done on the text field.
          */
         _dom_onclick : function () {
-            this.$DropDownTextInput._dom_onclick.call(this);
+            this.$DropDownTextInput._dom_onclick.apply(this, arguments);
             if (!this._calendarFocus) {
                 // clicking on the field while the popup is visible should close it
                 this._closeDropdown();

--- a/src/aria/widgets/form/TextInput.js
+++ b/src/aria/widgets/form/TextInput.js
@@ -23,6 +23,7 @@ var ariaUtilsType = require("../../utils/Type");
 var ariaUtilsArray = require("../../utils/Array");
 var ariaCoreBrowser = require("../../core/Browser");
 var ariaCoreTimer = require("../../core/Timer");
+var ariaTemplatesDomEventWrapper = require("../../templates/DomEventWrapper");
 
 /**
  * Specialize the input classes for Text input and manage the HTML input element
@@ -924,9 +925,16 @@ module.exports = Aria.classDefinition({
          * input widget if the autoselect property has been set to true.
          * @protected
          */
-        _dom_onclick : function () {
+        _dom_onclick : function (domEvent) {
             if (!!this._cfg.onclick) {
-                this.evalCallback(this._cfg.onclick);
+                var domEvtWrapper;
+                if (domEvent) {
+                    domEvtWrapper = new ariaTemplatesDomEventWrapper(domEvent);
+                }
+                this.evalCallback(this._cfg.onclick, domEvtWrapper);
+                if (domEvtWrapper) {
+                    domEvtWrapper.$dispose();
+                }
             }
         },
 

--- a/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTemplate.tpl
+++ b/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTemplate.tpl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.form.textinput.onclick.withEvent.OnClickWithEventTemplate",
+    $extends : "test.aria.widgets.form.textinput.onclick.OnClickTemplate",
+    $hasScript : true
+}}
+{/Template}

--- a/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTemplateScript.js
+++ b/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTemplateScript.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var ariaTemplatesDomEventWrapper = require("ariatemplates/templates/DomEventWrapper");
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.form.textinput.onclick.withEvent.OnClickWithEventTemplateScript",
+    $prototype : {
+        onaction : function (event) {
+            if (event && event instanceof ariaTemplatesDomEventWrapper && event.target.tagName === "INPUT") {
+                this.$OnClickTemplate.onaction.call(this);
+            }
+        }
+    }
+});

--- a/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTestCase.js
+++ b/test/aria/widgets/form/textinput/onclick/withEvent/OnClickWithEventTestCase.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.textinput.onclick.withEvent.OnClickWithEventTestCase",
+    $extends : "test.aria.widgets.form.textinput.onclick.OnClickBase",
+    $constructor : function () {
+        this.$OnClickBase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.form.textinput.onclick.withEvent.OnClickWithEventTemplate",
+            data : {
+                action : 0
+            }
+        });
+    }
+});


### PR DESCRIPTION
Before this commit, the `onclick` event handler of the TextInput-based widgets did not receive any event object. This commit makes sure a `DomEventWrapper` object is passed to the event handler, as it is done in other widgets.

Note that this PR implements a subset of #1638 