### PR TITLE
Missing call to $dispose on DomElementWrapper

### DIFF
--- a/test/aria/widgets/wai/processingIndicator/TplScript.js
+++ b/test/aria/widgets/wai/processingIndicator/TplScript.js
@@ -129,6 +129,7 @@ module.exports = Aria.tplScriptDefinition({
                 waiAriaReadInterval: readInterval,
                 waiAriaReadOnceFirst: readOnceFirst
             });
+            domElement.$dispose();
         },
 
         toggleOverlayOnSection: function () {


### PR DESCRIPTION
Following commit 925c9078cfea9cdaccab764330e217f18696fad6, the call to `$dispose` on `DomElementWrapper` objects returned by `$getElementById` is no longer done automatically. This commit adds a missing call to `$dispose` on a `DomElementWrapper` instance in a Jaws test case.