### PR TITLE
Fixes and improvements for beans pre-compilation

### DIFF
--- a/build/grunt-config/config-atpackager-prod.js
+++ b/build/grunt-config/config-atpackager-prod.js
@@ -40,7 +40,6 @@ module.exports = function (grunt) {
 
     grunt.config.set('atpackager.prod', {
         options : {
-            ATDebug : true,
             ATBootstrapFile : packagingSettings.bootstrap.bootstrapFileName,
             sourceDirectories : packagingSettings.prod.sourceDirectories,
             sourceFiles : ['**/*', '!aria/node.js', '!' + packagingSettings.bootstrap.bootstrapFileName],

--- a/src/aria/Aria.js
+++ b/src/aria/Aria.js
@@ -1621,6 +1621,20 @@ var Aria = module.exports = global.Aria;
         return arg;
     };
 
+    /**
+     * Returns an empty object. To be used in order to avoid closures.
+     */
+    Aria.returnObject = function () {
+        return {};
+    };
+
+    /**
+     * Returns an empty array. To be used in order to avoid closures.
+     */
+    Aria.returnArray = function () {
+        return [];
+    };
+
 })();
 var jsEval = require("noder-js/jsEval");
 

--- a/src/aria/core/BaseTypes.js
+++ b/src/aria/core/BaseTypes.js
@@ -251,6 +251,10 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:FunctionRef",
                     $description : "Fast normalization function for this type. Automatically added by the framework."
                 },
