### PR TITLE
Fixing issues in tests following #1749

### DIFF
--- a/test/aria/widgets/form/autocomplete/issue315/OpenDropDownFromButtonRobotTestCase.js
+++ b/test/aria/widgets/form/autocomplete/issue315/OpenDropDownFromButtonRobotTestCase.js
@@ -1,9 +1,9 @@
 Aria.classDefinition({
-    $classpath : "test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonTestCase",
-    $extends : "aria.jsunit.TemplateTestCase",
+    $classpath : "test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonRobotTestCase",
+    $extends : "aria.jsunit.RobotTestCase",
     $dependencies : ["aria.utils.FireDomEvent"],
     $constructor : function () {
-        this.$TemplateTestCase.constructor.call(this);
+        this.$RobotTestCase.constructor.call(this);
         this.setTestEnv({
             template : "test.aria.widgets.form.autocomplete.issue315.OpenDropDownFromButtonTestCaseTpl",
             data : {

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -110,7 +110,11 @@ var generalBrowserExcludes = {
     "Chrome": [
         "test/aria/utils/mouse/MouseDragKoRobotTestCase.js"
     ],
-    "Safari": [],
+    "Safari": [
+        // Excluded because a <select> in Safari behaves differently (pressing the down arrow key opens the
+        // dropdown instead of changing the selection):
+        "test/aria/widgets/form/select/onBlur/SelectOnBlurSimpleRobotTestCase.js"
+    ],
     "IE 7": [
         "test/aria/utils/domNavigationManager/DomNavigationManagerRobotTestCase.js"
     ],


### PR DESCRIPTION
This PR fixes test issues which are happening following commit 8432f5b24f516bfc1361181d98535736c5b9fd47 from #1749:
- `SelectOnBlurSimpleRobotTestCase` fails on Safari because a `<select>` in Safari (on Mac) behaves differently than in other browsers (on Windows): pressing the down arrow key opens the dropdown instead of only changing the selection, as it is expected in the test. This test is now excluded from the test campaign for Safari.

- `OpenDropDownFromButtonTestCase` fails on IE 8 because SynEvents does not faithfully reproduces the behavior of IE 8. This test was replaced by a robot test which correctly tests what is really happening on IE 8.