### PR TITLE
Screen reader reading previously focused autocomplete field on tab

### DIFF
--- a/src/aria/widgets/form/AutoComplete.js
+++ b/src/aria/widgets/form/AutoComplete.js
@@ -285,7 +285,6 @@ module.exports = Aria.classDefinition({
         _afterDropdownClose : function () {
             if (this._cfg.waiAria) {
                 var field = this.getTextInputField();
-                field.removeAttribute("aria-activedescendant");
                 field.removeAttribute("aria-owns");
 
                 var dropDownIcon = this._getDropdownIcon();

--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -68,6 +68,8 @@ var phantomjsExcludesPatterns = [
     "test/aria/widgets/container/dialog/container/*TestCase.js",
     "test/aria/widgets/wai/popup/dialog/modal/SecondRobotTestCase.js",
     "test/aria/widgets/container/dialog/hiddenViewportResize/HiddenDialogViewportResizeTestCase.js",
+    // Google Maps raises an error on PhantomJS:
+    "test/aria/map/Google3MapProviderTestCase.js",
     // Excluded because clicking on a <select> on PhantomJS does not open it:
     "test/aria/widgets/form/select/onBlur/SelectOnBlurSimpleRobotTestCase.js",
     // Excluded because it often randomly fails with PhantomJS on travis-ci:


### PR DESCRIPTION
This fixes an issue with JAWS, which reads the previously focused autocomplete field when pressing tab while the suggestions list is opened.
The problem seems to come from the `aria-activedescendant` attribute being removed too quickly (before the next field is focused).
