### PR TITLE
feat/test #1763 Now in TemplateTestCase it is possible to pass any option to the underlying Aria.loadTemplate call

### DIFF
--- a/src/aria/jsunit/TemplateTestCase.js
+++ b/src/aria/jsunit/TemplateTestCase.js
@@ -15,6 +15,7 @@
 var Aria = require("../Aria");
 var ariaUtilsSynEvents = require("../utils/SynEvents");
 require("../templates/RefreshManager");
+var ariaUtilsObject = require("../utils/Object");
 var ariaUtilsDom = require("../utils/Dom");
 var ariaJsunitTestCase = require("./TestCase");
 var ariaCoreLog = require("../core/Log");
@@ -49,7 +50,8 @@ module.exports = Aria.classDefinition({
             data : {},
             iframe : false,
             baseCss : this.IFRAME_BASE_CSS_TEXT, // css that will be set on the <iframe> itself
-            iframePageCss : "" // css that will be injected into iframe as <style> tag
+            iframePageCss : "", // css that will be injected into iframe as <style> tag,
+            templateLoadingExtraOptions: {}
         };
 
         /**
@@ -130,7 +132,7 @@ module.exports = Aria.classDefinition({
          * By default, a template test case with classpath a.b.c will automatically load the test template a/b/cTpl.tpl.
          * However, if needed, this method can be called to configure which template classpath to be loaded.
          * Additionally, it can also be used to pass some data and/or module controller. To be called in the constructor
-         * of a template test case: this.setTestEnv({template: "...", moduleCtrl: "...", data: {...}});
+         * of a template test case: this.setTestEnv({template: "...", moduleCtrl: "...", data: {...}, templateLoadingExtraOptions: {...}});
          * @param {Object} env
          */
         setTestEnv : function (env) {
@@ -189,13 +191,13 @@ module.exports = Aria.classDefinition({
             }
 
             this.testWindow.scroll(0, 0);
-            Aria.loadTemplate({
+            Aria.loadTemplate(ariaUtilsObject.assign({}, this.env.templateLoadingExtraOptions, {
                 classpath : this.env.template,
                 div : this.testDiv,
                 data : this.env.data,
                 moduleCtrl : this.env.moduleCtrl,
                 provideContext : true
-            }, {
+            }), {
                 fn : this._templateLoadCB,
                 scope : this,
                 args : {
@@ -823,6 +825,7 @@ module.exports = Aria.classDefinition({
          * <li>cssText Any inline style to be added on the iframe</li>
          * <li>data Data model</li>
          * <li>moduleCtrl Module controller definition</li>
+         * <li>templateLoadingExtraOptions Extra options for template loading not already set by other configurations</li>
          * </ul>
          * <br>
          * The callback receive an object containing
@@ -938,7 +941,7 @@ module.exports = Aria.classDefinition({
                 window : window,
                 document : document
             });
-            window.Aria.loadTemplate({
+            window.Aria.loadTemplate(ariaUtilsObject.assign({}, this.env.templateLoadingExtraOptions, {
                 classpath : definition.template,
                 div : div,
                 data : definition.data,
@@ -947,7 +950,7 @@ module.exports = Aria.classDefinition({
                 width : definition.width,
                 height : definition.height,
                 rootDim : definition.rootDim
-            }, {
+            }), {
                 fn : this._iframeDone,
                 scope : this,
                 args : args

--- a/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCase.js
+++ b/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCase.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require('ariatemplates/Aria');
+
+var TemplateTestCase = require('ariatemplates/jsunit/TemplateTestCase');
+
+
+
+module.exports = Aria.classDefinition({
+    $classpath: 'test.aria.jsunit.templateTests.TemplateTestCaseTemplateExtraOptionsTestCase',
+    $extends: TemplateTestCase,
+
+    $constructor: function () {
+        this.$TemplateTestCase.$constructor.apply(this, arguments);
+
+        var mainMacroArg = 'This is the arg passed to the main macro';
+        this.mainMacroArg = mainMacroArg;
+
+        var data = {
+            property: 'this is kept'
+        };
+        this.data = data;
+
+        var ignoredData = {
+            property: 'this is ignored'
+        };
+        this.ignoredData = ignoredData;
+
+        this.setTestEnv({
+            data: data,
+            templateLoadingExtraOptions: {
+                data: ignoredData,
+                args: [mainMacroArg]
+            }
+        });
+    },
+
+    $prototype: {
+        runTemplateTest: function () {
+            var actualData = this.templateCtxt.data;
+            var expectedData = this.data;
+            this.assertTrue(actualData.property === expectedData.property, 'Options in templateLoadingExtraOptions should not replace the ones from the test environment.');
+
+            var actualInitArgs = actualData.mainMacroArg;
+            var expectedInitArgs = this.mainMacroArg;
+            this.assertTrue(actualInitArgs === expectedInitArgs, 'mainMacroArg should have been passed to the template loading through the options templateLoadingExtraOptions.');
+
+            this.end();
+        }
+    }
+});

--- a/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCaseTpl.tpl
+++ b/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCaseTpl.tpl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath: 'test.aria.jsunit.templateTests.TemplateTestCaseTemplateExtraOptionsTestCaseTpl',
+    $hasScript: true
+}}
+
+    {macro main(arg)}
+        ${this.setMainMacroArg(arg)|eat}
+    {/macro}
+
+{/Template}

--- a/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCaseTplScript.js
+++ b/test/aria/jsunit/templateTests/TemplateTestCaseTemplateExtraOptionsTestCaseTplScript.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+var Aria = require('aria/Aria');
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath: 'test.aria.jsunit.templateTests.TemplateTestCaseTemplateExtraOptionsTestCaseTplScript',
+
+    $prototype: {
+        setMainMacroArg: function (arg) {
+            this.data.mainMacroArg = arg;
+        }
+    }
+});


### PR DESCRIPTION
Any option not already set (by other `env` properties or else) will be taken into account from the object set in `env.templateLoadingExtraOptions`; in other words those options have the least precedence.