+                "$fastNormParent" : {
+                    $type : "json:ObjectRef",
+                    $description : "Reference to the parent bean used when calling a parent $fastNorm method. Automatically added by the framework."
+                },
                 "$getDefault" : {
                     $type : "json:FunctionRef",
                     $description : "Return default value. Automatically added by the framework."

--- a/test/nodeTestResources/testProject/attester/attester4.yml
+++ b/test/nodeTestResources/testProject/attester/attester4.yml
@@ -5,6 +5,7 @@ resources:
   - 'test/nodeTestResources/testProject/test'
 tests:
  aria-templates:
+  debug: false
   bootstrap: '/ariatemplates.js'
   extraScripts:
    - /map.js

--- a/test/nodeTestResources/testProject/src/app/SampleBean.js
+++ b/test/nodeTestResources/testProject/src/app/SampleBean.js
@@ -36,6 +36,22 @@ Aria.beanDefinitions({
                 "value2" : {
                     $type : "json:Integer",
                     $default : 7
+                },
+                "structure" : {
+                    $type : "json:Object",
+                    $default : {
+                        value4 : 50
+                    },
+                    $properties : {
+                        "value3" : {
+                            $type : "json:Integer",
+                            $default : 12
+                        },
+                        "value4" : {
+                            $type : "json:Integer",
+                            $default : 70
+                        }
+                    }
                 }
             }
         }

--- a/test/nodeTestResources/testProject/src/app/SampleBean.js
+++ b/test/nodeTestResources/testProject/src/app/SampleBean.js
@@ -19,6 +19,72 @@ Aria.beanDefinitions({
         "json" : "aria.core.JsonTypes"
     },
     $beans : {
+        "Ancestor1" : {
+            $type : "json:Object",
+            $properties : {
+                "text1" : {
+                    $type : "json:String",
+                    $default : "defValue1"
+                },
+                "text2" : {
+                    $type : "json:String",
+                    $default : "defValue2"
+                },
+                "obj" : {
+                    $type : "json:Object",
+                    $default : {},
+                    $properties : {
+                        "subProperty1" : {
+                            $type : "json:String",
+                            $default : "defV1"
+                        }
+                    }
+                }
+            }
+        },
+        "Ancestor2" : {
+            $type : "Ancestor1"
+        },
+        "Ancestor3" : {
+            $type : "Ancestor2",
+            $properties : {
+                "text3" : {
+                    $type : "json:String",
+                    $default : "defValue3"
+                },
+                "text4" : {
+                    $type : "json:String",
+                    $default : "defValue4"
+                }
+            }
+        },
+        "Child" : {
+            $type : "Ancestor3",
+            $properties : {
+                "text1" : {
+                    $type : "Ancestor3.text1",
+                    $default : "defChildTextV1"
+                },
+                "text3" : {
+                    $type : "Ancestor3.text3",
+                    $default : "defChildTextV3"
+                },
+                "obj": {
+                    $type : "Ancestor3.obj",
+                    $default : {},
+                    $properties : {
+                        "subProperty1" : {
+                            $type: "Ancestor3.obj.subProperty1",
+                            $default : "defChildV1"
+                        },
+                        "subProperty2" : {
+                            $type: "json:String",
+                            $default : "defChildV2"
+                        }
+                    }
+                }
+            }
+        },
         "Tree" : {
             $type : "json:Object",
             $properties : {
@@ -52,6 +118,18 @@ Aria.beanDefinitions({
                             $default : 70
                         }
                     }
+                },
+                "child" : {
+                    $type : "Child"
+                },
+                "ancestor3" : {
+                    $type : "Ancestor3"
+                },
+                "ancestor2" : {
+                    $type : "Ancestor2"
+                },
+                "ancestor1" : {
+                    $type : "Ancestor1"
                 }
             }
         }

--- a/test/nodeTestResources/testProject/test/SampleBeanTest.js
+++ b/test/nodeTestResources/testProject/test/SampleBeanTest.js
@@ -23,7 +23,11 @@ Aria.classDefinition({
             return {
                 value1 : 1,
                 subTrees : [{
-                            value2 : 0
+                            value2 : 0,
+                            child : {},
+                            ancestor3 : {},
+                            ancestor2 : {},
+                            ancestor1 : {}
                         }, {
                             value1 : 4,
                             structure : {},
@@ -52,6 +56,39 @@ Aria.classDefinition({
                 subTrees : [{
                             value1 : 3,
                             value2 : 0,
+                            child : {
+                                text1: "defChildTextV1",
+                                text3: "defChildTextV3",
+                                obj: {
+                                    subProperty1: "defChildV1",
+                                    subProperty2: "defChildV2"
+                                },
+                                text4: "defValue4",
+                                text2: "defValue2"
+                            },
+                            ancestor3 : {
+                                text1: "defValue1",
+                                text3: "defValue3",
+                                obj: {
+                                    subProperty1: "defV1"
+                                },
+                                text4: "defValue4",
+                                text2: "defValue2"
+                            },
+                            ancestor2 : {
+                                text1: "defValue1",
+                                text2: "defValue2",
+                                obj: {
+                                    subProperty1: "defV1"
+                                }
+                            },
+                            ancestor1 : {
+                                text1: "defValue1",
+                                text2: "defValue2",
+                                obj: {
+                                    subProperty1: "defV1"
+                                }
+                            },
                             structure : {
                                 value3 : 12,
                                 value4 : 50

--- a/test/nodeTestResources/testProject/test/SampleBeanTest.js
+++ b/test/nodeTestResources/testProject/test/SampleBeanTest.js
@@ -26,11 +26,15 @@ Aria.classDefinition({
                             value2 : 0
                         }, {
                             value1 : 4,
+                            structure : {},
                             subTrees : [{
                                         subTrees : [{
                                                     subTrees : []
                                                 }, {
-                                                    value1 : 2
+                                                    value1 : 2,
+                                                    structure : {
+                                                        value3 : 777
+                                                    }
                                                 }]
                                     }]
                         }]
@@ -41,23 +45,47 @@ Aria.classDefinition({
             return {
                 value1 : 1,
                 value2 : 7,
+                structure : {
+                    value3 : 12,
+                    value4 : 50
+                },
                 subTrees : [{
                             value1 : 3,
                             value2 : 0,
+                            structure : {
+                                value3 : 12,
+                                value4 : 50
+                            },
                             subTrees : []
                         }, {
                             value1 : 4,
                             value2 : 7,
+                            structure : {
+                                value3 : 12,
+                                value4 : 70
+                            },
                             subTrees : [{
                                         value1 : 3,
                                         value2 : 7,
+                                        structure : {
+                                            value3 : 12,
+                                            value4 : 50
+                                        },
                                         subTrees : [{
                                                     value1 : 3,
                                                     value2 : 7,
+                                                    structure : {
+                                                        value3 : 12,
+                                                        value4 : 50
+                                                    },
                                                     subTrees : []
                                                 }, {
                                                     value1 : 2,
                                                     value2 : 7,
+                                                    structure : {
+                                                        value3 : 777,
+                                                        value4 : 70
+                                                    },
                                                     subTrees : []
                                                 }]
                                     }]


### PR DESCRIPTION
This PR contains a set of fixes and improvements linked to beans pre-compilation, introduced in #1759:
- the `ATDebug` flag when compiling beans is now removed because it also caused all templates to be compiled in debug mode (with line numbers)
- there are new checks in `BeanExtractor` to be sure that the configuration in the `JsonValidator` is correct for the extraction with the given options to be successful
- an issue with default values which were not correctly normalized in non debug mode is now fixed
- the value returned by the generated `$getDefault` functions is no longer fully normalized, but it is expanded in `$fastNorm` in order to reduce the size of compiled beans
- beans which are not used in the fast normalization process are now discarded by the bean extractor when `onlyFastNorm` is true, in order to reduce the size of the resulting file
- functions returning typical default values (`{}`, `[]`, and `null`) are now cached to avoid generating them multiple times and to reduce the size of compiled beans
- the generated fast normalization functions now call the fast normalization function generated for the parent bean when it is useful and possible, in order to reduce the size of compiled beans
- a consistency issue between fast and slow normalization is now fixed by removing early normalization of default values. Default values are no longer normalized at the time a bean is pre-processed. At the time a default value is used, its copy is normalized in the context where it is used. This can change the result of normalization in case a bean overrides the default value of some of its parent properties and inherits from the default value of its parent (which is no longer normalized).