### PR TITLE
Keep existing log appenders in aria.jsunit.Assert

### DIFF
--- a/src/aria/core/Cache.js
+++ b/src/aria/core/Cache.js
@@ -36,9 +36,7 @@ module.exports = Aria.classDefinition({
             "CML" : ".cml",
             "TXT" : ".tpl.txt",
             "RES" : ".js"
-        },
-
-        DEPRECATED_METHOD : "%1 is deprecated."
+        }
     },
     $prototype : {
         /**
@@ -118,7 +116,6 @@ module.exports = Aria.classDefinition({
          * @return {String} logical path e.g x/y/MyClass.tpl
          */
         getFilename : function (classpath) {
-            this.$logWarn(this.DEPRECATED_METHOD, ["getFilename"]);
             var basePath = Aria.getLogicalPath(classpath);
             for (var i = 0, l = atExtensions.length; i < l; i++) {
                 try {

--- a/src/aria/core/ClassMgr.js
+++ b/src/aria/core/ClassMgr.js
@@ -34,7 +34,7 @@ module.exports = Aria.classDefinition({
     },
     $statics : {
         NODER_MIGRATION : "With the migration to noder-js, aria.core.ClassMgr.%1 is no longer supported.",
-        DEPRECATED_METHOD : "aria.core.ClassMgr.%1 is deprecated."
+        DEPRECATED_METHOD : "aria.core.ClassMgr.%1 is deprecated. Please use %2 instead."
     },
     $prototype : {
         /**
@@ -110,8 +110,6 @@ module.exports = Aria.classDefinition({
          * be bypassed by adding a timestamp to the url
          */
         unloadClass : function (classpath, timestampNextTime) {
-            this.$logWarn(this.DEPRECATED_METHOD, ["unloadClass"]);
-
             var classRef = Aria.getClassRef(classpath);
             // no class ref for beans
             if (classRef) {

--- a/src/aria/core/Log.js
+++ b/src/aria/core/Log.js
@@ -254,6 +254,7 @@ module.exports = Aria.classDefinition({
          */
         addAppender : function (appender) {
             this._appenders.push(appender);
+            return appender;
         },
 
         /**

--- a/src/aria/jsunit/Assert.js
+++ b/src/aria/jsunit/Assert.js
@@ -92,23 +92,12 @@ var ariaUtilsJson = require("../utils/Json");
              */
             this._expectedErrorList = null;
 
-            ariaCoreLog.clearAppenders();
-            ariaCoreLog.addAppender(new (require("../core/log/SilentArrayAppender"))());
-            if (Aria.verbose) {
-                // Readd the default appender in verbose mode to log things also to the browser console.
-                // The order of appenders matters due to getAppenders()[0] used in assertErrorInLogs|assertLogsEmpty.
-                // Not using Aria.debug not to have a message flood in Attester.
-                ariaCoreLog.addAppender(new (require("../core/log/DefaultAppender"))());
-            }
-
-            ariaCoreLog.resetLoggingLevels();
-            ariaCoreLog.setLoggingLevel("*", 1);
+            this._logAppender = ariaCoreLog.addAppender(new (require("../core/log/SilentArrayAppender"))());
         },
         $destructor : function () {
             this._expectedEventsList = null;
             this.$Test.$destructor.call(this);
-
-            // appenders are cleared after the destroy so we can check for error in $dispose
+            ariaCoreLog.removeAppender(this._logAppender);
         },
         $prototype : {
             /**
@@ -328,7 +317,7 @@ var ariaUtilsJson = require("../utils/Json");
                     this._assertCount++;
                     this._totalAssertCount++;
                 }
-                var logAppender = ariaCoreLog.getAppenders()[0];
+                var logAppender = this._logAppender;
 
                 if (!logAppender.isEmpty()) {
                     var logs = logAppender.getLogs(), errFound = false, msg = '';
@@ -378,7 +367,7 @@ var ariaUtilsJson = require("../utils/Json");
              */
             assertErrorInLogs : function (errorMsg, count) {
                 var res = null;
-                var logAppender = ariaCoreLog.getAppenders()[0];
+                var logAppender = this._logAppender;
                 var logs = logAppender.getLogs(), errFound = false, newLogs = [];
                 if (!errorMsg) {
                     this.assertTrue(false, "assertErrorInLogs was called with a null error message.");

--- a/src/aria/jsunit/TestSuite.js
+++ b/src/aria/jsunit/TestSuite.js
@@ -18,8 +18,6 @@ var ariaJsunitTestCase = require("./TestCase");
 var ariaJsunitTestWrapper = require("./TestWrapper");
 var ariaUtilsType = require("../utils/Type");
 var ariaJsunitTest = require("./Test");
-var ariaCoreLog = require("../core/Log");
-
 
 /**
  * The testsuite class
@@ -581,9 +579,6 @@ module.exports = Aria.classDefinition({
                     description : "Uncaught exception while destroying " + classpath + "\nMessage : " + er.message
                 });
             }
-
-            ariaCoreLog.clearAppenders();
-            ariaCoreLog.resetLoggingLevels();
 
             this.__runningTest = null;
         },

--- a/test/aria/pageEngine/IframeBase.js
+++ b/test/aria/pageEngine/IframeBase.js
@@ -86,7 +86,7 @@ Aria.classDefinition({
         },
 
         _waitForAriaLoad : function (cb) {
-            this._testWindow.aria.core.Log.addAppender(aria.core.Log.getAppenders()[0]);
+            this._testWindow.aria.core.Log.addAppender(this._logAppender);
             if (this._dependencies.length > 0) {
                 this._testWindow.Aria.load({
                     classes : this._dependencies,

--- a/test/aria/templates/inheritance/logs/LogsTestCase.js
+++ b/test/aria/templates/inheritance/logs/LogsTestCase.js
@@ -31,7 +31,7 @@ Aria.classDefinition({
 
         runTemplateTest : function () {
 
-            var logAppender = aria.core.Log.getAppenders()[0];
+            var logAppender = this._logAppender;
             var logs = logAppender.getLogs();
 
             var expectedErrorsNb = 2;

--- a/test/aria/utils/HistoryTestCase.js
+++ b/test/aria/utils/HistoryTestCase.js
@@ -70,7 +70,7 @@
                 if (this._testInIframe) {
                     this._newWindow = this._iframe.contentWindow;
                 }
-                this._newWindow.aria.core.Log.addAppender(aria.core.Log.getAppenders()[0]);
+                this._newWindow.aria.core.Log.addAppender(this._logAppender);
                 this._newWindow.document.title = "HistoryTest";
 
                 this.waitFor({

--- a/test/aria/widgets/form/autocomplete/issue315/OpenDropDownFromButtonRobotTestCase.js
+++ b/test/aria/widgets/form/autocomplete/issue315/OpenDropDownFromButtonRobotTestCase.js
@@ -13,7 +13,7 @@ Aria.classDefinition({
     },
     $prototype : {
         runTemplateTest : function () {
-            aria.core.Log.getAppenders()[0].setLogs([]);
+            this._logAppender.setLogs([]);
             var expandButton = this.getExpandButton("ac1");
             this.synEvent.click(expandButton, {
                 fn : function () {
@@ -32,7 +32,7 @@ Aria.classDefinition({
         },
 
         _openAc : function (evt, args) {
-            var logs = aria.core.Log.getAppenders()[0].getLogs();
+            var logs = this._logAppender.getLogs();
             this.assertEquals(logs.length, 1);
             this.assertEquals(logs[0].msg, "OpenDropDownFromButtonTest handler message");
             this.notifyTemplateTestEnd();


### PR DESCRIPTION
Before this PR, creating an instance of `aria.jsunit.Assert` (the base class for most tests) cleared all appenders in `aria.core.Log`. Now, this class only manages its own appender to collect errors during tests and no longer impacts any other appender.
See also #590.

Also, a second commit in the PR removes the deprecation messages for `unloadClass` and `getFilename` as those methods are used in the framework itself (especially in base test classes but also in some other places) and the messages can then be confusing for an application developer which does not call those methods directly, and those messages are more visible in test logs if appenders are not cleared (and they are no longer cleared in the `Assert` class).