### PR TITLE
Adding restoreFocusOnClose parameter in Dialog widget

### DIFF
--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -2043,6 +2043,9 @@ module.exports = Aria.beanDefinitions({
                         },
                         "center" : {
                             $type : "common:BindingRef"
+                        },
+                        "restoreFocusOnClose": {
+                            $type : "common:BindingRef"
                         }
                     }
                 },
@@ -2180,6 +2183,11 @@ module.exports = Aria.beanDefinitions({
                 "resizeend" : {
                     $type : "common:Callback",
                     $description : "Callback called after the dialog resizing ends."
+                },
+                "restoreFocusOnClose" : {
+                    $type : "json:Boolean",
+                    $description : "If the dialog is modal and this parameter is true, the element which was focused before the dialog was displayed will be focused back when the dialog is closed. This parameter is ignored for non-modal dialogs.",
+                    $default : true
                 },
                 "container" : {
                     $type : "json:MultiTypes",

--- a/src/aria/widgets/container/Dialog.js
+++ b/src/aria/widgets/container/Dialog.js
@@ -586,6 +586,8 @@ module.exports = Aria.classDefinition({
                 this._toggleMaximize(newValue);
             } else if (propertyName === "width" || propertyName === "height") {
                 this._onDimensionsChanged(false);
+            } else if (propertyName === "restoreFocusOnClose") {
+                this._cfg[propertyName] = newValue;
             } else {
                 // delegate to parent class
                 this.$Container._onBoundPropertyChange.apply(this, arguments);
@@ -960,7 +962,7 @@ module.exports = Aria.classDefinition({
 
                 if (modal) {
                     var previouslyFocusedElement = this._previouslyFocusedElement;
-                    if (previouslyFocusedElement != null) {
+                    if (cfg.restoreFocusOnClose && ariaUtilsDom.isInDom(previouslyFocusedElement) && !/^body$/i.test(previouslyFocusedElement.tagName)) {
                         setTimeout(function () {
                             try {
                                 // On IE 7 and 8, focusing an element which is no longer in the DOM

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreDisabledRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreDisabledRobotTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreDisabledRobotTestCase",
+    $extends : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseRobotBase",
+    $prototype : {
+        initialValue: false,
+        toggleValueWhileDialogOpen: false,
+        finalFocusedId: "otherButton"
+    }
+});

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEnabledRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEnabledRobotTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreEnabledRobotTestCase",
+    $extends : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseRobotBase",
+    $prototype : {
+        initialValue: true,
+        toggleValueWhileDialogOpen: false,
+        finalFocusedId: "openDialogButton"
+    }
+});

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEventuallyDisabledRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEventuallyDisabledRobotTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreEventuallyDisabledRobotTestCase",
+    $extends : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseRobotBase",
+    $prototype : {
+        initialValue: true,
+        toggleValueWhileDialogOpen: true,
+        finalFocusedId: "otherButton"
+    }
+});

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEventuallyEnabledRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreEventuallyEnabledRobotTestCase.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreEventuallyEnabledRobotTestCase",
+    $extends : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseRobotBase",
+    $prototype : {
+        initialValue: false,
+        toggleValueWhileDialogOpen: true,
+        finalFocusedId: "openDialogButton"
+    }
+});

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnClose.tpl
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnClose.tpl
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnClose",
+   $hasScript : true
+}}
+
+	{macro main ()}
+        <input {id "tf"/}><br><br>
+        {@aria:Button {
+            id: "openDialogButton",
+            label: "Open dialog",
+            onclick: openDialog
+        }/}<br><br>
+        {@aria:Button {
+            id: "otherButton",
+            label: "Other (useless) button"
+        }/}
+        {@aria:Dialog {
+            id : "myDialog",
+            modal : true,
+            macro : "dialogContent",
+            onClose : onDialogClose,
+            bind : {
+                "restoreFocusOnClose": {
+                    inside : data,
+                    to : "restoreFocusOnDialogClose"
+                },
+                "visible" : {
+                    inside : data,
+                    to : 'dialogVisible'
+                }
+            }
+        }/}
+    {/macro}
+
+	{macro dialogContent()}
+        <input type="text">
+		<br/>
+		<br/>
+		<div style="overflow:auto;width:300px;height:300px;" {id "myDiv"/}>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec mauris turpis, gravida et porta vel, auctor vel lectus. Quisque leo felis, malesuada et ornare id, tempus non neque. Donec turpis mauris, dignissim sit amet rutrum non, vehicula vitae est. Duis velit leo, condimentum in euismod nec, luctus eu sem. Sed pretium sagittis nisl sed posuere. Sed ut leo nibh, sit amet sollicitudin ligula. Aliquam non purus nisl. Nunc ut tellus nec diam convallis elementum sit amet a purus. Ut molestie, sem et vulputate facilisis, urna nulla ultricies metus, in aliquet turpis eros non nunc. Donec at turpis vel ante dapibus dignissim tincidunt quis eros. Integer eleifend congue tortor, tempor egestas eros mollis posuere. Phasellus sit amet lorem sed turpis aliquam dignissim a sit amet nisl. Cras malesuada gravida pretium. Vestibulum luctus vehicula gravida. Cras ut est sed leo posuere venenatis nec non mauris. Vestibulum in tellus dui. Vivamus suscipit tempus dolor a varius.
+
+			Mauris ac ultrices nisl. Fusce sollicitudin placerat accumsan. Ut eu ante velit. Duis blandit tortor quis tellus sollicitudin eu interdum enim lacinia. Pellentesque vel leo ipsum. Nulla eget lorem quis quam laoreet luctus. Nam ut purus ut enim venenatis cursus in viverra metus. Pellentesque sed lorem odio. Vestibulum et ipsum et ante ullamcorper luctus. Cras eleifend quam sit amet mi ullamcorper non lacinia arcu hendrerit. Nulla leo metus, eleifend vel egestas at, consectetur nec enim. Donec dui orci, rutrum ac rhoncus et, ultrices non est. Integer magna leo, viverra a egestas ut, placerat in lorem. Donec felis purus, interdum cursus consectetur vel, suscipit sit amet sapien. Duis tempus euismod purus eu rhoncus. Maecenas vestibulum velit metus, in blandit leo. Curabitur nisl nulla, aliquam id convallis vitae, aliquam sit amet justo. Nunc erat eros, venenatis eget egestas at, blandit sit amet dui. Quisque fringilla, risus ac varius dignissim, ante risus porta nisl, a volutpat erat sem ut lectus.
+
+			Maecenas hendrerit porta ligula nec sollicitudin. In bibendum sagittis dolor ac feugiat. Cras ligula tellus, interdum sed elementum congue, mollis eu libero. Sed nibh massa, rhoncus id iaculis non, auctor in neque. Ut sollicitudin convallis ultricies. Mauris tempor tincidunt pharetra. Aliquam auctor arcu ac lectus ultrices imperdiet. Maecenas tristique, nulla eget dignissim faucibus, orci risus tempus ipsum, et commodo diam erat id ligula. Sed hendrerit tortor sem, eu molestie odio. Sed viverra eros nec diam mollis consequat. Morbi ultricies rhoncus velit, vel elementum tellus fringilla sit amet. Integer fringilla semper ante, sit amet mollis libero varius nec. Quisque sit amet sem libero. Suspendisse sed magna diam, quis faucibus lacus. Phasellus dictum, neque quis tincidunt tincidunt, augue sem varius ipsum, in interdum purus metus id mauris.
+
+			Nunc vitae lectus augue. Fusce eu tellus consequat orci facilisis sagittis. Sed eu adipiscing nibh. Maecenas hendrerit rutrum gravida. Vivamus consectetur velit in mauris accumsan dictum. Donec hendrerit, est nec accumsan eleifend, elit ipsum fermentum sem, et semper nulla purus sed nulla. Nunc sollicitudin pharetra massa. Praesent quis pulvinar purus. In imperdiet lectus nec ipsum gravida dapibus. Donec cursus laoreet ullamcorper.
+		</div>
+
+	{/macro}
+
+{/Template}

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnCloseRobotBase.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnCloseRobotBase.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseRobotBase",
+    $extends : "aria.jsunit.RobotTestCase",
+    $constructor : function () {
+        this.$RobotTestCase.constructor.call(this);
+        this.data = {
+            dialogVisible : false,
+            restoreFocusOnDialogClose: this.initialValue
+        };
+        this.setTestEnv({
+            template : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnClose",
+            data : this.data
+        });
+    },
+    $prototype : {
+        initialValue: false,
+        toggleValueWhileDialogOpen: false,
+        finalFocusedId: "",
+
+        runTemplateTest : function () {
+            var self = this;
+
+            function step0() {
+                var tf = self.getElementById("tf");
+                self.synEvent.execute([
+                    ["click", tf],
+                    ["waitFocus", tf],
+                    ["type", null, "[tab]"],
+                    ["pause", 100],
+                    ["type", null, "[enter]"]
+                ], step1);
+            }
+
+            function step1() {
+                self.waitFor({
+                    condition: function () {
+                        return !!self.getElementById("myDiv");
+                    },
+                    callback: step2
+                });
+            }
+            
+            function step2() {
+                if (self.toggleValueWhileDialogOpen) {
+                    aria.utils.Json.setValue(self.data, "restoreFocusOnDialogClose", !self.data.restoreFocusOnDialogClose);
+                }
+                self.synEvent.execute([
+                    ["type", null, "[escape]"]
+                ], step3);
+            }
+
+            function step3() {
+                var expectedFocusElt = self.getWidgetDomElement(self.finalFocusedId, "button");
+                self.waitFor({
+                    condition: function () {
+                        return !self.getElementById("myDiv") && Aria.$window.document.activeElement === expectedFocusElt;
+                    },
+                    callback: step4
+                });
+            }
+
+            function step4() {
+                // check that the focused element does not change later
+                setTimeout(step5, 500);
+            }
+
+            function step5() {
+                self.assertEquals(Aria.$window.document.activeElement, self.getWidgetDomElement(self.finalFocusedId, "button"));
+                self.end();
+            }
+
+            step0();
+        }
+    }
+});

--- a/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnCloseScript.js
+++ b/test/aria/widgets/container/dialog/restoreFocusOnClose/RestoreFocusOnCloseScript.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.container.dialog.restoreFocusOnClose.RestoreFocusOnCloseScript",
+    $prototype : {
+        openDialog : function () {
+            this.$json.setValue(this.data, "dialogVisible", true);
+        },
+        onDialogClose : function () {
+            this.$focus("otherButton");
+        }
+    }
+});

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -147,7 +147,8 @@ var generalBrowserExcludes = {
         "test/aria/widgets/wai/tabs/Group4RobotTestCase.js",
         "test/aria/widgets/action/link/disabled/LinkDisabledTestCase.js",
         "test/aria/widgets/form/multiselect/downArrowKeyPreventDef/MSDownArrowKeyRobotTestCase.js",
-        "test/aria/widgets/form/textinput/helpText/HelpTextTestCase.js"
+        "test/aria/widgets/form/textinput/helpText/HelpTextTestCase.js",
+        "test/aria/widgets/container/dialog/restoreFocusOnClose/*.js"
     ].concat(microsoftMapsTests),
     "IE 9": [
         "test/aria/utils/hashManager/HashManagerOneTestCase.js",


### PR DESCRIPTION
This commit adds the "restoreFocusOnClose" parameter on the Dialog widget, which is true by default (to keep the same behavior as before which restores the focus to the element that was focused before the dialog was opened when the dialog is closed) but which can now also be set to false (either directly in the configuration, or through a binding) to disable the automatic restoration of the focus. This is especially useful if the application manages the focus itself when the dialog is closed and does not want the framework to interfere.
This parameter is ignored for non-modal dialogs (the focus is never restored in that case).