### PR TITLE
Adding Slovak date resources

### DIFF
--- a/build/config/locales.json
+++ b/build/config/locales.json
@@ -29,6 +29,7 @@
     "pt_PT",
     "ro_RO",
     "ru_RU",
+    "sk_SK",
     "sv_SE",
     "th_TH",
     "tk_TK",

--- a/src/aria/resources/DateRes_sk_SK.js
+++ b/src/aria/resources/DateRes_sk_SK.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates sk_SK
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "nedeľa",
+            "pondelok",
+            "utorok",
+            "streda",
+            "štvrtok",
+            "piatok",
+            "sobota"
+        ],
+        dayShort : false,
+        monthShort : false,
+        month : [
+            "január",
+            "február",
+            "marec",
+            "apríl",
+            "máj",
+            "jún",
+            "júl",
+            "august",
+            "september",
+            "október",
+            "november",
+            "december"
+        ]
+    }
+});


### PR DESCRIPTION
This PR adds partial support for the Slovak language, which can be used to make aria.utils.Date.format return formatted dates in Slovak.

cf #1756 for the last added language (date resources only)