### PR TITLE
fix/test Fixing tests not working properly with large viewport

### DIFF
--- a/test/aria/widgets/container/dialog/movable/test5/MovableDialogFiveRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/movable/test5/MovableDialogFiveRobotTestCase.js
@@ -24,7 +24,7 @@ Aria.classDefinition({
 
         this.setTestEnv({
             template : "test.aria.widgets.container.dialog.movable.test5.MovableDialogTemplateFive",
-            css : "position:relative;top:400px;border:15px solid blue;",
+            css : "position:relative;top:400px;height:50000px;border:15px solid blue;",
             data : this.data
         });
     },

--- a/test/aria/widgets/container/dialog/resize/test4/DialogOnResizeScrollRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test4/DialogOnResizeScrollRobotTestCase.js
@@ -20,14 +20,24 @@ Aria.classDefinition({
         this.$AbstractResizableDialogRobotBase.constructor.call(this);
 
         this.setTestEnv({
-            css : "position:relative;top:400px;border:15px solid blue;"
+            css : "position:relative;top:400px;height:50000px;border:15px solid blue;"
         });
     },
     $prototype : {
 
         runTemplateTest : function () {
             Aria.$window.scrollBy(0,150);
-            this.startResizeTest();
+            aria.core.Timer.addCallback({
+                fn : this.startResizeTest,
+                scope : this,
+                delay : 1000
+            });
+        },
+
+        startResizeTest : function () {
+            var dom = aria.utils.Dom;
+            this.assertEquals(dom.getDocumentScrollElement().scrollTop, 150, "The page should have %2 px of scroll, but it has %1 px instead");
+            this.$AbstractResizableDialogRobotBase.startResizeTest.call(this);
         }
     }
 });

--- a/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollRobotTestCase.js
+++ b/test/aria/widgets/container/dialog/resize/test5/OverlayOnResizeScrollRobotTestCase.js
@@ -25,7 +25,7 @@ Aria.classDefinition({
 
         this.setTestEnv({
             template : "test.aria.widgets.container.dialog.resize.test5.OverlayOnResizeScrollTemplate",
-            css : "position:relative;top:400px;border:15px solid blue;",
+            css : "position:relative;top:400px;height:50000px;border:15px solid blue;",
             data : this.data
         });
     },


### PR DESCRIPTION
This PR fixes some tests that were not working properly when run with a large viewport because the viewport was able to fully display the content and the tests were expecting the viewport to have a scrollbar.
This commit fixes this by increasing the size of the content to make sure that a scrollbar is present.