### PR TITLE
Adding blurBeforeAction option in aria:Button configuration 

### DIFF
--- a/src/aria/jsunit/JawsTestCase.js
+++ b/src/aria/jsunit/JawsTestCase.js
@@ -114,7 +114,7 @@ module.exports = Aria.classDefinition({
             var textArea = this._createFullScreenTextArea();
             this.synEvent.execute([
                 ["type", null, "[<insert>][space][>insert<]h"], // displays history window
-                ["pause", 2000],
+                ["pause", 4000],
                 ["type", null, "[<ctrl>]a[>ctrl<][<ctrl>]c[>ctrl<]"], // copies the whole history in the clipboard
                 ["pause", 1000],
                 ["type", null, "[<alt>][F4][>alt<]"], // closes history window

--- a/src/aria/widgets/CfgBeans.js
+++ b/src/aria/widgets/CfgBeans.js
@@ -1224,6 +1224,10 @@ module.exports = Aria.beanDefinitions({
                         }
                     }
                 },
+                "blurBeforeAction" : {
+                    $type : "json:Boolean",
+                    $description : "If true, the button blurs any other focused element on the page before calling the onclick handler."
+                },
                 "height" : {
                     $type : "json:Integer",
                     $description : "The height of the button",

--- a/src/aria/widgets/action/Button.js
+++ b/src/aria/widgets/action/Button.js
@@ -324,6 +324,29 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Cf the documentation of this method in the parent class.
+         * @override
+         */
+        _performAction : function (domEvt) {
+            if (this._cfg.blurBeforeAction) {
+                var document = Aria.$window.document;
+                var activeElement = document.activeElement;
+                this.getDom(); // makes sure _focusElt is defined
+                if (activeElement && activeElement !== document.body && activeElement !== this._focusElt) {
+                    activeElement.blur();
+                    var self = this;
+                    setTimeout(function () {
+                        // executes the action a bit later, when the blur has been fully taken into account
+                        // (especially by IE)
+                        self._performAction(domEvt);
+                    });
+                    return true;
+                }
+            }
+            return this.$ActionWidget._performAction.call(this, domEvt);
+        },
+
+        /**
          * React to delegated mouse up events
          * @protected
          * @param {aria.DomEvent} domEvt Event

--- a/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionJawsTestCase.js
+++ b/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionJawsTestCase.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var ariaUtilsJson = require("ariatemplates/utils/Json");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.input.actionWidget.blurBeforeAction.BlurBeforeActionJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.input.actionWidget.blurBeforeAction.BlurBeforeActionTpl",
+            data: {}
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            var data = this.templateCtxt.data;
+            this.noiseRegExps.push(/type/i);
+
+            this.synEvent.execute([
+                ["click", this.getElementById("tf1")], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 200], ["type", null, "hello"], ["pause", 200],
+                ["type", null, "[escape]"], ["pause", 200], ["type", null, "b"], ["pause", 200],
+                ["type", null, "[enter]"], ["pause", 200], ["click", this.getElementById("tf2")], ["pause", 100],
+                ["type", null, "[up]"], ["pause", 200], ["type", null, "[up]"], ["pause", 2000]
+            ], {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "First field Edit",
+                        "Query Edit",
+                        "virtual PC Cursor",
+                        "Search Button",
+                        "Second field Edit",
+                        "Second field",
+                        "Last search: hello"
+                    ].join("\n"), this.end);
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionTpl.tpl
+++ b/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionTpl.tpl
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{Template {
+    $classpath: "test.aria.widgets.wai.input.actionWidget.blurBeforeAction.BlurBeforeActionTpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        <input {id "tf1"/} aria-label="First field"><br>
+        {@aria:TextField {
+            label: "Query",
+            bind: {
+                "value": {
+                    to: "query",
+                    inside: data
+                }
+            }
+        }/}<br>
+        {@aria:Text {
+            bind: {
+                "text": {
+                    to: "query",
+                    inside: data
+                }
+            }
+        }/}<br>
+        {@aria:Button {
+            label: "Search",
+            blurBeforeAction: true,
+            onclick: {
+                fn: buttonClicked,
+                scope: this
+            }
+        }/}<br><br>
+        Last search:
+        {@aria:Text {
+            bind: {
+                "text": {
+                    to: "lastSearchedQuery",
+                    inside: data
+                }
+            }
+        }/}<br>
+        <input {id "tf2"/} aria-label="Second field"><br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionTplScript.js
+++ b/test/aria/widgets/wai/input/actionWidget/blurBeforeAction/BlurBeforeActionTplScript.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath: "test.aria.widgets.wai.input.actionWidget.blurBeforeAction.BlurBeforeActionTplScript",
+    $prototype: {
+        buttonClicked: function (evt) {
+            this.$json.setValue(this.data, "lastSearchedQuery", this.data.query);
+        }
+    }
+});


### PR DESCRIPTION
If `blurBeforeAction` is `true`, the button blurs any other focused element on the page before calling the `onclick` handler.

This is especially useful to solve issues with screen readers (such as JAWS) that can click on a button without changing the focus, and if the focus is still in a field, the data model may contain an old value because the value is usually only updated in the data model on blur.
