### PR TITLE
Adding Mongolian date resources

### DIFF
--- a/build/config/locales.json
+++ b/build/config/locales.json
@@ -22,6 +22,7 @@
     "ja_JP",
     "kl_GL",
     "ko_KR",
+    "mn_MN",
     "ms_MY",
     "nl_NL",
     "no_NO",

--- a/src/aria/resources/DateRes_mn_MN.js
+++ b/src/aria/resources/DateRes_mn_MN.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DO NOT FORMAT
+ * Aria resource object for dates mn-MN
+ */
+Aria.resourcesDefinition({
+    $classpath : 'aria.resources.DateRes',
+    $resources : {
+        day : [
+            "Ням гараг",
+            "Даваа гараг",
+            "Мягмар гараг",
+            "Лхагва гараг",
+            "Пүрэв гараг",
+            "Баасан гараг",
+            "Бямба гараг"
+        ],
+        dayShort : [
+            "Ням",
+            "Дав",
+            "Мяг",
+            "Лха",
+            "Пү",
+            "Ба",
+            "Бя"
+        ],
+        month : [
+            "Нэгдүгээр сар",
+            "Хоёрдугаар сар",
+            "Гуравдугаар сар",
+            "Дөрөвдүгээр сар",
+            "Тавдугаар сар",
+            "Зургаадугаар сар",
+            "Долоодугаар сар",
+            "Наймдугаар сар",
+            "Есдүгээр сар",
+            "Аравдугаар сар",
+            "Арван нэгдүгээр сар",
+            "Арван хоёрдугаар сар"
+        ],
+        monthShort : [
+            "1-р сар",
+            "2-р сар",
+            "3-р сар",
+            "4-р сар",
+            "5-р сар",
+            "6-р сар",
+            "7-р сар",
+            "8-р сар",
+            "9-р сар",
+            "10-р сар",
+            "11-р сар",
+            "12-р сар"
+        ]
+    }
+});


### PR DESCRIPTION
This commit adds partial support for the Mongolian language, which can be used to make `aria.utils.Date.format` return formatted dates in Mongolian.

cf #1771 for the last added language (date resources only)