### PR TITLE
fix #1783 Wrong wording for "Saturday" in Vietnamese language

### DIFF
--- a/src/aria/resources/DateRes_vi_VN.js
+++ b/src/aria/resources/DateRes_vi_VN.js
@@ -23,7 +23,7 @@ Aria.resourcesDefinition({
             "Thứ tư",
             "Thứ năm",
             "Thứ sáu",
-            "Thứ bẩy"
+            "Thứ bảy"
         ],
         // a false value for the following items mean: use substring
         // to generate the short versions of days or months


### PR DESCRIPTION
PTR 14075903
AT 1792