### PR TITLE
fix aria:Button had its title attribute on the span instead of button

### DIFF
--- a/src/aria/widgets/Widget.js
+++ b/src/aria/widgets/Widget.js
@@ -37,7 +37,7 @@ module.exports = Aria.classDefinition({
     $extends : ariaWidgetLibsBindableWidget,
     $css : [ariaWidgetsGlobalStyle],
     $onload : function () {
-        // check for skin existency
+        // check for skin existence
         if (!aria.widgets.AriaSkin) {
             this.$JsObject.$logError.call(this, this.SKIN_NOT_READY);
         }
@@ -429,7 +429,7 @@ module.exports = Aria.classDefinition({
             } else {
                 out.write('margin:' + this._defaultMargin + 'px;" ');
             }
-            if (cfg.tooltip) {
+            if (cfg.tooltip && !this._customTooltipMgt) {
                 out.write('title="' + ariaUtilsString.escapeHTMLAttr(cfg.tooltip) + '" ');
             }
             if (cfg.tabIndex != null && !this._customTabIndexProvided && !cfg.disabled) {
@@ -747,7 +747,7 @@ module.exports = Aria.classDefinition({
          */
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             var domElt = this.getDom();
-            if (propertyName == 'tooltip') {
+            if (propertyName == 'tooltip' && !this._customTooltipMgt) {
                 domElt.title = newValue;
             }
             if (propertyName == 'disabled') {

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -116,6 +116,14 @@ module.exports = Aria.classDefinition({
         _skinnableClass : "Button",
 
         /**
+         * The tooltip is managed by this class rather than by the Widget base class,
+         * because the title attribute is supposed to be on the &lt;button&gt; html tag
+         * and not the root &lt;span&gt; of the widget (especially for screen readers).
+         * @type Boolean
+         */
+        _customTooltipMgt : true,
+
+        /**
          * Internal method to update the state of the widget
          * @param {Boolean} skipChangeState If true the internal state won't change
          * @protected
@@ -173,6 +181,10 @@ module.exports = Aria.classDefinition({
         _onBoundPropertyChange : function (propertyName, newValue, oldValue) {
             this.$ActionWidget._onBoundPropertyChange.apply(this, arguments);
             var changedState = false;
+            if (propertyName === "tooltip") {
+                this.getDom(); // makes sure _focusElt is defined
+                this._focusElt.title = newValue;
+            }
             if (propertyName === "disabled") {
                 changedState = true;
                 this._isDisabled = !!newValue;
@@ -203,6 +215,7 @@ module.exports = Aria.classDefinition({
         _widgetMarkup : function (out) {
             var cfg = this._cfg;
             var tabIndexString = (cfg.tabIndex != null ? ' tabindex="' + this._calculateTabIndex() + '" ' : '');
+            var titleString = cfg.tooltip ? ' title="' + ariaUtilsString.escapeHTMLAttr(cfg.tooltip) + '" ' : '';
             var isIE7 = ariaCoreBrowser.isIE7;
             var ariaTestMode = (Aria.testMode) ? ' id="' + this._domId + '_button" ' : '';
             var buttonClass = cfg.disabled ? "xButton xButtonDisabled" : "xButton";
@@ -227,6 +240,7 @@ module.exports = Aria.classDefinition({
                     waiAriaAttributes,
                     ariaTestMode,
                     tabIndexString,
+                    titleString,
                     disableMarkup,
                     styleMarkup,
                     !cfg.waiAria
@@ -237,7 +251,7 @@ module.exports = Aria.classDefinition({
                 if (isIE7) {
                     // FIXME: find a way to put a button also on IE7
                     // on IE7 the button is having display issues the current frame implementation inside it
-                    out.write(['<span class="' + buttonClass + '" style="margin: 0;"', waiAriaAttributes, tabIndexString, ariaTestMode,
+                    out.write(['<span class="' + buttonClass + '" style="margin: 0;"', waiAriaAttributes, tabIndexString, titleString, ariaTestMode,
                             '>'].join(''));
                 } else {
                     out.write([
@@ -246,6 +260,7 @@ module.exports = Aria.classDefinition({
                         ' class="' + buttonClass + '"',
                         waiAriaAttributes,
                         tabIndexString,
+                        titleString,
                         ariaTestMode,
                         disableMarkup,
                         '>'

--- a/test/aria/widgets/wai/input/actionWidget/buttonTooltip/ButtonTooltipJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/buttonTooltip/ButtonTooltipJawsTestCase.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.actionWidget.buttonTooltip.ButtonTooltipJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $prototype : {
+        runTemplateTest : function () {
+            this.noiseRegExps.push(/^Type/i);
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 200],
+                ["type", null, "[tab]"], ["pause", 200],
+                ["type", null, "[tab]"], ["pause", 200]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "First field Edit",
+                        "my first button Button",
+                        "first tooltip",
+                        "my second button Button",
+                        "second tooltip",
+                        "Last field Edit"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/actionWidget/buttonTooltip/ButtonTooltipJawsTestCaseTpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/buttonTooltip/ButtonTooltipJawsTestCaseTpl.tpl
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath: "test.aria.widgets.wai.input.actionWidget.buttonTooltip.ButtonTooltipJawsTestCaseTpl"
+}}
+
+    {macro main()}
+        <div style="margin:10px;">
+            <input {id "tf1"/} aria-label="First field"><br>
+            {@aria:Button {
+                label: "my first button",
+                tooltip: "first tooltip"
+            }/}<br>
+            {@aria:Button {
+                sclass: "simple",
+                label: "my second button",
+                tooltip: "second tooltip"
+            }/}<br>
+            <input {id "tf2"/} aria-label="Last field"><br>
+        </div>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
This PR fixes an issue with the aria:Button widget with screen readers: the fact that the title attribute was not set on the button tag but on the containing span was preventing Jaws from reading the tooltip.