### PR TITLE
feat #1751 ErrorList widget: now custom displayOptions can be passed to the template

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1609,6 +1609,10 @@ module.exports = Aria.beanDefinitions({
                     $description : "Template used to display the messages list.",
                     $default : "aria.widgets.errorlist.ErrorListTemplate"
                 },
+                "displayOptions" : {
+                    $type : "json:MultiTypes",
+                    $description : "Custom options that are not interpreted and passed to the template."
+                },
                 "messages" : {
                     $type : "json:ObjectRef",
                     $description : "Messages list (of type aria.validators.CfgBeans.MessagesList) to be displayed in the widget.",

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -49,7 +49,6 @@ module.exports = Aria.classDefinition({
         }
 
         this._initTemplate({
-            defaultTemplate : this._cfg.defaultTemplate,
             moduleCtrl : {
                 classpath : "aria.widgets.errorlist.ErrorListController",
                 initArgs : {
@@ -60,7 +59,8 @@ module.exports = Aria.classDefinition({
                     title : cfg.title,
                     titleTag : cfg.titleTag,
                     titleClassName : cfg.titleClassName,
-                    messages : cfg.messages
+                    messages : cfg.messages,
+                    displayOptions : cfg.displayOptions
                 }
             }
         });

--- a/src/aria/widgets/errorlist/ErrorListController.js
+++ b/src/aria/widgets/errorlist/ErrorListController.js
@@ -49,7 +49,8 @@ module.exports = Aria.classDefinition({
                 titleClassName : args.titleClassName,
                 divCfg : args.divCfg,
                 filterTypes : args.filterTypes,
-                displayCodes : args.displayCodes
+                displayCodes : args.displayCodes,
+                displayOptions : args.displayOptions
             };
             this.setMessages(args.messages);
             this.$callback(cb);

--- a/test/aria/widgets/errorlist/displayOptions/ErrorListCustomTemplate.tpl
+++ b/test/aria/widgets/errorlist/displayOptions/ErrorListCustomTemplate.tpl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath: 'test.aria.widgets.errorlist.displayOptions.ErrorListCustomTemplate'
+}}
+
+	{macro main()}
+		<div id='${this.data.displayOptions.id}'>${this.data.displayOptions.text}</div>
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/errorlist/displayOptions/ErrorListDisplayOptionsTestCase.js
+++ b/test/aria/widgets/errorlist/displayOptions/ErrorListDisplayOptionsTestCase.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var TemplateTestCase = require('ariatemplates/jsunit/TemplateTestCase');
+
+require('./ErrorListCustomTemplate.tpl');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath: 'test.aria.widgets.errorlist.displayOptions.ErrorListDisplayOptionsTestCase',
+    $extends: TemplateTestCase,
+
+    $constructor: function () {
+        this.$TemplateTestCase.$constructor.apply(this, arguments);
+
+        var text = 'This is custom text passed to ErrorList widget instance\'s template through the displayOptions property';
+        this._text = text;
+
+        var elementId = 'error_list_template_content';
+        this._elementId = elementId;
+
+        this.setTestEnv({
+            template: 'test.aria.widgets.errorlist.displayOptions.Tpl',
+            data: {
+                text: text,
+                elementId: elementId
+            }
+        });
+    },
+
+    $prototype: {
+        runTemplateTest: function () {
+            var contentElement = Aria.$window.document.getElementById(this._elementId);
+
+            this.assertTrue(contentElement != null, 'Custom id should have been passed and output to build the element.');
+            this.assertTrue(contentElement.textContent === this._text, 'Custom text should have been passed and output inside the element.');
+
+            this.end();
+        }
+    }
+});

--- a/test/aria/widgets/errorlist/displayOptions/Tpl.tpl
+++ b/test/aria/widgets/errorlist/displayOptions/Tpl.tpl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath: 'test.aria.widgets.errorlist.displayOptions.Tpl'
+}}
+
+	{macro main()}
+		{@aria:ErrorList {
+			defaultTemplate: 'test.aria.widgets.errorlist.displayOptions.ErrorListCustomTemplate',
+			displayOptions: {
+				text: this.data.text,
+				id: this.data.elementId
+			}
+		}/}
+	{/macro}
+
+{/Template}


### PR DESCRIPTION
Now the template used by the `ErrorList` widget will have a `displayOptions` property in its data model, as defined by the user inside the widget instance's configuration under the homonym property.