### PR TITLE
fix/test Issue353RobotTestCase randomly failing on PhantomJS

### DIFF
--- a/test/testConfigBuilder.js
+++ b/test/testConfigBuilder.js
@@ -75,7 +75,9 @@ var phantomjsExcludesPatterns = [
     // Excluded because it often randomly fails with PhantomJS on travis-ci:
     "test/aria/widgets/container/tooltip/TooltipRobotTestCase.js",
     // Advanced robot test (using dragging, text selection, etc.) which not necessarily makes sense for PhantomJS
-    "test/aria/widgets/container/dialog/resize/dontSelectOnResize/DialogResizeDontSelectRobotTestCase.js"
+    "test/aria/widgets/container/dialog/resize/dontSelectOnResize/DialogResizeDontSelectRobotTestCase.js",
+    // Randomly failing on PhantomJS:
+    "test/aria/templates/issue353/Issue353RobotTestCase.js"
 ];
 
 var nophantomExcludesPatterns = [


### PR DESCRIPTION
This PR excludes Issue353RobotTestCase from the set of tests run by PhantomJS which makes it run by Firefox in Travis.