### PR TITLE
easypackage and atbuild issues with npm3

### DIFF
--- a/tasks/task-atbuild.js
+++ b/tasks/task-atbuild.js
@@ -15,15 +15,16 @@
 
 var path = require('path');
 
-var getModulePath = function (name) {
-    return path.join(__dirname, '../node_modules', name);
+var getModulePath = function (pkgName, pathInPkg) {
+    var pkgJsonPath = require.resolve(pkgName + "/package.json");
+    return path.join(path.dirname(pkgJsonPath), pathInPkg || ".");
 };
 
 module.exports = function (grunt) {
     var packagingSettings = require('../build/grunt-config/config-packaging')(grunt);
 
-    grunt.loadTasks(getModulePath('atpackager/tasks'));
-    require(getModulePath('atpackager')).loadPlugin(getModulePath('noder-js/atpackager'));
+    grunt.loadTasks(getModulePath('atpackager', 'tasks'));
+    require(getModulePath('atpackager')).loadPlugin(getModulePath('noder-js', 'atpackager'));
     grunt.registerMultiTask('atbuild', 'Aria Templates framework build', function () {
 
         var options = this.options({

--- a/tasks/task-easypackage.js
+++ b/tasks/task-easypackage.js
@@ -16,14 +16,15 @@
 var path = require('path');
 var configuration = require('./easypackage/configuration');
 
-var getModulePath = function (name) {
-    return path.join(__dirname, '../node_modules', name);
+var getModulePath = function (pkgName, pathInPkg) {
+    var pkgJsonPath = require.resolve(pkgName + "/package.json");
+    return path.join(path.dirname(pkgJsonPath), pathInPkg || ".");
 };
 
 module.exports = function (grunt) {
-    grunt.loadTasks(getModulePath('atpackager/tasks'));
-    require(getModulePath('atpackager')).loadPlugin(getModulePath('noder-js/atpackager'));
-    require(getModulePath('atpackager')).loadPlugin(getModulePath('at-noder-converter/atpackager'));
+    grunt.loadTasks(getModulePath('atpackager', 'tasks'));
+    require(getModulePath('atpackager')).loadPlugin(getModulePath('noder-js', 'atpackager'));
+    require(getModulePath('atpackager')).loadPlugin(getModulePath('at-noder-converter', 'atpackager'));
 
     grunt.registerMultiTask('easypackage', 'Packaging for Aria Templates application', function () {
 


### PR DESCRIPTION
This PR fixes issues with the `easypackage` and `atbuild` grunt tasks when using npm3 (with its flat structure).