### PR TITLE
fix incorrect focus state in IE for aria:Tab widget

### DIFF
--- a/src/aria/widgets/container/Tab.js
+++ b/src/aria/widgets/container/Tab.js
@@ -14,6 +14,7 @@
  */
 var Aria = require("../../Aria");
 
+var ariaCoreBrowser = require("../../core/Browser");
 var ariaUtilsArray = require("../../utils/Array");
 var ariaUtilsString = require("../../utils/String");
 var subst = ariaUtilsString.substitute;
@@ -523,6 +524,19 @@ module.exports = Aria.classDefinition({
         },
 
         /**
+         * Internal method to handle the mouse down event
+         * @param {aria.DomEvent} domEvt
+         * @protected
+         */
+        _dom_onmousedown : ariaCoreBrowser.isIE ? function (domEvt) {
+            var target = domEvt.target;
+            if (!ariaTemplatesNavigationManager.canBeFocused(target)) {
+                // prevent IE from focusing any element
+                domEvt.preventDefault();
+            }
+        } : Aria.empty,
+
+        /**
          * The method called when the markup is clicked
          * @param {aria.DomEvent} domEvt
          * @protected
@@ -532,8 +546,6 @@ module.exports = Aria.classDefinition({
             if (this._cfg) {
                 if (this._cfg.waiAria) {
                     domEvt.preventDefault();
-                } else if (!this._hasFocus) {
-                    this._focus();
                 }
             }
         },

--- a/test/aria/widgets/container/tab/dontFocusTab/DontFocusTabRobotTestCase.js
+++ b/test/aria/widgets/container/tab/dontFocusTab/DontFocusTabRobotTestCase.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var domUtils = require("ariatemplates/utils/Dom");
+
+module.exports = Aria.classDefinition({
+    $classpath: "test.aria.widgets.container.tab.dontFocusTab.DontFocusTabRobotTestCase",
+    $extends: require("ariatemplates/jsunit/RobotTestCase"),
+    $prototype: {
+        runTemplateTest: function () {
+            var myInput = this.getElementById("myInput");
+            var summaryTab = this.getElementById("summaryTab");
+            this.synEvent.execute([
+                ["click", myInput],
+                ["waitFocus", myInput],
+                ["click", summaryTab],
+                ["pause", 2000]
+            ], {
+                    fn: function () {
+                        // checks that the focus is not in the tab:
+                        var activeElement = Aria.$window.document.activeElement;
+                        this.assertFalse(domUtils.isAncestor(activeElement, summaryTab), "The focus should not be in the tab.");
+                        this.end();
+                    },
+                    scope: this
+                }
+            );
+        }
+    }
+});

--- a/test/aria/widgets/container/tab/dontFocusTab/DontFocusTabRobotTestCaseTpl.tpl
+++ b/test/aria/widgets/container/tab/dontFocusTab/DontFocusTabRobotTestCaseTpl.tpl
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+    $classpath : "test.aria.widgets.container.tab.dontFocusTab.DontFocusTabRobotTestCaseTpl"
+}}
+    {macro main()}
+        <input {id "myInput"/}>
+        <br><br>
+        {@aria:Tab {
+            id: "summaryTab",
+            tabId: "summary",
+            bind: {
+                selectedTab: {
+                    to: "selectedTab",
+                    inside: data
+                }
+            }
+        }}Summary{/@aria:Tab}
+        {@aria:Tab {
+            id: "detailsTab",
+            tabId: "details",
+            bind: {
+                selectedTab: {
+                    to: "selectedTab",
+                    inside: data
+                }
+            }
+        }}Details{/@aria:Tab}
+        {@aria:Tab {
+            id: "mapTab",
+            tabId: "map",
+            bind: {
+                selectedTab: {
+                    to: "selectedTab",
+                    inside: data
+                }
+            }
+        }}Map{/@aria:Tab}
+        <br><br>
+        <input>
+    {/macro}
+
+{/Template}


### PR DESCRIPTION
Clicking on `<td>` or `<span style="display:inline-block">` elements on IE focuses those elements whereas they are not focusable on other browsers (when `tabindex` is not specified).
This fix prevents this discrepancy between browsers from happening for the aria:Tab widget.