### PR TITLE
ua-parser-js trailing comma

### DIFF
--- a/build/grunt-config/config-atpackager-bootstrap-src.js
+++ b/build/grunt-config/config-atpackager-bootstrap-src.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
                 sourceFile.setTextContent(content);
 
                 var targetFile = packaging.addOutputFile(logicalPath, true);
-                targetFile.builder = packaging.createObject('Concat', targetFile.builtinBuilders);
+                targetFile.builder = packaging.createObject('JSConcat', targetFile.builtinBuilders);
                 sourceFile.setOutputFile(targetFile);
             }
         };


### PR DESCRIPTION
The new version of `ua-parser-js` (0.7.26) contains a trailing comma in an array. This is an issue with some (old) browsers.
This PR adds a reformatting step (included in the `JSConcat` builder of `atpackager`) so that the trailing comma is removed before `ua-parser-js` is included in Aria Templates (to avoid any problem).