### PR TITLE
Jaws 2021 with Edge not reading loading overlay text

### DIFF
--- a/src/aria/utils/overlay/LoadingOverlay.js
+++ b/src/aria/utils/overlay/LoadingOverlay.js
@@ -140,7 +140,9 @@ module.exports = Aria.classDefinition({
             var overlay = this.$Overlay._createOverlay.call(this, params);
 
             if (waiAria) {
-                this._showElementBack = ariaUtilsDomNavigationManager.hidingManager.hide(element);
+                this._showElementBack = element == Aria.$window.document.body ?
+                    ariaUtilsDomNavigationManager.hidingManager.hideOthers(overlay) :
+                    ariaUtilsDomNavigationManager.hidingManager.hide(element);
                 this._navigationInterceptor = ariaUtilsDomNavigationManager.SkippedElementNavigationHandler(element);
                 this._navigationInterceptor.ensureElements();
             }

--- a/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCase.js
+++ b/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCase.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+
+module.exports = Aria.classDefinition({
+    $classpath : "test.aria.utils.overlay.loadingIndicator.wai.body.BodyOverlayJawsTestCase",
+    $extends : require("ariatemplates/jsunit/JawsTestCase"),
+    $prototype : {
+        skipClearHistory : true,
+
+        runTemplateTest : function () {
+            var textField = this.getElementById("field");
+            this.execute([
+                ["click", textField],
+                ["waitFocus", textField],
+                ["type", null, "[tab]"],
+                ["waitForJawsToSay", "Display loading indicator"],
+                ["type", null, "[space]"],
+                ["waitForJawsToSay", "myoverlaymessage"],
+                ["waitForJawsToSay", "finished"]
+            ], {
+                fn: this.end,
+                scope: this
+            });
+        }
+    }
+});

--- a/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCaseTpl.tpl
+++ b/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCaseTpl.tpl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{Template {
+   $classpath: "test.aria.utils.overlay.loadingIndicator.wai.body.BodyOverlayJawsTestCaseTpl",
+   $hasScript: true
+}}
+    {macro main()}
+        <input {id "field"/}>
+        {@aria:Button {
+            "label": "Display loading indicator",
+            "waiAria": true,
+            onclick: buttonClicked
+        } /}
+    {/macro}
+{/Template}

--- a/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCaseTplScript.js
+++ b/test/aria/utils/overlay/loadingIndicator/wai/body/BodyOverlayJawsTestCaseTplScript.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Aria = require("ariatemplates/Aria");
+var DomOverlay = require("ariatemplates/utils/DomOverlay");
+var Accessibility = require("ariatemplates/utils/Accessibility");
+
+module.exports = Aria.tplScriptDefinition({
+    $classpath : "test.aria.utils.overlay.loadingIndicator.wai.body.BodyOverlayJawsTestCaseTplScript",
+    $prototype : {
+        buttonClicked: function () {
+            DomOverlay.create(Aria.$window.document.body, {
+                message: "myoverlaymessage",
+                waiAria: true
+            });
+            setTimeout(function () {
+                DomOverlay.detachFrom(Aria.$window.document.body);
+                Accessibility.readText("finished");
+            }, 2000);
+        }
+    }
+});


### PR DESCRIPTION
Creating a loading overlay on the body added aria-hidden=true on the body which prevented Jaws 2021 (with Edge) from reading the text.