### PR TITLE
fix/test missing calls to parent destructor in some test classes

### DIFF
--- a/test/aria/modules/test/SampleModuleCtrl.js
+++ b/test/aria/modules/test/SampleModuleCtrl.js
@@ -31,5 +31,6 @@ Aria.classDefinition({
             this.$urlService.$dispose();
             this.$urlService = null;
         }
+        this.$ModuleCtrl.$destructor.call(this);
     }
 });

--- a/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTestCase.js
+++ b/test/aria/widgets/form/autocomplete/defaultErrorMessages/DefaultErrorMessagesTestCase.js
@@ -39,5 +39,6 @@ Aria.classDefinition({
     $destructor : function () {
         this.data.resourcesHandler.$dispose();
         this.data.resourcesHandler = null;
+        this.$DefaultErrorMessagesBase.$destructor.call(this);
     }
 });


### PR DESCRIPTION
These issues resulted in some error messages in the test logs:

``
  [Aria] Error: the $destructor of x was not called in y
``