### PR TITLE
Memory leak when calling $getElementById or $getChild on a template

### DIFF
--- a/src/aria/templates/DomElementWrapper.js
+++ b/src/aria/templates/DomElementWrapper.js
@@ -291,7 +291,6 @@ module.exports = Aria.classDefinition({
          * @private
          */
         this._dispose = function () {
-            this.setProcessingIndicator(false);
             domElt = null;
             tplCtxt = null;
             this.getChild = null;

--- a/src/aria/templates/SectionWrapper.js
+++ b/src/aria/templates/SectionWrapper.js
@@ -91,9 +91,6 @@ module.exports = Aria.classDefinition({
          * @private
          */
         this._dispose = function () {
-            // Prevents the call to setProcessingIndicator done in DomElementWrapper,
-            // because processing indicators on sections should keep their state on refresh:
-            this.setProcessingIndicator = Aria.empty;
             parentDispose.call(this);
             sectionObject = null;
             parentDispose = null;

--- a/src/aria/templates/TemplateCtxt.js
+++ b/src/aria/templates/TemplateCtxt.js
@@ -119,15 +119,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
             this.__dataGround = null;
 
             /**
-             * Keep a list of wrappers retrieved either by $getElementById. These objects contain a reference to the
-             * DOM, and since I'm confident that the users will forget to dispose them, keep here a reference and
-             * they'll be disposed when the template is disposed
-             * @type Array
-             * @private
-             */
-            this.__wrappers = [];
-
-            /**
              * List of loading overlay registered to this template context
              * @type Array
              * @private
@@ -198,8 +189,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
 
             // Dispose overlays
             this.__disposeProcessingIndicators();
-            // and wrappers
-            this.__disposeWrappers();
 
             var tpl = this._tpl;
             if (tpl) {
@@ -476,11 +465,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
 
                     // Before removing the content from the DOM dispose any processing indicators to avoid leaks
                     this.__disposeProcessingIndicators();
-
-                    if (section && !section.id) {
-                        // remove also any html wrapper, in case it is a complete refresh
-                        this.__disposeWrappers();
-                    }
 
                     // Inserting a section will add the html in the page, resume the CSSMgr before
                     ariaTemplatesCSSMgr.resume();
@@ -1356,9 +1340,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
                     // dom element
                     wrapper = new ariaTemplatesDomElementWrapper(oElm, this);
                 }
-                if (this.__wrappers) {
-                    this.__wrappers.push(wrapper);
-                }
                 return wrapper;
             },
 
@@ -1377,9 +1358,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
                 }
                 if (oElm) {
                     var wrapper = new ariaTemplatesDomElementWrapper(oElm, this);
-                    if (this.__wrappers) {
-                        this.__wrappers.push(wrapper);
-                    }
                     return wrapper;
                 }
                 return null;
@@ -1717,18 +1695,6 @@ var ariaCoreJsonValidator = require("../core/JsonValidator");
                 // Dispose all the overlays that are not bound to a section
                 ariaUtilsDomOverlay.disposeOverlays(this.__loadingOverlays);
                 this.__loadingOverlays = [];
-            },
-
-            /**
-             * Dispose all DOMElement wrappers linked to this template context. This avoids memory leaks.
-             * @private
-             */
-            __disposeWrappers : function () {
-                // backward because we call splice)
-                for (var i = this.__wrappers.length; i--;) {
-                    this.__wrappers[i].$dispose();
-                    this.__wrappers.splice(i, 1);
-                }
             },
 
             /**

--- a/test/aria/dom/logscheck/LogsCheckTestCase.js
+++ b/test/aria/dom/logscheck/LogsCheckTestCase.js
@@ -35,6 +35,7 @@ Aria.classDefinition({
             // this shall not fail on IE
             var hiddenTarget = this.templateCtxt.$getElementById('target');
             hiddenTarget.focus();
+            hiddenTarget.$dispose();
 
             this.templateCtxt.$refresh();
             this.assertErrorInLogs(aria.templates.TemplateCtxt.BEFORE_REFRESH_EXCEPTION, "Missing error in log: BEFORE_REFRESH_EXCEPTION");

--- a/test/aria/html/textinput/autoselectapi/AutoselectTestCaseTplScript.js
+++ b/test/aria/html/textinput/autoselectapi/AutoselectTestCaseTplScript.js
@@ -19,6 +19,7 @@ Aria.tplScriptDefinition({
         focus : function () {
             var textinput = this.$getElementById("textinput");
             textinput.focus();
+            textinput.$dispose();
         }
     }
 });

--- a/test/aria/templates/autorefresh/MultipleTestCase.js
+++ b/test/aria/templates/autorefresh/MultipleTestCase.js
@@ -39,14 +39,17 @@ Aria.classDefinition({
             // The first value should be updated
             var value1 = tpl.$getElementById("v1");
             this.assertTrue(value1.getValue() === "A");
+            value1.$dispose();
 
             // Not the second value
             var value2 = tpl.$getElementById("v2");
             this.assertTrue(value2.getValue() === "a");
+            value2.$dispose();
 
             // Not the third value
             var value3 = tpl.$getElementById("v3");
             this.assertTrue(value3.getValue() === "a");
+            value3.$dispose();
 
             this.notifyTemplateTestEnd();
         }

--- a/test/aria/templates/dynamicSection/DynSectionTestCase.js
+++ b/test/aria/templates/dynamicSection/DynSectionTestCase.js
@@ -95,6 +95,10 @@ Aria.classDefinition({
                 this.assertTrue(tpl.data.refCount["section" + i] == 1);
             }
 
+            section1.$dispose();
+            section2.$dispose();
+            section3.$dispose();
+            section4.$dispose();
             this._replaceTestTemplate(this._testEnv2, {
                 fn : this.runTestTwo,
                 scope : this
@@ -164,7 +168,9 @@ Aria.classDefinition({
                 this.assertTrue(tpl.data.refCount["section" + i] == 1);
             }
             this.assertTrue(tpl.data.refCount["section4"] == 2);
-
+            section1.$dispose();
+            section2.$dispose();
+            section3.$dispose();
             this.notifyTemplateTestEnd();
         }
     }

--- a/test/aria/templates/dynamicSection/testTwo/DynSectionTestTwoScript.js
+++ b/test/aria/templates/dynamicSection/testTwo/DynSectionTestTwoScript.js
@@ -34,6 +34,7 @@ Aria.tplScriptDefinition({
                     args: ["newSection"]
                 }
             });
+            refSection.$dispose();
         }
     }
 });

--- a/test/aria/templates/macrolibs/MacrolibsTestCase.js
+++ b/test/aria/templates/macrolibs/MacrolibsTestCase.js
@@ -161,6 +161,7 @@ Aria.classDefinition({
 
             var div = this.templateCtxt.$getElementById('div');
             this.assertTrue(!!div, "Div cannot be retrieved with it id.");
+            div.$dispose();
 
             this._replaceTestTemplate(this._templatesEnv, {
                 fn : this.myTestTemplates,

--- a/test/aria/templates/memoization/MemoTestCase.js
+++ b/test/aria/templates/memoization/MemoTestCase.js
@@ -28,9 +28,11 @@ Aria.classDefinition({
             // Try to get the elements in the page
             var something = this.templateCtxt.$getElementById("something");
             this.assertTrue(something.tagName.toLowerCase() == "div");
+            something.$dispose();
 
             var another = this.templateCtxt.$getElementById("another");
             this.assertTrue(another.tagName.toLowerCase() == "span");
+            another.$dispose();
 
             this.notifyTemplateTestEnd();
         }

--- a/test/aria/templates/scrollControl/ScrollControlTestCase.js
+++ b/test/aria/templates/scrollControl/ScrollControlTestCase.js
@@ -64,6 +64,8 @@ Aria.classDefinition({
             scrPos = myDiv.getScroll();
             this.assertTrue(scrPos.scrollTop === 0 && scrPos.scrollLeft === 0);
 
+            mySection.$dispose();
+            myDiv.$dispose();
             this._replaceTestTemplate(this._testEnv2);
 
         },

--- a/test/aria/templates/section/SectionTestCase.js
+++ b/test/aria/templates/section/SectionTestCase.js
@@ -132,7 +132,9 @@ Aria.classDefinition({
             this.assertTrue(this.templateCtxt.data.macroParam === "newParam", "mySectionWithMacro2: the parameter for macroForSection was wrong");
 
             // check that the cssClass statement was correctly set on the section wrapper
-            var sClass = this.templateCtxt.$getElementById("mySectionWithMacro1").classList.getClassName();
+            var mySectionWithMacro1 = this.templateCtxt.$getElementById("mySectionWithMacro1");
+            var sClass = mySectionWithMacro1.classList.getClassName();
+            mySectionWithMacro1.$dispose();
             this.assertTrue(sClass === "mySectionClass");
 
             // clean

--- a/test/aria/templates/section/processingIndicator/ProcessingIndicatorOnSectionTestCase.js
+++ b/test/aria/templates/section/processingIndicator/ProcessingIndicatorOnSectionTestCase.js
@@ -41,7 +41,7 @@ Aria.classDefinition({
             this.assertEquals(this._indHelper.totalOverlays(), 0);
 
             // create explicitly an overlay
-            this.templateCtxt.$getElementById("testSectionInDialog").setProcessingIndicator(true);
+            this.setTestSectionInDialogProcessingIndicator(true);
             this.assertEquals(this._indHelper.totalOverlays(), 1);
             this.__checkOverlayOnSection("testSectionInDialog");
 
@@ -58,16 +58,16 @@ Aria.classDefinition({
             this.assertEquals(this._indHelper.totalOverlays(), 0);
 
             // check that the status of the overaly can be changed on the wrapper
-            this.templateCtxt.$getElementById("testSectionInDialog").setProcessingIndicator(true);
+            this.setTestSectionInDialogProcessingIndicator(true);
             this.assertEquals(this._indHelper.totalOverlays(), 1);
             this.__checkOverlayOnSection("testSectionInDialog");
-            this.templateCtxt.$getElementById("testSectionInDialog").setProcessingIndicator(false);
+            this.setTestSectionInDialogProcessingIndicator(false);
             this.assertEquals(this._indHelper.totalOverlays(), 0);
             this._json.setValue(this.data, "xpos", 25);
             this.assertEquals(this._indHelper.totalOverlays(), 0);
 
             // check that the refresh of the section makes the overlay stay
-            this.templateCtxt.$getElementById("testSectionInDialog").setProcessingIndicator(true);
+            this.setTestSectionInDialogProcessingIndicator(true);
             this.assertEquals(this._indHelper.totalOverlays(), 1);
             this.__checkOverlayOnSection("testSectionInDialog");
             this.templateCtxt.$refresh({
@@ -81,6 +81,12 @@ Aria.classDefinition({
                 scope : this,
                 delay : 100
             });
+        },
+
+        setTestSectionInDialogProcessingIndicator : function (value) {
+            var sectionWrapper = this.templateCtxt.$getElementById("testSectionInDialog");
+            sectionWrapper.setProcessingIndicator(value);
+            sectionWrapper.$dispose();
         },
 
         _finishTest : function () {

--- a/test/aria/templates/section/sectionAttributes/SectionAttributesTestCase.js
+++ b/test/aria/templates/section/sectionAttributes/SectionAttributesTestCase.js
@@ -69,10 +69,11 @@ Aria.classDefinition({
             this.assertEquals(dom.getData("foo1"), "Foo 1", "The expando attribute 'foo1' should be set to 'Foo 1'");
             this.assertEquals(dom.getData("foo2"), "Foo 2", "The expando attribute 'foo2' should be set to 'Foo 2'");
 
-            this.testEnd();
+            this.endTest();
         },
 
-        testEnd : function () {
+        endTest : function () {
+            this.dom.$dispose();
             this.notifyTemplateTestEnd();
         }
     }

--- a/test/aria/templates/section/sectionAttributes/binding/SectionAttributesBindingBase.js
+++ b/test/aria/templates/section/sectionAttributes/binding/SectionAttributesBindingBase.js
@@ -211,6 +211,7 @@ Aria.classDefinition({
             jsonUtil.removeListener(this.testData, "attributes", changeListener, false, true);
             changeListener = null;
 
+            this._domWrapper.$dispose();
             this.end();
         },
 

--- a/test/aria/utils/overlay/loadingIndicator/automatic/AutomaticTestCase.js
+++ b/test/aria/utils/overlay/loadingIndicator/automatic/AutomaticTestCase.js
@@ -57,6 +57,12 @@ Aria.classDefinition({
             this._Body();
         },
 
+        setProcessingIndicator : function (id, value) {
+            var wrapper = this.templateCtxt.$getElementById(id);
+            wrapper.setProcessingIndicator(value);
+            wrapper.$dispose();
+        },
+
         __getSubTemplateContext : function () {
             // Go backward because I think that the template widget is at the end
             for (var i = this.templateCtxt._mainSection._content.length; i--;) {
@@ -74,6 +80,12 @@ Aria.classDefinition({
             if (context) {
                 return context.$getElementById(name);
             }
+        },
+
+        setSubTemplateProcessingIndicator : function (id, value) {
+            var wrapper = this.__getSubTemplateSectionWrapper(id);
+            wrapper.setProcessingIndicator(value);
+            wrapper.$dispose();
         },
 
         _Body : function () {
@@ -138,13 +150,12 @@ Aria.classDefinition({
             document.body.insertBefore(div, document.body.firstChild);
 
             // Put a loading indicator on all the elements except the body
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("d2").setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
+            this.setProcessingIndicator("s2", true);
+            this.setProcessingIndicator("d1", true);
+            this.setProcessingIndicator("d2", true);
             aria.utils.DomOverlay.create(div);
-            var subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(true);
+            this.setSubTemplateProcessingIndicator("subSection", true);
 
             // Check that now it's in the DOM
             this.assertTrue(this.helper.countInDom() === 6);
@@ -165,13 +176,12 @@ Aria.classDefinition({
             this.assertTrue(overlays === 1, "Overlays not disposed: " + overlays);
 
             // Put again loading a indicator on all the elements including the body
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("d2").setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
+            this.setProcessingIndicator("s2", true);
+            this.setProcessingIndicator("d1", true);
+            this.setProcessingIndicator("d2", true);
             aria.utils.DomOverlay.create(div);
-            subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(true);
+            this.setSubTemplateProcessingIndicator("subSection", true);
             aria.utils.DomOverlay.create(document.body);
 
             // Check that now it's in the DOM
@@ -205,10 +215,9 @@ Aria.classDefinition({
             this.assertTrue(overlays === 4, "Overlays not disposed: " + overlays);
 
             // Destroy all of them
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(false);
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(false);
-            subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(false);
+            this.setProcessingIndicator("s1", false);
+            this.setProcessingIndicator("s2", false);
+            this.setSubTemplateProcessingIndicator("subSection", false);
             aria.utils.DomOverlay.detachFrom(div);
 
             // Check for leaks
@@ -228,16 +237,15 @@ Aria.classDefinition({
 
         _SectionBind : function () {
             // Put a loading indicator on all the sections (s1 and s2 are bound to the same value)
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
 
             // There should be two indicator already
             this.assertTrue(this.helper.countInDom() === 2);
 
             // This one should do nothing, the indicator is already there
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(true);
+            this.setProcessingIndicator("s2", true);
 
-            var subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(true);
+            this.setSubTemplateProcessingIndicator("subSection", true);
 
             // Check that now it's in the DOM
             this.assertTrue(this.helper.countInDom() === 3);
@@ -263,11 +271,10 @@ Aria.classDefinition({
             this.assertTrue(overlays === 3, "Overlays not disposed: " + overlays);
 
             // Close them
-            subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(false);
+            this.setSubTemplateProcessingIndicator("subSection", false);
 
             // This should close also the indicator on s1
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(false);
+            this.setProcessingIndicator("s2", false);
 
             // Check that there are no overlays
             this.assertFalse(this.helper.isInDom());
@@ -277,13 +284,12 @@ Aria.classDefinition({
             this.assertTrue(overlays === 0, "Overlays not disposed: " + overlays);
 
             // Close also s1 that shouldn't give errors
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(false);
+            this.setProcessingIndicator("s1", false);
 
             // Put again loading a indicator on all the sections
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("s2").setProcessingIndicator(true);
-            subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
+            this.setProcessingIndicator("s2", true);
+            this.setSubTemplateProcessingIndicator("subSection", true);
 
             // Check that now it's in the DOM
             this.assertTrue(this.helper.countInDom() === 3);
@@ -303,11 +309,10 @@ Aria.classDefinition({
             this.assertTrue(this.helper.countInDom() === 3);
 
             // Destroy them
-            subsection = this.__getSubTemplateSectionWrapper("subSection");
-            subsection.setProcessingIndicator(false);
+            this.setSubTemplateProcessingIndicator("subSection", false);
 
             // This should close also the indicator on s2
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(false);
+            this.setProcessingIndicator("s1", false);
 
             // Check that there are no overlays
             this.assertFalse(this.helper.isInDom());
@@ -326,7 +331,7 @@ Aria.classDefinition({
 
         _Nasty : function () {
             // Try a combination of nasty bindings
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
 
             // Four sections are bound
             this.assertTrue(this.helper.countInDom() === 4);
@@ -345,7 +350,7 @@ Aria.classDefinition({
             this.assertTrue(overlays === 4, "Overlays not disposed: " + overlays);
 
             // Close one that was not opened directly
-            this.templateCtxt.$getElementById("s4").setProcessingIndicator(false);
+            this.setProcessingIndicator("s4", false);
 
             // The four sections should be disposed
             this.assertFalse(this.helper.isInDom());

--- a/test/aria/utils/overlay/loadingIndicator/ieScrollIssue2/IEScrollIssue2Base.js
+++ b/test/aria/utils/overlay/loadingIndicator/ieScrollIssue2/IEScrollIssue2Base.js
@@ -38,7 +38,9 @@ Aria.classDefinition({
 
         runTemplateTest : function () {
             this.refreshPositionCalled = 0;
-            this.templateCtxt.$getElementById("mySpan").setProcessingIndicator(true, "Loading...");
+            var wrapper = this.templateCtxt.$getElementById("mySpan");
+            wrapper.setProcessingIndicator(true, "Loading...");
+            wrapper.$dispose();
             this.assertSameGeometry(this.getElementById("mySpan"), this.getUniqueOverlay());
             this.getElementById("container").scrollTop = 50;
             this.waitFor({
@@ -91,7 +93,9 @@ Aria.classDefinition({
             this.assertEquals(this.refreshPositionCalled, 0);
             var container = this.getElementById("container");
             this.assertEquals(container.scrollTop, 75);
-            this.templateCtxt.$getElementById("mySpan").setProcessingIndicator(true, "Loading...");
+            var wrapper = this.templateCtxt.$getElementById("mySpan");
+            wrapper.setProcessingIndicator(true, "Loading...");
+            wrapper.$dispose();
             this.assertSameGeometry(this.getElementById("mySpan"), this.getUniqueOverlay());
             container.scrollTop = 25;
             this.waitFor({

--- a/test/aria/utils/overlay/loadingIndicator/manual/ManualTestCase.js
+++ b/test/aria/utils/overlay/loadingIndicator/manual/ManualTestCase.js
@@ -127,6 +127,8 @@ Aria.classDefinition({
             // Remove it for the last time
             span.setProcessingIndicator(false);
 
+            span.$dispose();
+
             // Check for leaks
             var overlays = this.helper.totalOverlays();
             this.assertTrue(overlays === 0, "Overlays not disposed: " + overlays);
@@ -158,6 +160,8 @@ Aria.classDefinition({
 
             // Remove it for the last time
             div.setProcessingIndicator(false);
+
+            div.$dispose();
 
             // Check for leaks
             var overlays = this.helper.totalOverlays();
@@ -250,6 +254,8 @@ Aria.classDefinition({
             // Remove it for the last time
             section.setProcessingIndicator(false);
 
+            section.$dispose();
+
             // Check for leaks
             var overlays = this.helper.totalOverlays();
             this.assertTrue(overlays === 0, "Overlays not disposed: " + overlays);
@@ -298,6 +304,7 @@ Aria.classDefinition({
             section.setProcessingIndicator(false);
             this.assertFalse(data.processing);
 
+            section.$dispose();
             // Check for leaks
             var overlays = this.helper.totalOverlays();
             this.assertTrue(overlays === 0, "Overlays not disposed: " + overlays);
@@ -309,19 +316,25 @@ Aria.classDefinition({
             });
         },
 
+        setProcessingIndicator : function (id, value) {
+            var wrapper = this.templateCtxt.$getElementById(id);
+            wrapper.setProcessingIndicator(value);
+            wrapper.$dispose();
+        },
+
         _Twice : function () {
-            // Set and unset the process indicator twice on the same wrapper
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(false);
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(false);
+            // Set and unset the process indicator twice on the same element
+            this.setProcessingIndicator("s1", false);
+            this.setProcessingIndicator("s1", false);
 
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(false);
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(false);
+            this.setProcessingIndicator("d1", false);
+            this.setProcessingIndicator("d1", false);
 
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("s1").setProcessingIndicator(true);
+            this.setProcessingIndicator("s1", true);
+            this.setProcessingIndicator("s1", true);
 
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(true);
-            this.templateCtxt.$getElementById("d1").setProcessingIndicator(true);
+            this.setProcessingIndicator("d1", true);
+            this.setProcessingIndicator("d1", true);
 
             // There should be only two loading indicators
             this.assertTrue(this.helper.countInDom() === 2);

--- a/test/performance/leakOnRefresh/TemplateRefreshTestCase.js
+++ b/test/performance/leakOnRefresh/TemplateRefreshTestCase.js
@@ -31,10 +31,8 @@ Aria.classDefinition({
 
         doRefresh : function (iteration) {
             var wrapper = this.templateCtxt.$getElementById("container");
+            wrapper.$dispose();
             this.templateCtxt.$refresh();
-
-            // after a refresh the variables containing DOM references should be empty
-            this.assertEquals(this.templateCtxt.__wrappers.length, 0);
 
             if (iteration > 0) {
                 aria.core.Timer.addCallback({


### PR DESCRIPTION
Each time a call to `$getElementById` or `$getChild` is done on a template, a new `DomElementWrapper` object is created and, until this commit, the wrapper was also added to an array in the template context, with the only purpose of calling `$dispose` on all wrapper elements when the template is fully refreshed or disposed. If this does not happen (e.g. if there are only partial refreshes), and many calls to the `$getElementById` and `$getChild` functions are done, this creates a leak. With this commit, wrappers are no longer stored on the template context, it is up to the application to dispose them (if needed).