### PR TITLE
Moving aria/tester/index.html to aria-tester.html

### DIFF
--- a/build/grunt-config/config-atpackager-bootstrap.js
+++ b/build/grunt-config/config-atpackager-bootstrap.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
     grunt.config.set('atpackager.bootstrap', {
         options : {
             sourceDirectories : ['src'],
-            sourceFiles : ['aria/**/*', '!aria/node.js', '!aria/bootstrap.tpl.js', '!aria/css/**'],
+            sourceFiles : ['aria/**/*', '!aria/node.js', '!aria/bootstrap.tpl.js', '!aria/css/**', 'aria-tester.html'],
             outputDirectory : packagingSettings.bootstrap.outputDirectory,
             defaultBuilder : builder,
             visitors : [{
@@ -64,10 +64,28 @@ module.exports = function (grunt) {
                             }]
                 }
             }, {
+                type : "TextReplace",
+                cfg : {
+                    files : ['aria-tester.html'],
+                    replacements : [{
+                                find : "aria/bootstrap.js",
+                                replace : packagingSettings.bootstrap.bootstrapFileName
+                            }, {
+                                find : "aria/css/atskin.js",
+                                replace : "aria/css/atskin-" + packagingSettings.pkg.version + ".js"
+                            }]
+                }
+            }, {
                 type : 'CopyUnpackaged',
                 cfg : {
                     files : stripBannerFiles,
                     builder : builder
+                }
+            }, {
+                type : 'CopyUnpackaged',
+                cfg : {
+                    files : ['aria-tester.html'],
+                    builder: 'Concat'
                 }
             }, {
                 type : 'CopyUnpackaged',

--- a/src/aria-tester.html
+++ b/src/aria-tester.html
@@ -11,8 +11,8 @@
 		};
 
 	</script>
-	<script type="text/javascript" src="../bootstrap.js"></script>
-	<script type="text/javascript" src="../css/atskin.js"></script>
+	<script type="text/javascript" src="aria/bootstrap.js"></script>
+	<script type="text/javascript" src="aria/css/atskin.js"></script>
 	<style>
 		html {
 			overflow : hidden;
@@ -21,7 +21,7 @@
 			margin : 0px;
 			background-color : #FAFAFA;
 			font-family: tahoma,arial,helvetica,sans-serif;
-    		font-size: 11px;
+			font-size: 11px;
 		}
 	</style>
 </head>


### PR DESCRIPTION
This allows to publish to production the full `aria` folder without having to filter files inside it.