### PR TITLE
fix JAWS reading dialog title when closing dropdown widget

### DIFF
--- a/src/aria/popups/container/DomElement.js
+++ b/src/aria/popups/container/DomElement.js
@@ -186,10 +186,10 @@ module.exports = Aria.classDefinition({
             if (base) {
                 this.$logError(this.BASE_NOT_IMPLEMENTED, ["centerInside"]);
             }
-            var container = this.container;
+            var geometry = this._getGeometry();
             return {
-                left : Math.floor(container.scrollLeft + (container.clientWidth - size.width) / 2),
-                top : Math.floor(container.scrollTop + (container.clientHeight - size.height) / 2)
+                left : Math.floor(geometry.x + (geometry.width - size.width) / 2),
+                top : Math.floor(geometry.y + (geometry.height - size.height) / 2)
             };
         }
 

--- a/src/aria/popups/container/ViewportElement.js
+++ b/src/aria/popups/container/ViewportElement.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var Aria = require("ariatemplates/Aria");
+var DomUtils = require("../../utils/Dom");
+var Viewport = require("./Viewport");
+
+module.exports = Aria.classDefinition({
+    $classpath : "aria.popups.container.ViewportElement",
+    $extends : require("./DomElement"),
+    $constructor : function (parentContainer) {
+        this.parentContainer = parentContainer;
+        var childContainer = parentContainer.ownerDocument.createElement("div");
+        childContainer.style.position = "absolute";
+        parentContainer.appendChild(childContainer);
+        this.$DomElement.$constructor.call(this, childContainer);
+        this._updateChildPosition();
+    },
+    $destructor : function () {
+        this.parentContainer.removeChild(this.container);
+        this.parentContainer = null;
+        this.$DomElement.$destructor.call(this);
+    },
+    $prototype : {
+        _updateChildPosition : function () {
+            var viewportSize = Viewport.getClientSize();
+            var parentPosition = DomUtils.calculatePosition(this.parentContainer);
+            var containerStyle = this.container.style;
+            containerStyle.left = (-parentPosition.left) + "px";
+            containerStyle.top = (-parentPosition.top) + "px";
+            containerStyle.width = viewportSize.width + "px";
+            containerStyle.height = viewportSize.height + "px";
+        },
+
+        _getGeometry : function () {
+            this._updateChildPosition();
+            return this.$DomElement._getGeometry.call(this);
+        }
+    }
+});

--- a/src/aria/widgets/form/MultiSelect.js
+++ b/src/aria/widgets/form/MultiSelect.js
@@ -324,7 +324,6 @@ module.exports = Aria.classDefinition({
                 if (dropDownIcon) {
                     dropDownIcon.setAttribute("aria-expanded", "true");
                 }
-                this._removeDialogRole();
             }
         },
 

--- a/test/aria/widgets/wai/dropdown/dialogTitle/DropDownDialogTitleJawsTestCase.js
+++ b/test/aria/widgets/wai/dropdown/dialogTitle/DropDownDialogTitleJawsTestCase.js
@@ -78,13 +78,11 @@ Aria.classDefinition({
                         "DropDownLabelForDatePicker",
                         "Calendar table. Use arrow keys to navigate and space to validate.",
                         "DatePickerLabel Edit",
-                        "MyDialogTitle dialog", // must be after "DatePickerLabel Edit"
                         "DropDownLabelForDatePicker",
                         "AutoCompleteLabel Edit",
                         "List view Desktop device",
                         "AutoCompleteLabel Edit",
                         "Desktop device",
-                        "MyDialogTitle dialog", // must be after "AutoCompleteLabel Edit"
                         "DropDownLabelForAutoComplete",
                         "MultiSelectLabel Edit",
                         "DropDownLabelForMultiSelect",
@@ -93,7 +91,6 @@ Aria.classDefinition({
                         "Desktop device check box checked",
                         "MultiSelectLabel Edit",
                         "Desktop device",
-                        "MyDialogTitle dialog", // must be after "MultiSelectLabel Edit"
                         "DropDownLabelForMultiSelect",
                         "LastFieldLabel Edit"
                     ].join("\n"), this.end, function (response) {

--- a/test/aria/widgets/wai/dropdown/dialogTitle/Tpl.tpl
+++ b/test/aria/widgets/wai/dropdown/dialogTitle/Tpl.tpl
@@ -23,6 +23,9 @@
             waiAria: true,
             title: "MyDialogTitle",
             modal: true,
+            movable: true,
+            resizable: true,
+            maximizable: true,
             macro: "dialogContent",
             bind: {
                 visible: {


### PR DESCRIPTION
This PR contains a better fix for the problem described in #1797.

When a dropdown widget with `waiAria:true` is inside a dialog with `role=dialog` the dropdown DOM element is no longer appended to the `<body>` but to the element that has `role=dialog`. Therefore, screen readers correctly understand that the dropdown is not outside the dialog and no longer read the dialog title when changing the focus after closing the dropdown.