### PR TITLE
Adding the onblur event on the Select widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ cache:
     - node_modules
 addons:
   firefox: "50.0"
+  apt:
+    packages:
+    - awesome
 before_install:
 # Settings needed for graphic output in Firefox
   - export DISPLAY=:99.0
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/awesome_99.pid --make-pidfile --background --exec /usr/bin/awesome
   - npm install -g geckodriver
 # Diagnostics
   - npm --version

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -996,6 +996,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "common:Callback",
                     $description : "Function to be called when the state of the widget changes."
                 },
+                "onblur" : {
+                    $type : "common:Callback",
+                    $description : "Function to be called when the widget loses focus."
+                },
                 "bind" : {
                     $type : "DropDownInputCfg.bind",
                     $properties : {

--- a/src/aria/widgets/form/DatePicker.js
+++ b/src/aria/widgets/form/DatePicker.js
@@ -102,25 +102,14 @@ module.exports = Aria.classDefinition({
 
         /**
          * Handle events raised by the frame
-         * @param {Object} evt
+         * @protected
          * @override
+         * @param {Object} evt
          */
         _frame_events : function (evt) {
-            if (evt.iconName == "dropdown" && !this._cfg.disabled) {
-                var evtName = evt.name;
-                if (evtName == "iconKeyDown") {
-                    var keyCode = evt.event.keyCode;
-                    if (keyCode == 13 || keyCode == 32) {
-                        evtName = "iconClick";
-                    }
-                }
-
-                if (evtName == "iconMouseDown") {
-                    evt.event.preventDefault(true);
-                } else if (evtName == "iconClick") {
-                    this._toggleDropdown();
-                    evt.event.preventDefault(true);
-                }
+            this.$DropDownTextInput._frame_events.apply(this, arguments);
+            if (evt.event.hasPreventDefault) {
+                evt.event.stopPropagation();
             }
         },
 

--- a/src/aria/widgets/form/DropDownListTrait.js
+++ b/src/aria/widgets/form/DropDownListTrait.js
@@ -102,6 +102,16 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Callback called when the user called when the user clicks the mouse in the list.
+         * @param {Object} evt object containing information about the element on which the mouse was clicked.
+         * @protected
+         */
+        _listMouseDown : function (evt) {
+            evt.target.setProperty("unselectable", "on");
+            evt.preventDefault(); // prevent the blur when clicking the popup inside the widget
+        },
+
+        /**
          * Callback for the keyevent on List widget. <br />
          * restore the focus on the right item if it does not have the focus, and propagate the key
          * @param {Object} evt object containing keyboard event information (charCode and keyCode). This is not an
@@ -169,6 +179,10 @@ module.exports = Aria.classDefinition({
                 },
                 onclose : {
                     fn : this._closeDropdown,
+                    scope : this
+                },
+                onmousedown : {
+                    fn : this._listMouseDown,
                     scope : this
                 },
                 onchange : options.onchange,

--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -38,9 +38,7 @@ module.exports = Aria.classDefinition({
         this.$TextInput.constructor.call(this, cfg, ctxt, lineNumber, controller);
         var iconTooltip = cfg.iconTooltip ? ' title="' + ariaUtilsString.escapeForHTML(cfg.iconTooltip) + '"' : '';
         this._iconsAttributes = {
-            // unselectable is necessary on IE so that, on mouse down, there is no blur of the active element
-            // (preventing the default action on mouse down does not help on IE)
-            "dropdown": 'unselectable="on"' + iconTooltip
+            "dropdown": iconTooltip
         };
         if (cfg.waiAria) {
             this._iconsAttributes.dropdown += ' aria-expanded="false" aria-haspopup="true"';

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -110,17 +110,16 @@ module.exports = Aria.classDefinition({
         /**
          * Handle events raised by the frame
          * @protected
+         * @override
          * @param {Object} evt
          */
         _frame_events : function (evt) {
             if (evt.iconName == "dropdown" && !this._cfg.disabled) {
-
                 var evtName = evt.name;
                 if (evtName == "iconKeyDown") {
                     var keyCode = evt.event.keyCode;
                     if (keyCode == 13 || keyCode == 32) {
                         evtName = "iconClick";
-                        evt.event.stopPropagation();
                     }
                 }
 
@@ -128,8 +127,14 @@ module.exports = Aria.classDefinition({
                     if (this._hasFocus) {
                         this._keepFocus = true;
                     }
+
+                    // unselectable is necessary on IE so that, on mouse down, there is no blur of the active element
+                    // (preventing the default action on mouse down does not help on IE)
+                    evt.event.target.setAttribute("unselectable", "on");
+                    evt.event.preventDefault();
                 } else if (evtName == "iconClick") {
                     this._toggleDropdown();
+                    evt.event.preventDefault();
                 }
             }
         },

--- a/src/aria/widgets/form/Select.js
+++ b/src/aria/widgets/form/Select.js
@@ -236,6 +236,13 @@ module.exports = Aria.classDefinition({
                 }
             }
             this._updateValue(true);
+            // _updateValue can change the value in the data model, which could make the widget be disposed
+            // (for example during a refresh of a section bound to that part of the data model)
+            // That's why we are checking if this._cfg is defined here:
+            var onblur = this._cfg ? this._cfg.onblur : null;
+            if (onblur) {
+                this.evalCallback(onblur);
+            }
         },
 
         /**

--- a/src/aria/widgets/form/list/templates/ListTemplateScript.js
+++ b/src/aria/widgets/form/list/templates/ListTemplateScript.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 var Aria = require("../../../../Aria");
-var ariaCoreBrowser = require("../../../../core/Browser");
 var ariaCoreTimer = require("../../../../core/Timer");
 
 
@@ -126,11 +125,6 @@ module.exports = Aria.tplScriptDefinition({
             if (!this.data.disabled) {
                 var itemIdx = evt.target.getData("itemIdx", true);
                 if (itemIdx) {
-                    if (ariaCoreBrowser.isWebkit) {
-                        // webkit-based browsers explicitly need this
-                        // (http://www.quirksmode.org/dom/events/blurfocus.html)
-                        evt.target.focus();
-                    }
                     this.moduleCtrl.itemClick(itemIdx);
                 }
             }

--- a/test/aria/widgets/form/select/onBlur/SelectOnBlur.tpl
+++ b/test/aria/widgets/form/select/onBlur/SelectOnBlur.tpl
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath:"test.aria.widgets.form.select.onBlur.SelectOnBlur",
+   $hasScript:true
+}}
+    {macro main()}
+        {foreach widgetData inArray data.widgets}
+            {call widget(widgetData)/}
+        {/foreach}
+    {/macro}
+
+    {macro widget(widgetData)}
+        <input {id widgetData.id + "Before"/}> {@aria:Select {
+            id: widgetData.id,
+            sclass: widgetData.sclass,
+            margins: "0 0 0 0",
+            width: 173,
+            options: data.options,
+            onblur: {
+                fn: this.selectOnBlur,
+                resIndex: -1,
+                scope: this,
+                args: widgetData
+            },
+            bind: {
+                value: {
+                    to : "value",
+                    inside : widgetData
+                }
+            }
+        }/} <input {id widgetData.id + "After"/}><br>
+        Value: {@aria:Text {
+            bind: {
+                text: {
+                    to: "value",
+                    inside: widgetData
+                }
+            }
+        }/}<br>
+        Blur events: {@aria:Text {
+            bind: {
+                text: {
+                    to: "blurEvents",
+                    inside: widgetData
+                }
+            }
+        }/}<br>
+    {/macro}
+{/Template}

--- a/test/aria/widgets/form/select/onBlur/SelectOnBlurRobotBase.js
+++ b/test/aria/widgets/form/select/onBlur/SelectOnBlurRobotBase.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.select.onBlur.SelectOnBlurRobotBase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $dependencies : ["aria.utils.Array", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {
+            widgets : [],
+            options : [{
+                        label : "Type A",
+                        value : "A"
+                    }, {
+                        label : "Type B",
+                        value : "B"
+                    }, {
+                        label : "Type C",
+                        value : "C"
+                    }, {
+                        label : "Type D",
+                        value : "D"
+                    }, {
+                        label : "Type E",
+                        value : "E"
+                    }, {
+                        label : "Type F",
+                        value : "F"
+                    }, {
+                        label : "Type G",
+                        value : "G"
+                    }]
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.select.onBlur.SelectOnBlur",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            this.execute(aria.utils.Array.map(this.data.widgets, function (widgetData) {
+                return [this.widgetTest, widgetData];
+            }, this), this.end);
+        },
+
+        widgetTest: function (widgetData, cb) {
+            var beforeElement = this.getElementById(widgetData.id + "Before");
+            var afterElement = this.getElementById(widgetData.id + "After");
+            var widgetInstance = this.getWidgetInstance(widgetData.id);
+            var widgetDom = widgetInstance.getDom();
+            var widgetGeometry = aria.utils.Dom.getGeometry(widgetDom);
+            var clickedValue;
+            this.execute([
+                [this.checkValue, widgetData, "A"],
+                [this.click, beforeElement], [this.waitForDomEltFocus, beforeElement],
+                [this.type, "[tab]"], [this.waitForDomEltBlur, beforeElement],
+                [this.type, "[down]"], [this.pause, 500],
+                [this.checkBlurEvents, widgetData, 0],
+                [this.type, "[tab]"], [this.waitForDomEltFocus, afterElement],
+                [this.checkValue, widgetData, "B"],
+                [this.checkBlurEvents, widgetData, 1],
+
+                [this.click, {
+                    // click on the icon
+                    x: widgetGeometry.x + widgetGeometry.width - 8,
+                    y: widgetGeometry.y + widgetGeometry.height / 2
+                }], [this.pause, 500],
+                [this.click, {
+                    // click on the option just below the position of the field
+                    x: widgetGeometry.x + widgetGeometry.width / 2,
+                    y: widgetGeometry.y + widgetGeometry.height * 1.5
+                }], [this.pause, 500],
+                [this.checkBlurEvents, widgetData, 1], // no change yet in the number of blur events
+                [this.click, afterElement], [this.waitForDomEltFocus, afterElement],
+                [this.checkBlurEvents, widgetData, 2],
+                // check that the value changed, and keep the new value in clickedValue
+                // depending on the browser, options are not displayed at the same place, so we cannot know
+                // on which option we clicked
+                [function (cb) {
+                    clickedValue = widgetData.value;
+                    this.assertNotEquals(clickedValue, "B");
+                    cb();
+                }],
+
+                [this.click, {
+                    // click on the icon
+                    x: widgetGeometry.x + widgetGeometry.width - 8,
+                    y: widgetGeometry.y + widgetGeometry.height / 2
+                }], [this.pause, 500],
+                [this.checkBlurEvents, widgetData, 2], // no change yet in the number of blur events
+                [this.click, {
+                    // click again on the icon
+                    x: widgetGeometry.x + widgetGeometry.width - 8,
+                    y: widgetGeometry.y + widgetGeometry.height / 2
+                }], [this.pause, 500],
+                [this.click, {
+                    // click in the middle of the widget
+                    x: widgetGeometry.x + widgetGeometry.width / 2,
+                    y: widgetGeometry.y + widgetGeometry.height / 2
+                }], [this.pause, 500],
+                [this.checkBlurEvents, widgetData, 2], // no change yet in the number of blur events
+                // on some browsers, for the native select element, it is needed to click twice:
+                // once to close the (native) popup and once to change the focus:
+                [this.click, beforeElement], [this.click, beforeElement], [this.waitForDomEltFocus, beforeElement],
+                [this.checkBlurEvents, widgetData, 3], // one more blur
+                [function (cb) {
+                    // check that the value did not change:
+                    this.assertEquals(widgetData.value, clickedValue);
+                    cb();
+                }]
+            ], cb);
+        },
+
+        checkBlurEvents: function (widgetData, expectedNumber, cb) {
+            this.assertEquals(widgetData.blurEvents, expectedNumber);
+            cb();
+        },
+
+        checkValue: function (widgetData, expectedValue, cb) {
+            this.assertEquals(widgetData.value, expectedValue);
+            cb();
+        },
+
+        pause: function (delay, cb) {
+            setTimeout(cb, delay);
+        },
+
+        click: function (item, cb) {
+            this.synEvent.click(item, cb);
+        },
+
+        type: function (text, cb) {
+            this.synEvent.type(null, text, cb);
+        },
+
+        execute: function (array, cb) {
+            var self = this;
+            var next = function () {
+                if (array.length === 0) {
+                    self.$callback(cb);
+                    return;
+                }
+                var args = array.shift();
+                var fn = args.shift();
+                args.push(next); // callback argument
+                fn.apply(self, args);
+            };
+            next();
+        }
+    }
+});

--- a/test/aria/widgets/form/select/onBlur/SelectOnBlurScript.js
+++ b/test/aria/widgets/form/select/onBlur/SelectOnBlurScript.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : 'test.aria.widgets.form.select.onBlur.SelectOnBlurScript',
+    $prototype : {
+        selectOnBlur: function (widgetData) {
+            this.$json.setValue(widgetData, "blurEvents", (widgetData.blurEvents || 0) + 1);
+        }
+    }
+});

--- a/test/aria/widgets/form/select/onBlur/SelectOnBlurSimpleRobotTestCase.js
+++ b/test/aria/widgets/form/select/onBlur/SelectOnBlurSimpleRobotTestCase.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.select.onBlur.SelectOnBlurSimpleRobotTestCase",
+    $extends : "test.aria.widgets.form.select.onBlur.SelectOnBlurRobotBase",
+    $constructor : function () {
+        this.$SelectOnBlurRobotBase.constructor.call(this);
+        this.data.widgets = [
+            {
+                sclass: "simple",
+                id: "selectSimple",
+                blurEvents: 0
+            }
+        ];
+    }
+});

--- a/test/aria/widgets/form/select/onBlur/SelectOnBlurStdRobotTestCase.js
+++ b/test/aria/widgets/form/select/onBlur/SelectOnBlurStdRobotTestCase.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.select.onBlur.SelectOnBlurStdRobotTestCase",
+    $extends : "test.aria.widgets.form.select.onBlur.SelectOnBlurRobotBase",
+    $constructor : function () {
+        this.$SelectOnBlurRobotBase.constructor.call(this);
+        this.data.widgets = [
+            {
+                sclass: "std",
+                id: "selectStd",
+                blurEvents: 0
+            }
+        ];
+    }
+});

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -61,6 +61,8 @@ var phantomjsExcludesPatterns = [
     "test/aria/widgets/container/dialog/container/*TestCase.js",
     "test/aria/widgets/wai/popup/dialog/modal/SecondRobotTestCase.js",
     "test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCase.js",
+    // Excluded because clicking on a <select> on PhantomJS does not open it:
+    "test/aria/widgets/form/select/onBlur/SelectOnBlurSimpleRobotTestCase.js",
     // Excluded because it often randomly fails with PhantomJS on travis-ci:
     "test/aria/widgets/container/tooltip/TooltipRobotTestCase.js"
 ];


### PR DESCRIPTION
This commit also adds some fixes to make sure there is no blur event when clicking on the dropdown icon or when clicking on an option in the list.