### PR TITLE
Dropdown icons no longer focusable when the widget is disabled

### DIFF
--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -87,7 +87,6 @@ module.exports = Aria.classDefinition({
         }
     },
     $destructor : function () {
-        this._dropDownIcon = null;
         if (this._waiReadDateOnKeyDown != null) {
             this._waiReadDateOnKeyDown.$dispose();
         }
@@ -139,12 +138,8 @@ module.exports = Aria.classDefinition({
 
         _initInputMarkup : function () {
             this.$DropDownTextInput._initInputMarkup.apply(this, arguments);
-            var dropDownIcon = null;
-            if (this._frame.getIcon) {
-                dropDownIcon = this._frame.getIcon("dropdown");
-            }
+            var dropDownIcon = this._getDropdownIcon();
             this.$assert(54, dropDownIcon);
-            this._dropDownIcon = dropDownIcon;
         },
 
         /**
@@ -397,7 +392,7 @@ module.exports = Aria.classDefinition({
                 // it is important to set aria-owns and aria-expanded attributes before
                 // calling the parent _afterDropdownOpen method (which gives focus to
                 // the calendar)
-                var dropDownIcon = this._dropDownIcon;
+                var dropDownIcon = this._getDropdownIcon();
                 var calendarId = this.controller.getCalendar().getCalendarDomId();
                 dropDownIcon.setAttribute("aria-owns", calendarId);
                 dropDownIcon.setAttribute("aria-activedescendant", calendarId);
@@ -414,7 +409,7 @@ module.exports = Aria.classDefinition({
 
         _afterDropdownClose : function () {
             this._calendarFocus = false;
-            var dropDownIcon = this._dropDownIcon;
+            var dropDownIcon = this._getDropdownIcon();
             if (this._cfg.waiAria && dropDownIcon) {
                 dropDownIcon.removeAttribute("aria-owns");
                 dropDownIcon.removeAttribute("aria-activedescendant");

--- a/src/aria/widgets/form/SelectBox.js
+++ b/src/aria/widgets/form/SelectBox.js
@@ -77,12 +77,8 @@ module.exports = Aria.classDefinition({
 
         _initInputMarkup : function () {
             this.$DropDownTextInput._initInputMarkup.apply(this, arguments);
-            var dropDownIcon = null;
-            if (this._frame.getIcon) {
-                dropDownIcon = this._frame.getIcon("dropdown");
-            }
+            var dropDownIcon = this._getDropdownIcon();
             this.$assert(54, dropDownIcon);
-            this._dropDownIcon = dropDownIcon;
         },
 
         /**
@@ -137,14 +133,14 @@ module.exports = Aria.classDefinition({
          */
         _afterDropdownOpen : function () {
             if (this._cfg.waiAria) {
-                this._dropDownIcon.setAttribute("aria-expanded", "true");
+                this._getDropdownIcon().setAttribute("aria-expanded", "true");
             }
             this.$DropDownListTrait._afterDropdownOpen.apply(this, arguments);
         },
 
         _afterDropdownClose : function () {
             if (this._cfg.waiAria) {
-                this._dropDownIcon.setAttribute("aria-expanded", "false");
+                this._getDropdownIcon().setAttribute("aria-expanded", "false");
             }
             this.$DropDownListTrait._afterDropdownClose.call(this);
         }

--- a/test/aria/widgets/wai/dropdown/disabled/DropDownDynamicallyDisabledDownJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/disabled/DropDownDynamicallyDisabledDownJawsTestCase.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.DropDownDynamicallyDisabledDownJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.disabled.Tpl",
+            data: {
+                disabled: false
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/type/i);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500]
+            ];
+            for (var i = 0; i < 14; i++) {
+                actions.push(["type", null, "[down]"], ["pause", 500]);
+            }
+            actions.push(["click", this.getElementById("firstItem")], ["pause", 500]);
+            for (var i = 0; i < 3; i++) {
+                actions.push(["type", null, "[up]"], ["pause", 500]);
+            }
+            actions.push(["type", null, "[space]"], ["pause", 500]);
+            for (var i = 0; i < 13; i++) {
+                actions.push(["type", null, "[down]"], ["pause", 500]);
+            }
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel",
+                        "Edit",
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel",
+                        "Edit",
+                        "DropDownLabelForAutoComplete",
+                        "SelectBoxLabel",
+                        "Edit",
+                        "DropDownLabelForSelectBox",
+                        "MultiSelectLabel",
+                        "Edit",
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel",
+                        "Edit",
+                        "FirstFieldLabel Edit",
+                        "FirstFieldLabel",
+                        "Disabled widgets",
+                        "check box not checked",
+                        "Disabled widgets check box checked",
+                        "Disabled widgets",
+                        "FirstFieldLabel",
+                        "Edit",
+                        "DatePickerLabel",
+                        "Edit Unavailable",
+                        "AutoCompleteLabel",
+                        "Edit Unavailable",
+                        "SelectBoxLabel",
+                        "Edit Unavailable",
+                        "MultiSelectLabel",
+                        "Edit Unavailable",
+                        "LastFieldLabel",
+                        "Edit"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/disabled/DropDownDynamicallyDisabledTabJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/disabled/DropDownDynamicallyDisabledTabJawsTestCase.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.DropDownDynamicallyDisabledTabJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.disabled.Tpl",
+            data: {
+                disabled: false
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/type/i);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500]
+            ];
+            for (var i = 0; i < 9; i++) {
+                actions.push(["type", null, "[tab]"], ["pause", 500]);
+            }
+            actions.push(["click", this.getElementById("firstItem")], ["pause", 500]);
+            actions.push(["type", null, "[<shift>][tab][>shift<]"], ["pause", 500]);
+            actions.push(["type", null, "[space]"], ["pause", 500]);
+            actions.push(["type", null, "[tab]"], ["pause", 500]);
+            actions.push(["type", null, "[tab]"], ["pause", 500]);
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel Edit",
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel Edit",
+                        "DropDownLabelForAutoComplete",
+                        "SelectBoxLabel Edit",
+                        "DropDownLabelForSelectBox",
+                        "MultiSelectLabel Edit",
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel Edit",
+                        "FirstFieldLabel Edit",
+                        "Disabled widgets check box not checked",
+                        "checked",
+                        "FirstFieldLabel Edit",
+                        "LastFieldLabel Edit"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/disabled/DropDownInitiallyDisabledDownJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/disabled/DropDownInitiallyDisabledDownJawsTestCase.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.DropDownInitiallyDisabledDownJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.disabled.Tpl",
+            data: {
+                disabled: true
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/type/i);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500]
+            ];
+            for (var i = 0; i < 10; i++) {
+                actions.push(["type", null, "[down]"], ["pause", 500]);
+            }
+            actions.push(["click", this.getElementById("firstItem")], ["pause", 500]);
+            for (var i = 0; i < 3; i++) {
+                actions.push(["type", null, "[up]"], ["pause", 500]);
+            }
+            actions.push(["type", null, "[space]"], ["pause", 500]);
+            for (var i = 0; i < 17; i++) {
+                actions.push(["type", null, "[down]"], ["pause", 500]);
+            }
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel",
+                        "Edit Unavailable",
+                        "AutoCompleteLabel",
+                        "Edit Unavailable",
+                        "SelectBoxLabel",
+                        "Edit Unavailable",
+                        "MultiSelectLabel",
+                        "Edit Unavailable",
+                        "LastFieldLabel",
+                        "Edit",
+                        "FirstFieldLabel Edit",
+                        "FirstFieldLabel",
+                        "Disabled widgets",
+                        "check box checked",
+                        "Disabled widgets check box not checked",
+                        "Disabled widgets",
+                        "FirstFieldLabel",
+                        "Edit",
+                        "DatePickerLabel",
+                        "Edit",
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel",
+                        "Edit",
+                        "DropDownLabelForAutoComplete",
+                        "SelectBoxLabel",
+                        "Edit",
+                        "DropDownLabelForSelectBox",
+                        "MultiSelectLabel",
+                        "Edit",
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel",
+                        "Edit"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/disabled/DropDownInitiallyDisabledTabJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/disabled/DropDownInitiallyDisabledTabJawsTestCase.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.DropDownInitiallyDisabledTabJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.disabled.Tpl",
+            data: {
+                disabled: true
+            }
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/type/i);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500],
+                ["type", null, "[tab]"], ["pause", 500],
+                ["click", this.getElementById("firstItem")], ["pause", 500],
+                ["type", null, "[<shift>][tab][>shift<]"], ["pause", 500],
+                ["type", null, "[space]"], ["pause", 500]
+            ];
+            for (var i = 0; i < 10; i++) {
+                actions.push(["type", null, "[tab]"], ["pause", 500]);
+            }
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "FirstFieldLabel Edit",
+                        "LastFieldLabel Edit",
+                        "FirstFieldLabel Edit",
+                        "Disabled widgets check box checked",
+                        "not checked",
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel Edit",
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel Edit",
+                        "DropDownLabelForAutoComplete",
+                        "SelectBoxLabel Edit",
+                        "DropDownLabelForSelectBox",
+                        "MultiSelectLabel Edit",
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel Edit"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/disabled/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/disabled/Tpl.tpl
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.Tpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        <div class="root">
+            {@aria:CheckBox {
+                waiAria: true,
+                label: "Disabled widgets",
+                bind: {
+                    value: {
+                        to: "disabled",
+                        inside: data
+                    }
+                }
+            }/}<br>
+            <input {id "firstItem"/} aria-label="FirstFieldLabel"> <br>
+            {@aria:DatePicker {
+                waiAria: true,
+                label: "DatePickerLabel",
+                waiIconLabel: "DropDownLabelForDatePicker",
+                id: "myDatePicker",
+                bind: {
+                    disabled: {
+                        to: "disabled",
+                        inside: data
+                    }
+                }
+            }/} <br>
+            {@aria:AutoComplete {
+                waiAria: true,
+                label: "AutoCompleteLabel",
+                waiIconLabel: "DropDownLabelForAutoComplete",
+                id: "myAutoCompleteWithExpandButton",
+                expandButton: true,
+                resourcesHandler: getAutoCompleteHandler(),
+                bind: {
+                    disabled: {
+                        to: "disabled",
+                        inside: data
+                    }
+                }
+            }/} <br>
+            {@aria:SelectBox {
+                waiAria: true,
+                label: "SelectBoxLabel",
+                waiIconLabel: "DropDownLabelForSelectBox",
+                id: "mySelectBox",
+                options: items,
+                bind: {
+                    disabled: {
+                        to: "disabled",
+                        inside: data
+                    }
+                }
+            }/} <br>
+            {@aria:MultiSelect {
+                waiAria: true,
+                label: "MultiSelectLabel",
+                waiIconLabel: "DropDownLabelForMultiSelect",
+                id: "myMultiSelect",
+                items: items,
+                bind: {
+                    disabled: {
+                        to: "disabled",
+                        inside: data
+                    }
+                }
+            }/} <br>
+            <input {id "lastItem"/} aria-label="LastFieldLabel"> <br>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/dropdown/disabled/TplScript.js
+++ b/test/aria/widgets/wai/dropdown/disabled/TplScript.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.disabled.TplScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        this.items = [{
+                    label : "Touch device",
+                    code : "Touch device",
+                    value : "Touch device"
+                }, {
+                    label : "Desktop device",
+                    code : "Desktop device",
+                    value : "Desktop device"
+                }];
+    },
+    $destructor : function () {
+        if (this.acHandler) {
+            this.acHandler.$dispose();
+            this.acHandler = null;
+        }
+    },
+    $prototype : {
+        getAutoCompleteHandler : function () {
+            if (!this.acHandler) {
+                var acHandler = new aria.resources.handlers.LCResourcesHandler();
+                acHandler.setSuggestions(this.items);
+                this.acHandler = acHandler;
+            }
+            return this.acHandler;
+        }
+    }
+});


### PR DESCRIPTION
This PR removes the "tabindex" attribute and adds the "aria-hidden" attribute on the dropdown icon of widgets when they are disabled.