### PR TITLE
Adding Bulgarian date resources

### DIFF
--- a/build/config/locales.json
+++ b/build/config/locales.json
@@ -1,6 +1,7 @@
 [
     "ar_SA",
     "az_AZ",
+    "bg_BG",
     "ca_ES",
     "cs_CZ",
     "da_DK",

--- a/src/aria/resources/DateRes_bg_BG.js
+++ b/src/aria/resources/DateRes_bg_BG.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates bg-BG
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "неделя",
+            "понеделник",
+            "вторник",
+            "сряда",
+            "четвъртък",
+            "петък",
+            "събота"
+        ],
+        dayShort : [
+            "нд",
+            "пн",
+            "вт",
+            "ср",
+            "чт",
+            "пт",
+            "сб"
+        ],
+        monthShort : [
+            "ян",
+            "фев",
+            "мар",
+            "апр",
+            "май",
+            "юни",
+            "юли",
+            "авг",
+            "сеп",
+            "окт",
+            "ное",
+            "дек"
+        ],
+        month : [
+            "януари",
+            "февруари",
+            "март",
+            "април",
+            "май",
+            "юни",
+            "юли",
+            "август",
+            "септември",
+            "октомври",
+            "ноември",
+            "декември"
+        ]
+    }
+});


### PR DESCRIPTION
This commit adds partial support for the Bulgarian language, which can be used to make aria.utils.Date.format return formatted dates in Bulgarian.

cf #1767 for the last added language (date resources only)