### PR TITLE
activateSort in aria:List not taken into account with default template

### DIFF
--- a/src/aria/widgets/form/list/ListController.js
+++ b/src/aria/widgets/form/list/ListController.js
@@ -591,7 +591,7 @@ module.exports = Aria.classDefinition({
                 var moveFocus, itemsView = data.itemsView;
                 if (ariaDomEvent.isNavigationKey(evt.keyCode)) {
                     this._navigationEvent = true;
-                    var startIndex = data.multipleSelect ? data.focusIndex : data.selectedIndex, isFocusable = false, oldFocus = startIndex;
+                    var startIndex = data.multipleSelect ? data.focusIndex : data.selectedIndex > -1 ? itemsView.getNewIndex(itemsView.items, data.selectedIndex) : data.selectedIndex, isFocusable = false, oldFocus = startIndex;
                     moveFocus = startIndex;
                     while (!isFocusable) {
                         moveFocus = this.calcMoveFocus(data.displayOptions.flowOrientation, moveFocus, data.numberOfRows, data.numberOfColumns, evt.keyCode, data.itemsView.items.length);
@@ -616,7 +616,7 @@ module.exports = Aria.classDefinition({
                 if (data.multipleSelect) {
                     evt.cancelDefault = this.setFocusedIndex(moveFocus);
                 } else if (data.selectedIndex != null) {
-                    this.setSelectedIndex(moveFocus);
+                    this.setSelectedIndex(moveFocus > -1 ? itemsView.items[moveFocus].initIndex : moveFocus);
                 }
                 evt.cancelDefault = true;
             }

--- a/src/aria/widgets/form/list/templates/ListTemplate.tpl
+++ b/src/aria/widgets/form/list/templates/ListTemplate.tpl
@@ -36,8 +36,8 @@
         {/if}
         >
         <a href="#" style="display: none;">&nbsp;</a> //IE6 does not highlight the 1 elm in list
-        {foreach item inArray data.items}
-            {call renderItem(item, item_index)/}
+        {foreach item inView data.itemsView}
+            {call renderItem(item, item.index)/}
         {/foreach}
         </div>
     {/macro}

--- a/src/aria/widgets/form/list/templates/ListTemplateScript.js
+++ b/src/aria/widgets/form/list/templates/ListTemplateScript.js
@@ -45,6 +45,17 @@ module.exports = Aria.tplScriptDefinition({
     $prototype : {
 
         /**
+         * Returns the DOM element wrapper corresponding to the element with the given index (in the data.items array).
+         * @param {Number} indexInDataItems index in data.items
+         * @return {aria.templates.DomElementWrapper}
+         */
+        getItemDom : function (indexInDataItems) {
+            var itemsView = this.data.itemsView;
+            var sortedIndex = itemsView.getNewIndex(itemsView.items, indexInDataItems);
+            return this.$getChild(this._refContainer, sortedIndex + this._itemShift);
+        },
+
+        /**
          * This method (called as a timer callback) changes scrollbar position for the selected item to be displayed (if
          * there is only one item selected).
          * @protected
@@ -53,7 +64,7 @@ module.exports = Aria.tplScriptDefinition({
             this._scrollToSelectedItemCb = null;
             var idx = this.data.selectedIndex;
             if (idx != null && idx > -1) {
-                var wrapper = this.$getChild(this._refContainer, idx + this._itemShift);
+                var wrapper = this.getItemDom(idx);
                 wrapper.scrollIntoView();
                 wrapper.$dispose();
             }
@@ -96,7 +107,7 @@ module.exports = Aria.tplScriptDefinition({
                     if (evt.unselectedIndexes.length > 0) {
                         for (var i = 0, len = evt.unselectedIndexes.length; i < len; i += 1) {
                             var idx = evt.unselectedIndexes[i];
-                            var wrapper = this.$getChild(this._refContainer, idx + this._itemShift);
+                            var wrapper = this.getItemDom(idx);
                             wrapper.classList.setClassName(this._getClassForItem(items[idx], false));
                             wrapper.$dispose();
                         }
@@ -105,7 +116,7 @@ module.exports = Aria.tplScriptDefinition({
                     if (evt.selectedIndexes.length > 0) {
                         for (var i = 0, len = evt.selectedIndexes.length; i < len; i += 1) {
                             var idx = evt.selectedIndexes[i];
-                            var wrapper = this.$getChild(this._refContainer, idx + this._itemShift);
+                            var wrapper = this.getItemDom(idx);
                             wrapper.classList.setClassName(this._getClassForItem(items[idx], false));
                             if (i === 0) {
                                 wrapper.scrollIntoView();

--- a/test/aria/widgets/form/list/activateSort/ListTestCase.js
+++ b/test/aria/widgets/form/list/activateSort/ListTestCase.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.form.list.activateSort.ListTestCase",
+    $extends : "aria.jsunit.TemplateTestCase",
+    $dependencies : ["aria.utils.Json", "aria.utils.Array", "aria.utils.String", "aria.utils.Dom"],
+    $constructor : function () {
+        this.$TemplateTestCase.constructor.call(this);
+        this.data = {
+            countries : [
+                { value: "US", label: "United States"},
+                { value: "UK", label: "United Kingdom" },
+                { value: "CH", label: "Switzerland" },
+                { value: "IT", label: "Italy" },
+                { value: "ES", label: "Spain" },
+                { value: "IS", label: "Israel" }
+            ],
+            selectedIndex: -1
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.form.list.activateSort.ListTestCaseTpl",
+            data : this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var self = this;
+
+            var listContainer = self.getWidgetDomElement("myId", "div");
+            var domItems = aria.utils.Array.clone(aria.utils.Dom.getElementsByClassName(listContainer, "xListItem_std"));
+            var labelItems = aria.utils.Array.map(domItems, function (domElt) {
+                return aria.utils.String.trim(domElt.innerHTML);
+            });
+
+            function step0() {
+                self.assertJsonEquals(labelItems, ["Israel", "Italy", "Spain", "Switzerland", "United Kingdom", "United States"]);
+                self.assertEquals(self.data.selectedIndex, -1);
+                self.assertEquals(domItems[0].className.indexOf("xListSelectedItem_std"), -1);
+                self.synEvent.click(domItems[0], step1);
+            }
+            
+            function step1() {
+                // selectedIndex is the index in the original array
+                self.assertEquals(self.data.selectedIndex, 5); // Israel
+                self.assertTrue(domItems[0].className.indexOf("xListSelectedItem_std") > -1);
+                self.assertEquals(domItems[1].className.indexOf("xListSelectedItem_std"), -1);
+                self.synEvent.type(Aria.$window.document.activeElement, "[down]", step2);
+            }
+
+            function step2() {
+                self.assertEquals(self.data.selectedIndex, 3); // Italy
+                self.assertEquals(domItems[0].className.indexOf("xListSelectedItem_std"), -1);
+                self.assertTrue(domItems[1].className.indexOf("xListSelectedItem_std") > -1);
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/form/list/activateSort/ListTestCaseTpl.tpl
+++ b/test/aria/widgets/form/list/activateSort/ListTestCaseTpl.tpl
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+	$classpath : "test.aria.widgets.form.list.activateSort.ListTestCaseTpl",
+  $templates : ["aria.widgets.form.list.templates.ListTemplate"]
+}}
+  {macro main()}
+    {@aria:List {
+      id: "myId",
+      activateSort: true,
+      minWidth:200,
+      bind: {
+        items: {
+          to: "countries",
+          inside: data
+        },
+        selectedIndex: {
+          to: "selectedIndex",
+          inside: data
+        }
+      }
+    } /}
+  {/macro}
+{/Template}


### PR DESCRIPTION
The `activateSort` property of the `@aria:List` widget was not taken into account with the default list template. There was also an issue with the way the arrow up and arrow down keys were working when the list is sorted. This PR fixes those problems.