### PR TITLE
fix JAWS reading dialog title when closing dropdown widget

### DIFF
--- a/src/aria/utils/Dom.js
+++ b/src/aria/utils/Dom.js
@@ -1112,7 +1112,8 @@ module.exports = Aria.classDefinition({
          * @return {Boolean} true if the HTML element is in the DOM hierarchy
          */
         isInDom : function (element) {
-            return element ? this.isAncestor(element, element.ownerDocument.body) : false;
+            var ownerDocument = element ? element.ownerDocument : null;
+            return ownerDocument ? this.isAncestor(element, ownerDocument.body) : false;
         },
 
         /**

--- a/src/aria/widgets/form/DropDownTrait.js
+++ b/src/aria/widgets/form/DropDownTrait.js
@@ -168,10 +168,52 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Removes role="dialog" from all parent elements and stores those elements in this._waiDialogRoleRemoved.
+         */
+        _removeDialogRole : function () {
+            if (!this._cfg.waiAria) {
+                return;
+            }
+            var waiDialogRoleRemoved = this._waiDialogRoleRemoved;
+            if (!waiDialogRoleRemoved) {
+                this._waiDialogRoleRemoved = waiDialogRoleRemoved = [];
+            }
+            var domElt = this.getDom().parentElement;
+            while (domElt) {
+                if (domElt.getAttribute("role") === "dialog") {
+                    domElt.removeAttribute("role");
+                    waiDialogRoleRemoved.push(domElt);
+                }
+                domElt = domElt.parentElement;
+            }
+        },
+
+        /**
+         * Asynchronously restores role="dialog" on all elements in this._waiDialogRoleRemoved
+         * (and removes those elements from this array).
+         */
+        _restoreDialogRole : function () {
+            var waiDialogRoleRemoved = this._waiDialogRoleRemoved;
+            if (!waiDialogRoleRemoved || waiDialogRoleRemoved.length === 0) {
+                return;
+            }
+            setTimeout(function () {
+                while (waiDialogRoleRemoved.length > 0) {
+                    var domElt = waiDialogRoleRemoved.pop();
+                    // don't restore the attribute if it changed in the mean time:
+                    if (!domElt.hasAttribute("role")) {
+                        domElt.setAttribute("role", "dialog");
+                    }
+                }
+            }, 1000);
+        },
+
+        /**
          * Callback for the event onAfterOpen raised by the popup.
          * @protected
          */
         _afterDropdownOpen : function () {
+            this._removeDialogRole();
             this._setPopupOpenProperty(true);
             // when the popup is clicked, keep the focus on the right element:
             if (this._hasFocus) {
@@ -201,6 +243,7 @@ module.exports = Aria.classDefinition({
 
             }
             this._keepFocus = false;
+            this._restoreDialogRole();
         },
 
         /**

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -324,6 +324,7 @@ module.exports = Aria.classDefinition({
                 if (dropDownIcon) {
                     dropDownIcon.setAttribute("aria-expanded", "true");
                 }
+                this._removeDialogRole();
             }
         },
 

--- a/test/aria/widgets/wai/dropdown/dialogTitle/DropDownDialogTitleJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/dialogTitle/DropDownDialogTitleJawsTestCase.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.classDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.dialogTitle.DropDownDialogTitleJawsTestCase",
+    $extends : "aria.jsunit.JawsTestCase",
+    $dependencies : ["aria.utils.Json"],
+    $constructor : function () {
+        this.$JawsTestCase.constructor.call(this);
+        this.data = {};
+        this.setTestEnv({
+            template : "test.aria.widgets.wai.dropdown.dialogTitle.Tpl",
+            data: this.data
+        });
+    },
+    $prototype : {
+        runTemplateTest : function () {
+            aria.utils.Json.setValue(this.data, "dialogVisible", true);
+            this.waitFor({
+                condition : function () {
+                    return !!this.getElementById("firstItem");
+                },
+                callback : this.afterDialogDisplayed
+            });
+        },
+
+        afterDialogDisplayed : function () {
+            this.noiseRegExps.push(/type|thisisadate/i, /^MyDialogTitle Edit$/);
+            var actions = [
+                ["click", this.getElementById("firstItem")], ["pause", 500],
+                ["type", null, "[tab]"], ["pause", 500],
+                
+                // DatePicker:
+                ["type", null, "[down]"], ["pause", 100],
+                ["type", null, "[space]"], ["pause", 2000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[enter]"], ["pause", 2000],
+                ["type", null, "[tab]"], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 100],
+
+                // AutoComplete:
+                ["type", null, "d"], ["pause", 100],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[enter]"], ["pause", 2000],
+                ["type", null, "[tab]"], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 100],
+
+                // MultiSelect:
+                ["type", null, "[down]"], ["pause", 100],
+                ["type", null, "[space]"], ["pause", 2000],
+                ["type", null, "[down]"], ["pause", 1000],
+                ["type", null, "[space]"], ["pause", 2000],
+                ["type", null, "[escape]"], ["pause", 2000],
+                ["type", null, "[tab]"], ["pause", 100],
+                ["type", null, "[tab]"], ["pause", 100],
+
+                // closes the dialog:
+                ["type", null, "[escape]"], ["pause", 1000]
+            ];
+            this.synEvent.execute(actions, {
+                fn: function () {
+                    this.assertJawsHistoryEquals([
+                        "MyDialogTitle dialog",
+                        "FirstFieldLabel Edit",
+                        "DatePickerLabel Edit",
+                        "DropDownLabelForDatePicker",
+                        "Calendar table. Use arrow keys to navigate and space to validate.",
+                        "DatePickerLabel Edit",
+                        "MyDialogTitle dialog", // must be after "DatePickerLabel Edit"
+                        "DropDownLabelForDatePicker",
+                        "AutoCompleteLabel Edit",
+                        "List view Desktop device",
+                        "AutoCompleteLabel Edit",
+                        "Desktop device",
+                        "MyDialogTitle dialog", // must be after "AutoCompleteLabel Edit"
+                        "DropDownLabelForAutoComplete",
+                        "MultiSelectLabel Edit",
+                        "DropDownLabelForMultiSelect",
+                        "Touch device check box not checked",
+                        "Desktop device check box not checked",
+                        "Desktop device check box checked",
+                        "MultiSelectLabel Edit",
+                        "Desktop device",
+                        "MyDialogTitle dialog", // must be after "MultiSelectLabel Edit"
+                        "DropDownLabelForMultiSelect",
+                        "LastFieldLabel Edit"
+                    ].join("\n"), this.end, function (response) {
+                        return response.replace(/\n(check box)/g, " $1").replace(/not checked\n(checked)/g, "$1");
+                    });
+                },
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/widgets/wai/dropdown/dialogTitle/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/dialogTitle/Tpl.tpl
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.wai.dropdown.dialogTitle.Tpl",
+    $hasScript: true
+}}
+
+    {macro main()}
+        {@aria:Dialog {
+            waiAria: true,
+            title: "MyDialogTitle",
+            modal: true,
+            macro: "dialogContent",
+            bind: {
+                visible: {
+                    to: "dialogVisible",
+                    inside: data
+                }
+            }
+        }/}
+        {@aria:Button {
+            waiAria: true,
+            label: "Open dialog",
+            onclick: openDialog
+        }/}
+    {/macro}
+
+    {macro dialogContent()}
+        <input {id "firstItem"/} aria-label="FirstFieldLabel"> <br>
+        {@aria:DatePicker {
+            waiAria: true,
+            label: "DatePickerLabel",
+            waiIconLabel: "DropDownLabelForDatePicker",
+            waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
+            waiAriaDateFormat: "'thisisadate' EEEE d MMMM yyyy",
+            pattern:  "'thisisadate' dd/MM/yyyy",
+            id: "myDatePicker"
+        }/} <br>
+        {@aria:AutoComplete {
+            waiAria: true,
+            label: "AutoCompleteLabel",
+            waiIconLabel: "DropDownLabelForAutoComplete",
+            id: "myAutoCompleteWithExpandButton",
+            expandButton: true,
+            resourcesHandler: getAutoCompleteHandler()
+        }/} <br>
+        {@aria:MultiSelect {
+            waiAria: true,
+            label: "MultiSelectLabel",
+            waiIconLabel: "DropDownLabelForMultiSelect",
+            id: "myMultiSelect",
+            items: items
+        }/} <br>
+        <input {id "lastItem"/} aria-label="LastFieldLabel"> <br>
+    {/macro}
+
+{/Template}

--- a/test/aria/widgets/wai/dropdown/dialogTitle/TplScript.js
+++ b/test/aria/widgets/wai/dropdown/dialogTitle/TplScript.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Aria.tplScriptDefinition({
+    $classpath : "test.aria.widgets.wai.dropdown.dialogTitle.TplScript",
+    $dependencies : ["aria.resources.handlers.LCResourcesHandler"],
+    $constructor : function () {
+        this.items = [{
+                    label : "Touch device",
+                    code : "Touch device",
+                    value : "Touch device"
+                }, {
+                    label : "Desktop device",
+                    code : "Desktop device",
+                    value : "Desktop device"
+                }];
+    },
+    $destructor : function () {
+        if (this.acHandler) {
+            this.acHandler.$dispose();
+            this.acHandler = null;
+        }
+    },
+    $prototype : {
+        openDialog : function () {
+            this.$json.setValue(this.data, "dialogVisible", true);
+        },
+
+        getAutoCompleteHandler : function () {
+            if (!this.acHandler) {
+                var acHandler = new aria.resources.handlers.LCResourcesHandler();
+                acHandler.setSuggestions(this.items);
+                this.acHandler = acHandler;
+            }
+            return this.acHandler;
+        }
+    }
+});


### PR DESCRIPTION
This PR contains a workaround for an issue with the JAWS screen reader: JAWS reads the dialog title when closing a dropdown widget that is inside the dialog, whereas it should not.

As investigated by @ymeine:

> - the issue comes from the fact the dropdown's element is physically outside the dialog, the focus is moved to it, and when closing the dropdown the focus is put back to the dialog, making JAWS announce it again
> - we can't put the dropdown's element inside the dialog because of other limitations (possible overflow styling on parent elements)
> - the right way to do is to use the WAI-ARIA attribute `aria-owns` to restore the logical structure of elements but JAWS doesn't support it
> - the workaround is to remove the `role=dialog` attribute on the Dialog's root element as long as a dropdown logically located inside it is open, and restore it short after closing this dropdown

The workaround implemented in this PR unfortunately only delays the issue because when the user moves the focus to another item inside the dialog, JAWS will detect the `role=dialog` attribute that was restored on the dialog and read the dialog title again!