### PR TITLE
Adding the waiOpenMsg property on the aria:Dialog widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2070,6 +2070,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:String",
                     $description : "The label to use for the close icon (can be used in various ways such as for tooltip or accessibility)."
                 },
+                "waiOpenMsg" : {
+                    $type : "json:String",
+                    $description : "When waiAria is activated, this property specifies the message to read when the modal dialog is opened."
+                },
                 "waiEscapeMsg" : {
                     $type : "json:String",
                     $description : "If this property is defined and if waiAria is activated, the user has to press escape twice (instead of only once) to close the dialog. This property specifies the message to read after the user pressed escape the first time."

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -850,7 +850,11 @@ module.exports = Aria.classDefinition({
 
             ariaCoreTimer.addCallback({
                 fn : function () {
-                    this.evalCallback(cfg.onOpen);
+                    // check that the dialog was not disposed
+                    if (this._cfg) {
+                        this.waiReadText(cfg.waiOpenMsg);
+                        this.evalCallback(cfg.onOpen);
+                    }
                 },
                 scope : this,
                 delay : 4

--- a/test/aria/widgets/wai/popup/dialog/waiOpenMsg/DialogOpenMsgJawsTestCase.js
+++ b/test/aria/widgets/wai/popup/dialog/waiOpenMsg/DialogOpenMsgJawsTestCase.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.popup.dialog.waiOpenMsg.DialogOpenMsgJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.popup.dialog.waiOpenMsg.Tpl"
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.synEvent.execute([
+                ["click", this.getElementById("firstField")],
+                ["type", null, "[tab][space]"],
+                ["pause", 5000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals(true, this.end, function (text) {
+                        return /My dialog heading level 1\nThis is the wai open message!/.test(text);
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/popup/dialog/waiOpenMsg/Tpl.tpl
+++ b/test/aria/widgets/wai/popup/dialog/waiOpenMsg/Tpl.tpl
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath : "test.aria.widgets.wai.popup.dialog.waiOpenMsg.Tpl",
+    $hasScript : true
+}}
+
+    {macro main()}
+        <div style="margin: 10px;">
+            First field: <input {id "firstField"/}><br><br>
+            {@aria:Button {
+                id: "openDialogButton",
+                label: "Show dialog",
+                onclick: openDialog
+            }/}
+            {@aria:Dialog {
+                title: "My dialog",
+                autoFocus: true,
+                waiAria: true,
+                waiOpenMsg: "This is the wai open message!",
+                macro: "dialogContent",
+                bind: {
+                    visible: {
+                        to: "dialogOpen",
+                        inside: data
+                    }
+                }
+            }/}
+        </div>
+    {/macro}
+
+    {macro dialogContent()}
+        <p>This is the content of my dialog!</p>
+        {@aria:Button {
+            label: "Do nothing"
+        }/}
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/popup/dialog/waiOpenMsg/TplScript.js
+++ b/test/aria/widgets/wai/popup/dialog/waiOpenMsg/TplScript.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.wai.popup.dialog.waiOpenMsg.TplScript',
+
+    $prototype : {
+        openDialog : function (evt) {
+            this.$json.setValue(this.data, "dialogOpen", true);
+        }
+    }
+});


### PR DESCRIPTION
The new `waiOpenMsg` property allows to specify a message to be read by screen readers when the dialog is opened.
