### PR TITLE
Adding Romanian date resources

### DIFF
--- a/build/config/locales.json
+++ b/build/config/locales.json
@@ -27,6 +27,7 @@
     "pl_PL",
     "pt_BR",
     "pt_PT",
+    "ro_RO",
     "ru_RU",
     "sv_SE",
     "th_TH",

--- a/src/aria/resources/DateRes_ro_RO.js
+++ b/src/aria/resources/DateRes_ro_RO.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates ro-RO
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "Duminică",
+            "Luni",
+            "Marți",
+            "Miercuri",
+            "Joi",
+            "Vineri",
+            "Sâmbătă"
+        ],
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "Ianuarie",
+            "Februarie",
+            "Martie",
+            "Aprilie",
+            "Mai",
+            "Iunie",
+            "Iulie",
+            "August",
+            "Septembrie",
+            "Octombrie",
+            "Noiembrie",
+            "Decembrie"
+        ]
+    }
+});


### PR DESCRIPTION
This PR adds partial support for the Romanian language, which can be used to make `aria.utils.Date.format` return formatted dates in Romanian.