### PR TITLE
Beans pre-compilation

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -40,6 +40,7 @@ module.exports = function (grunt) {
 
     grunt.config.set('atpackager.prod', {
         options : {
+            ATDebug : true,
             ATBootstrapFile : packagingSettings.bootstrap.bootstrapFileName,
             sourceDirectories : packagingSettings.prod.sourceDirectories,
             sourceFiles : ['**/*', '!aria/node.js', '!' + packagingSettings.bootstrap.bootstrapFileName],
@@ -68,7 +69,7 @@ module.exports = function (grunt) {
                             noCircularDependencies : false,
                             checkPackagesOrder : false
                         }
-                    }, 'ATValidateTemplates', 'ATCompileTemplates', 'ATRemoveDoc', {
+                    }, 'ATValidateTemplates', 'ATCompileTemplates', 'ATRemoveDoc', '<%= atbuildOptions.compileBeansVisitor %>', {
                         type : 'JSMinify',
                         cfg : {
                             files : atExtensions,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "at-noder-converter": "1.1.1",
-    "atpackager": "0.2.9",
+    "atpackager": "0.2.10",
     "gzip-js": "0.3.2",
     "noder-js": "1.6.2"
   },

--- a/src/aria/core/JsonTypesCheck.js
+++ b/src/aria/core/JsonTypesCheck.js
@@ -622,7 +622,8 @@ var ariaCoreJsonValidator = require("./JsonValidator");
         $classpath : "aria.core.JsonTypesCheck",
         $singleton : true,
         $statics : {
-            baseTypes : baseTypes
+            baseTypes : baseTypes,
+            fastNormalizers : fastNormalizers
         },
         $prototype : {}
     });

--- a/src/aria/utils/BeanExtractor.js
+++ b/src/aria/utils/BeanExtractor.js
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("../Aria");
+var jv = require("../core/JsonValidator");
+var fastNormalizers = require("../core/JsonTypesCheck").fastNormalizers;
+var ariaUtilsString = require("./String");
+var ariaUtilsType = require("./Type");
+var asyncRequire = require('noder-js/asyncRequire').create(module);
+
+var getNamespaceLogicalPath = function (namespace) {
+    if (typeof namespace !== "string") {
+        namespace = namespace.$package;
+    }
+    return Aria.getLogicalPath(namespace, ".js");
+};
+
+var Code = function (code) {
+    this.code = code;
+};
+
+var namespacesReplacer = function (path, value) {
+    if (path.length === 1) {
+        return new Code("require(" + ariaUtilsString.stringify(getNamespaceLogicalPath(value)) + ")");
+    }
+    return value;
+};
+
+var variablesMgr = function () {
+    var counter = 0;
+    var out = null;
+    return {
+        createVariable: function (value) {
+            if (!out) {
+                out = ["var "];
+            } else {
+                out.push(",\n");
+            }
+            var name = "v" + counter;
+            counter++;
+            out.push(name, "=", value);
+            return name;
+        },
+        getCode: function () {
+            var res = "";
+            if (out) {
+                out.push(";");
+                res = out.join("");
+                out = null;
+            }
+            return res;
+        }
+    };
+};
+
+var stringify = function (rootValue, filter, replacer) {
+    var out = [];
+    var processValue = function (path, value) {
+        if (replacer) {
+            value = replacer(path, value, rootValue);
+        }
+        if (value instanceof Code) {
+            out.push(value.code);
+        } else if (ariaUtilsType.isArray(value)) {
+            out.push("[");
+            var first = true;
+            for (var i = 0, l = value.length; i < l; i++) {
+                var subPath = path.concat([i]);
+                var subValue = value[i];
+                if (filter(subPath, subValue, rootValue)) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        out.push(",");
+                    }
+                    processValue(subPath, subValue);
+                }
+            }
+            out.push("]");
+        } else if (ariaUtilsType.isObject(value)) {
+            out.push("{");
+            var first = true;
+            for (var key in value) {
+                if (value.hasOwnProperty(key)) {
+                    var subPath = path.concat([key]);
+                    var subValue = value[key];
+                    if (filter(subPath, subValue, rootValue)) {
+                        if (first) {
+                            first = false;
+                        } else {
+                            out.push(",");
+                        }
+                        out.push(ariaUtilsString.stringify(key), ":");
+                        processValue(subPath, subValue);
+                    }
+                }
+            }
+            out.push("}");
+        } else if (ariaUtilsType.isString(value)) {
+            out.push(ariaUtilsString.stringify(value));
+        } else if (value == null || ariaUtilsType.isBoolean(value) || ariaUtilsType.isNumber(value) || isNaN(value) || ariaUtilsType.isFunction(value) || ariaUtilsType.isRegExp(value)) {
+            out.push(value + "");
+        } else {
+            throw new Error("Unexpected value to stringify: " + value);
+        }
+    };
+
+    processValue([], rootValue);
+    return out.join("");
+};
+
+var excludedProperties = {
+    $properties: true,
+    $contentType: true,
+    $keyType: true,
+    $contentTypes: true
+};
+excludedProperties[jv._MD_TYPENAME] = true;
+excludedProperties[jv._MD_PARENTDEF] = true;
+excludedProperties[jv._MD_BASETYPE] = true;
+
+var docExcludedProperties = {
+    $description: true,
+    $sample: true
+};
+
+var onlyFastNormIncludedProperties = {
+    $fastNorm: true,
+    $getDefault: true
+};
+
+var getTypeName = function (bean) {
+    return bean[jv._MD_TYPENAME];
+};
+
+var getParentBean = function (bean) {
+    return bean[jv._MD_PARENTDEF];
+};
+
+var WeakMap = Aria.$global.WeakMap || (function () {
+    // mini weak map implementation for our needs
+    var weakMapCounter = 0;
+    var WeakMap = function () {
+        this._key = "aria.utils.BeanExtractor:weakMap" + weakMapCounter;
+        weakMapCounter++;
+    };
+    WeakMap.prototype = {
+        'get': function (obj) {
+            return obj[this._key];
+        },
+        'set': function (obj, value) {
+            obj[this._key] = value;
+        }
+    };
+    return WeakMap;
+})();
+
+var globalFnMap = new WeakMap();
+for (var key in fastNormalizers) {
+    if (fastNormalizers.hasOwnProperty(key)) {
+        globalFnMap.set(fastNormalizers[key], "fastNormalizers." + key);
+    }
+}
+globalFnMap.set(Aria.returnNull, "Aria.returnNull");
+
+module.exports = Aria.classDefinition({
+    $classpath: "aria.utils.BeanExtractor",
+    $singleton: true,
+    $prototype: {
+        /**
+         * Extracts and serializes the compiled version of a beans package.
+         * @param {String} logicalPath Logical path of the beans package to extract and serialize.
+         * @param {Object} config Configuration options. The following configuration options are available:
+         * <ul>
+         * <li>onlyFastNorm (Boolean) If this property is set to true (which is the default), only bean properties needed for fast normalization are
+         * included in the result ($getDefault and $fastNorm). This means the resulting file will not be usable to fully check the structure of data,
+         * it will only be usable to add default values.</li>
+         * <li>removeMultiTypes (Boolean) If this property is set to true (which is the default), the $contentTypes property of MultiTypes beans will
+         * not be included in the result.</li>
+         * <li>removeDoc (Boolean) If this property is set to true (which is the default), the $description and $sample properties of bean definitions
+         * will not be included in the result.</li>
+         * </ul>
+         * @return {Object} A noder-js promise resolving to an object that contains the following two properties:
+         * <ul>
+         * <li>skip (Boolean): If this property is true, the given logical path does not contain a bean that can be serialized. This is the case for
+         * aria.core.JsonTypes (which cannot be serialized by this method yet) and for logical paths that do not contain bean definitions.</li>
+         * <li>text (String): If skip is false, this property contains the serialized string of the module.</li>
+         * </ul>
+         */
+        extract: function (logicalPath, config) {
+            return asyncRequire(logicalPath).spreadSync(function (beanPackage) {
+                if (!(beanPackage.$package && beanPackage.$namespaces && beanPackage.$beans) || beanPackage.$package === jv._BASE_TYPES_PACKAGE) {
+                    return {
+                        skip: true,
+                        text: null
+                    };
+                }
+                config = config || {};
+                config.removeDoc = "removeDoc" in config ? !!config.removeDoc : true;
+                config.removeMultiTypes = "removeMultiTypes" in config ? !!config.removeMultiTypes : true;
+                config.onlyFastNorm = "onlyFastNorm" in config ? !!config.onlyFastNorm : true;
+                var variables = variablesMgr();
+                var subBeansCode = [];
+                var toPostProcess = [];
+                var packagePathPrefix = beanPackage.$package + ".";
+                var packagePathPrefixLength = packagePathPrefix.length;
+                var referencedBeans = {};
+                var beanStringifyFilter = function (path) {
+                    if (path.length === 1) {
+                        var name = path[0];
+                        if (config.onlyFastNorm) {
+                            return onlyFastNormIncludedProperties.hasOwnProperty(name);
+                        }
+                        if (excludedProperties.hasOwnProperty(name)) {
+                            return false;
+                        }
+                        if (config.removeDoc && docExcludedProperties.hasOwnProperty(name)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                };
+                var localFnMap = new WeakMap();
+                var beanPropertiesReplacer = function (path, value, bean) {
+                    if (ariaUtilsType.isFunction(value)) {
+                        var varName = localFnMap.get(value);
+                        if (!varName) {
+                            var expression = globalFnMap.get(value);
+                            if (!expression) {
+                                var parentBean = getParentBean(bean);
+                                if (value === parentBean.$fastNorm) {
+                                    expression = getVariable(processBean(parentBean)) + ".$fastNorm";
+                                } else {
+                                    expression = value.toString();
+                                }
+                            }
+                            varName = variables.createVariable(expression);
+                            localFnMap.set(value, varName);
+                        }
+                        return new Code(varName);
+                    }
+                    return value;
+                };
+
+                var getVariable = function (beanInfo) {
+                    if (!beanInfo.variable) {
+                        throw new Error("Invalid recursive structure in " + getTypeName(beanInfo.bean));
+                    }
+                    return beanInfo.variable;
+                };
+                var processSubBean = function (beanInfo, key) {
+                    var subBean = beanInfo.bean[key];
+                    if (subBean) {
+                        subBeansCode.push(getVariable(beanInfo), ".", key, "=", getVariable(processBean(subBean)), ";");
+                    }
+                };
+                var processSubBeansCollection = function (beanInfo, key) {
+                    var collection = beanInfo.bean[key];
+                    if (collection) {
+                        var parentBean = getParentBean(beanInfo.bean);
+                        if (collection === parentBean[key]) {
+                            var parentBeanInfo = processBean(parentBean);
+                            subBeansCode.push(getVariable(beanInfo), ".", key, "=", getVariable(parentBeanInfo), ".", key, ";");
+                        } else {
+                            subBeansCode.push(getVariable(beanInfo), ".", key, "=", processBeansCollection(collection), ";");
+                        }
+                    }
+                };
+                var processBean = function (bean) {
+                    var typeName = getTypeName(bean);
+                    var beanInfo = referencedBeans[typeName];
+                    if (!beanInfo) {
+                        beanInfo = referencedBeans[typeName] = {
+                            bean: bean
+                        };
+                        var value;
+                        var internalBean = typeName.substr(0, packagePathPrefixLength) === packagePathPrefix;
+                        if (internalBean) {
+                            var processedParentBean = processBean(getParentBean(bean));
+                            var out = ["registerBean(", ariaUtilsString.stringify(typeName.substr(packagePathPrefixLength)), ",", getVariable(processedParentBean)];
+                            var stringifiedBean = stringify(bean, beanStringifyFilter, beanPropertiesReplacer);
+                            if (stringifiedBean !== "{}") {
+                                out.push(",", stringifiedBean);
+                            }
+                            out.push(")");
+                            value = out.join("");
+                            toPostProcess.push(beanInfo);
+                        } else {
+                            value = "getBean(" + ariaUtilsString.stringify(typeName) + ")";
+                        }
+                        beanInfo.variable = variables.createVariable(value);
+                    }
+                    return beanInfo;
+                };
+                var postProcessBeanInfo = function (beanInfo) {
+                    processSubBean(beanInfo, "$contentType");
+                    processSubBean(beanInfo, "$keyType");
+                    processSubBeansCollection(beanInfo, "$properties");
+                    if (Aria.debug && !config.removeMultiTypes) {
+                        processSubBeansCollection(beanInfo, "$contentTypes");
+                    }
+                };
+                var beanVariableReplacer = function (path, value) {
+                    if (path.length === 1) {
+                        return new Code(getVariable(processBean(value)));
+                    }
+                    return value;
+                };
+                var processBeansCollection = function (beans) {
+                    return stringify(beans, Aria.returnTrue, beanVariableReplacer);
+                };
+
+                var output = processBeansCollection(beanPackage.$beans);
+                if (config.onlyFastNorm) {
+                    output = "{}";
+                }
+                while (toPostProcess.length > 0) {
+                    postProcessBeanInfo(toPostProcess.shift());
+                }
+                return {
+                    skip: false,
+                    text: [
+                        'var Aria = require("ariatemplates/Aria");\n',
+                        'module.exports = Aria.beanDefinitions({\n',
+                            '$package:', ariaUtilsString.stringify(beanPackage.$package),',\n',
+                            '$namespaces:', stringify(beanPackage.$namespaces, Aria.returnTrue, namespacesReplacer), ',\n',
+                            '$compiled:function(registerBean, getBean, fastNormalizers){\n',
+                                variables.getCode(), subBeansCode.join(""), "\n",
+                                "return ", output, ";\n",
+                            '}\n',
+                        '});\n'
+                    ].join("")
+                };
+            });
+        }
+    }
+});

--- a/tasks/easypackage/configuration.js
+++ b/tasks/easypackage/configuration.js
@@ -61,7 +61,10 @@ module.exports = function (grunt, args) {
                         checkPackagesOrder : false
                     }
                 } : null, args.validateTemplates ? 'ATValidateTemplates' : null,
-                args.compileTemplates ? 'ATCompileTemplates' : null, 'ATRemoveDoc', args.convertToNoderjs ? {
+                args.compileTemplates ? 'ATCompileTemplates' : null, 'ATRemoveDoc', args.compileBeans ? {
+                    type: "ATCompileBeans",
+                    cfg: args.compileBeans
+                } : null, args.convertToNoderjs ? {
                     type : 'ATNoderConverter',
                     cfg : {
                         files : args.convertToNoderjs

--- a/tasks/task-atbuild.js
+++ b/tasks/task-atbuild.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
             packages : require('../build/config/files-prod.json'),
             outputDirectory : packagingSettings.prod.outputDirectory,
             outputBootstrapFile : packagingSettings.bootstrap.bootstrapFileName,
+            compileBeans : false,
             clean : true,
             gzipStats : false,
             checkPackaged : true
@@ -41,6 +42,10 @@ module.exports = function (grunt) {
         grunt.config.set('atbuildOptions.allow_unpackaged_files', options.checkPackaged
                 ? packagingSettings.prod.allowUnpackagedFiles
                 : ['**/*']);
+        grunt.config.set('atbuildOptions.compileBeansVisitor', options.compileBeans ? {
+            type: "ATCompileBeans",
+            cfg: options.compileBeans
+        } : null);
         grunt.config.set('atbuildOptions.localization_files', require('../build/config/files-prod-localization.json'));
         grunt.config.set('atbuildOptions.license_min', packagingSettings.licenseMin);
         grunt.config.set('atbuildOptions.license', packagingSettings.license);

--- a/tasks/task-easypackage.js
+++ b/tasks/task-easypackage.js
@@ -41,6 +41,7 @@ module.exports = function (grunt) {
             includeDependencies : true,
             validateTemplates : false,
             compileTemplates : true,
+            compileBeans : false,
             minify : true,
             hash : true,
             checkPackaged : false,

--- a/test/nodeTestResources/testProject/attester/attester3.yml
+++ b/test/nodeTestResources/testProject/attester/attester3.yml
@@ -1,0 +1,14 @@
+resources:
+ '/':
+  - 'test/nodeTestResources/testProject/target/three'
+  - 'test/nodeTestResources/testProject/target/fwk'
+  - 'test/nodeTestResources/testProject/test'
+tests:
+ aria-templates:
+  bootstrap: '/custom-at.js'
+  extraScripts:
+   - /map.js
+   - /extraScript.js
+  classpaths:
+   includes:
+    - SampleBeanTest

--- a/test/nodeTestResources/testProject/attester/attester4.yml
+++ b/test/nodeTestResources/testProject/attester/attester4.yml
@@ -1,0 +1,15 @@
+resources:
+ '/':
+  - 'test/nodeTestResources/testProject/target/beans/app'
+  - 'test/nodeTestResources/testProject/target/beans/fwk'
+  - 'test/nodeTestResources/testProject/test'
+tests:
+ aria-templates:
+  bootstrap: '/ariatemplates.js'
+  extraScripts:
+   - /map.js
+   - /extraScript.js
+  classpaths:
+   includes:
+    - AppTemplateTest
+    - SampleBeanTest

--- a/test/nodeTestResources/testProject/gruntfiles/Gruntfile4.js
+++ b/test/nodeTestResources/testProject/gruntfiles/Gruntfile4.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Beans precompilation
+
+var path = require('path');
+module.exports = function (grunt) {
+    grunt.registerTask('default', ['atbuild', 'easypackage']);
+    grunt.loadTasks('../../../../tasks');
+    grunt.config.set('atbuild.default', {
+        options : {
+            bootstrapFiles : require(path.join(__dirname, '../build/config/files-bootstrap.json')),
+            packages : require(path.join(__dirname, '../build/config/files-prod.json')),
+            checkPackaged : false,
+            outputBootstrapFile : 'ariatemplates.js',
+            outputDirectory : path.join(__dirname, '../target/beans/fwk'),
+            compileBeans : {
+                onlyFastNorm: true
+            },
+            clean : true,
+            gzipStats : false
+        }
+    });
+    grunt.config.set('easypackage.default', {
+        options : {
+            outputDirectory : path.join(__dirname, "../target/beans/app"),
+            sourceDirectories : [path.join(__dirname, '../src')],
+            sourceFiles : ['**/*'],
+            ATAppEnvironment : {
+                defaultWidgetLibs : {
+                    "light" : "atplugins.lightWidgets.LightWidgetLib"
+                }
+            },
+            compileBeans : {
+                onlyFastNorm: true
+            },
+            includeDependencies : true,
+            packages : [{
+                name : "app.js",
+                files : ["app/css/SkinLoader.js", "app/SampleTemplate.tpl"]
+            }],
+            clean : true,
+            gzipStats : false,
+            hash : false
+        }
+    });
+};

--- a/test/nodeTestResources/testProject/src/app/SampleBean.js
+++ b/test/nodeTestResources/testProject/src/app/SampleBean.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.beanDefinitions({
+    $package : "app.SampleBean",
+    $namespaces : {
+        "json" : "aria.core.JsonTypes"
+    },
+    $beans : {
+        "Tree" : {
+            $type : "json:Object",
+            $properties : {
+                "value1" : {
+                    $type : "json:Integer",
+                    $default : 3
+                },
+                "subTrees" : {
+                    $type : "json:Array",
+                    $default : [],
+                    $contentType : {
+                        $type : "Tree"
+                    }
+                },
+                "value2" : {
+                    $type : "json:Integer",
+                    $default : 7
+                }
+            }
+        }
+    }
+});

--- a/test/nodeTestResources/testProject/test/SampleBeanTest.js
+++ b/test/nodeTestResources/testProject/test/SampleBeanTest.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "SampleBeanTest",
+    $extends : "aria.jsunit.TestCase",
+    $dependencies : ["aria.core.JsonValidator", "app.SampleBean"],
+    $prototype : {
+
+        _initialData : function () {
+            return {
+                value1 : 1,
+                subTrees : [{
+                            value2 : 0
+                        }, {
+                            value1 : 4,
+                            subTrees : [{
+                                        subTrees : [{
+                                                    subTrees : []
+                                                }, {
+                                                    value1 : 2
+                                                }]
+                                    }]
+                        }]
+            };
+        },
+
+        _normalizedData : function () {
+            return {
+                value1 : 1,
+                value2 : 7,
+                subTrees : [{
+                            value1 : 3,
+                            value2 : 0,
+                            subTrees : []
+                        }, {
+                            value1 : 4,
+                            value2 : 7,
+                            subTrees : [{
+                                        value1 : 3,
+                                        value2 : 7,
+                                        subTrees : [{
+                                                    value1 : 3,
+                                                    value2 : 7,
+                                                    subTrees : []
+                                                }, {
+                                                    value1 : 2,
+                                                    value2 : 7,
+                                                    subTrees : []
+                                                }]
+                                    }]
+                        }]
+            };
+        },
+
+        _checkNormalization : function () {
+            var param = {
+                json : this._initialData(),
+                beanName : "app.SampleBean.Tree"
+            };
+            var res = aria.core.JsonValidator.normalize(param);
+            this.assertJsonEquals(param.json, this._normalizedData());
+        },
+
+        testExecuteNormalize : function () {
+            this._checkNormalization();
+        }
+    }
+});


### PR DESCRIPTION
This PR adds support for beans pre-compilation and optimizes a bit `aria.core.JsonValidator` to avoid generating twice the same fast-normalization function when a bean can simply reuse the fast-normalization function of its parent.