### PR TITLE
Fix for 1754 - fix __includePropForBackRef in utils/Json.js

### DIFF
--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -106,6 +106,10 @@ var ariaUtilsObject = require("./Object");
      * @private
      */
     var __includePropForBackRef = function (propertyName) {
+        if (!ariaUtilsType.isString(propertyName)) {
+            return true;
+        }
+
         // which property names are included for back references
         return (propertyName != jsonUtils.OBJECT_PARENT_PROPERTY &&
             propertyName.substr(0, jsonUtils.META_FOR_LISTENERS.length) != jsonUtils.META_FOR_LISTENERS &&

--- a/src/aria/utils/Json.js
+++ b/src/aria/utils/Json.js
@@ -107,7 +107,9 @@ var ariaUtilsObject = require("./Object");
      */
     var __includePropForBackRef = function (propertyName) {
         // which property names are included for back references
-        return (propertyName != jsonUtils.OBJECT_PARENT_PROPERTY && propertyName != jsonUtils.META_FOR_LISTENERS && propertyName != jsonUtils.META_FOR_RECLISTENERS);
+        return (propertyName != jsonUtils.OBJECT_PARENT_PROPERTY &&
+            propertyName.substr(0, jsonUtils.META_FOR_LISTENERS.length) != jsonUtils.META_FOR_LISTENERS &&
+            propertyName.substr(0, jsonUtils.META_FOR_RECLISTENERS.length) != jsonUtils.META_FOR_RECLISTENERS);
     };
 
     /**


### PR DESCRIPTION
Fix for issue 1754
__includePropForBackRef now checks that the provided property name starts with, and not is equal to, the aria:listener and aria:reclistener prefixes.