### PR TITLE
New `ariaLive` parameter on the `@aria:ErrorList` widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1656,6 +1656,11 @@ module.exports = Aria.beanDefinitions({
                     $type : "json:Boolean",
                     $description : "Set this bindable property to true to put the focus on the first item. As soon as the focus has been set, the property will be set back to false.",
                     $default : false
+                },
+                "ariaLive" : {
+                    $type : "json:Boolean",
+                    $description : "Specifies whether role=alert and aria-live=assertive are included (true) or omitted (false) on the container element (defaults to true, only used if waiAria is true)",
+                    $default : true
                 }
             }
         },

--- a/src/aria/widgets/errorlist/ErrorList.js
+++ b/src/aria/widgets/errorlist/ErrorList.js
@@ -44,7 +44,7 @@ module.exports = Aria.classDefinition({
         divCfg.margins = "0 0 0 0";
         divCfg.id = cfg.id + "_div";
 
-        if (cfg.waiAria) {
+        if (cfg.waiAria && cfg.ariaLive) {
             this._extraAttributes = ' role="alert" aria-live="assertive" ';
         }
 

--- a/test/aria/widgets/wai/errorlist/binding/ErrorListBindingCtrl.js
+++ b/test/aria/widgets/wai/errorlist/binding/ErrorListBindingCtrl.js
@@ -12,7 +12,8 @@ Aria.classDefinition({
             phoneNumber : "",
             email : "",
             errorMessages : [],
-            focus: false
+            focus: false,
+            focusOnError: true
         };
         this.myDataUtil = aria.utils.Data;
         this.validators = [];
@@ -30,6 +31,12 @@ Aria.classDefinition({
         $publicInterfaceName : "test.aria.widgets.wai.errorlist.binding.IErrorListBindingCtrl",
         init : function (arg, cb) {
             var validatorPkg = aria.utils.validators;
+            if ("ariaLive" in arg) {
+                this.json.setValue(this._data, "ariaLive", arg.ariaLive);
+            }
+            if ("focusOnError" in arg) {
+                this.json.setValue(this._data, "focusOnError", arg.focusOnError);
+            }
 
             var firstNameValidator = new validatorPkg.Mandatory("The first name is a required field using a mandatory validator.");
             this.myDataUtil.setValidatorProperties(firstNameValidator, null, "onblur");
@@ -58,7 +65,7 @@ Aria.classDefinition({
             var messages = {};
             this.myDataUtil.validateModel(this._data, messages);
             this.json.setValue(this._data, "errorMessages", messages.listOfMessages);
-            if (messages.listOfMessages && messages.listOfMessages.length) {
+            if (messages.listOfMessages && messages.listOfMessages.length && this._data.focusOnError) {
                 this.json.setValue(this._data, "focus", true);
             }
         }

--- a/test/aria/widgets/wai/errorlist/binding/ErrorListBindingTpl.tpl
+++ b/test/aria/widgets/wai/errorlist/binding/ErrorListBindingTpl.tpl
@@ -11,6 +11,7 @@
         margins: "10 1 10 1",
         title: "Error",
         filterTypes: ['E'],
+        ariaLive: data.ariaLive,
         bind: {
             messages: {
                 to: "errorMessages",

--- a/test/aria/widgets/wai/errorlist/binding/ErrorListNoAriaLiveJawsTestCase.js
+++ b/test/aria/widgets/wai/errorlist/binding/ErrorListNoAriaLiveJawsTestCase.js
@@ -24,7 +24,7 @@ require("ariatemplates/utils/validators/CfgBeans"); // just to make sure it is c
 require("ariatemplates/widgets/errorlist/ErrorListTemplate.tpl"); // just to be sure the template is loaded when the test is run, since it depends on its (DOM) content
 
 module.exports = Aria.classDefinition({
-    $classpath : "test.aria.widgets.wai.errorlist.binding.ErrorListBindingJawsTestCase",
+    $classpath : "test.aria.widgets.wai.errorlist.binding.ErrorListNoAriaLiveJawsTestCase",
     $extends : JawsTestCase,
 
     $constructor : function() {
@@ -37,7 +37,11 @@ module.exports = Aria.classDefinition({
         this.setTestEnv({
             template : "test.aria.widgets.wai.errorlist.binding.ErrorListBindingTpl",
             moduleCtrl : {
-                classpath : 'test.aria.widgets.wai.errorlist.binding.ErrorListBindingCtrl'
+                classpath : 'test.aria.widgets.wai.errorlist.binding.ErrorListBindingCtrl',
+                initArgs: {
+                    ariaLive : false,
+                    focusOnError : false
+                }
             }
         });
 
@@ -63,25 +67,11 @@ module.exports = Aria.classDefinition({
                 ["type", null, "[down][down]"],
                 ["pause", 1000],
                 ["type", null, "[space]"],
-                ["pause", 1000],
-                ["type", null, "[down]"],
-                ["pause", 1000],
-                ["type", null, "[down]"],
-                ["pause", 1000],
-                ["type", null, "[down]"],
-                ["pause", 1000],
-                ["type", null, "[space]"],
-                ["pause", 2000],
-                ["type", null, "[down]"],
-                ["pause", 1000],
-                ["type", null, "[down]"],
-                ["pause", 1000],
-                ["type", null, "[down]"],
-                ["pause", 5000]
+                ["pause", 3000] // check that nothing is said when errors are displayed
             ], {
                 fn: function () {
                     this.assertJawsHistoryEquals(
-                        "Email Address: Edit\nType in text.\nSubmit Button\nError\nError • The first name is a required field using a mandatory validator.• The last name is a required field using a mandatory validator.• The phone number is a required field using a mandatory validator.• The email is a required field using a mandatory validator.\nlist of 4 items\n• Link The first name is a required field using a mandatory validator.\n• Link The last name is a required field using a mandatory validator.\nAlert!\nThe last name is a required field using a mandatory validator.\nLast Name: Edit\nType in text.\nPhone Number:\nEdit\nAlert!\nThe phone number is a required field using a mandatory validator.",
+                        "Email Address: Edit\nType in text.\nSubmit Button",
                         this.end,
                         function filter(content) {
                             content = content.replace(/(Submit)\n(Button)/gi, '$1 $2');


### PR DESCRIPTION
This new `ariaLive` parameter allows to specify whether `role="alert"` and `aria-live="assertive"` are included (`true`) or omitted (`false`) on the container element of the `@aria:ErrorList` widget (defaults to `true`, only used if `waiAria` is `true`)