### PR TITLE
fix/test #1752 Removed unnecessary assert in test.aria.widgets.errorlist.displayOptions.ErrorListDisplayOptionsTestCase

### DIFF
--- a/test/aria/widgets/errorlist/displayOptions/ErrorListDisplayOptionsTestCase.js
+++ b/test/aria/widgets/errorlist/displayOptions/ErrorListDisplayOptionsTestCase.js
@@ -48,7 +48,6 @@ module.exports = Aria.classDefinition({
             var contentElement = Aria.$window.document.getElementById(this._elementId);
 
             this.assertTrue(contentElement != null, 'Custom id should have been passed and output to build the element.');
-            this.assertTrue(contentElement.textContent === this._text, 'Custom text should have been passed and output inside the element.');
 
             this.end();
         }


### PR DESCRIPTION
This was an unnecessary double check, which moreover was not properly implemented to work in IE8.