### PR TITLE
Chrome 61 has document.scrollingElement = document.documentElement

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1224,9 +1224,13 @@ module.exports = Aria.classDefinition({
             if (document == null) {
                 document = Aria.$window.document;
             }
-            return ((!(ariaCoreBrowser.isSafari || ariaCoreBrowser.isChrome || ariaCoreBrowser.isEdge || ariaCoreBrowser.isOpera) && (document.compatMode == "CSS1Compat"))
-                    ? document.documentElement
-                    : document.body);
+            var result = document.scrollingElement;
+            if (!result) {
+                result = ((!(ariaCoreBrowser.isSafari || ariaCoreBrowser.isChrome || ariaCoreBrowser.isEdge || ariaCoreBrowser.isOpera) && (document.compatMode == "CSS1Compat"))
+                        ? document.documentElement
+                        : document.body);
+            }
+            return result;
         },
 
         /**


### PR DESCRIPTION
In Chrome 61, as specified in https://blog.chromium.org/2017/08/chrome-61-beta-javascript-modules.html:
> To align with the spec and preserve browser consistency, the scrollingElement is now the documentElement in standards mode.

This commit fixes the problems caused by this change in Chrome 61 by first using `document.scrollingElement` before relying on a browser-dependent logic to determine which is the scrolling element.

This commit fixes `test.aria.utils.DomScrollIntoViewTestCase` (and probably other tests too) on Chrome 61.