### PR TITLE
Improving the default error message for the MinMaxLength validator

### DIFF
--- a/src/aria/utils/validators/MinMaxLength.js
+++ b/src/aria/utils/validators/MinMaxLength.js
@@ -39,7 +39,7 @@ module.exports = Aria.classDefinition({
         this.$Validator.$destructor.call(this);
     },
     $statics : {
-        DEFAULT_LOCALIZED_MESSAGE : "The value must be more than %1 and less than %2 characters long.",
+        DEFAULT_LOCALIZED_MESSAGE : "The value must be between %1 and %2 characters long.",
 
         // ERROR MESSAGES:
         MISSING_MIN_MAX_VALUES : "There was a problem loading the MinMaxLength validator, MIN and MAX values must be passed into the validators constructor."

--- a/test/aria/utils/validators/MinMaxLengthTestCase.js
+++ b/test/aria/utils/validators/MinMaxLengthTestCase.js
@@ -37,7 +37,7 @@ Aria.classDefinition({
                 test = validator.validate(badItem);
                 this.assertFalse(test == null, "testing:" + badItem + ":");
             }
-            this.assertTrue(test[0].errorMessage === "The value must be more than 2 and less than 4 characters long.");
+            this.assertTrue(test[0].errorMessage === "The value must be between 2 and 4 characters long.");
 
             validator.$dispose();
         }


### PR DESCRIPTION
The previous message could give the impression that the boundaries were strict (> and <) but they are not (>= and <=).