### PR TITLE
fix: Enabling role=button for multiselect widgets

### DIFF
--- a/src/aria/widgets/form/DropDownTextInput.js
+++ b/src/aria/widgets/form/DropDownTextInput.js
@@ -41,7 +41,7 @@ module.exports = Aria.classDefinition({
             "dropdown": iconTooltip
         };
         if (cfg.waiAria) {
-            this._iconsAttributes.dropdown += ' aria-expanded="false" aria-haspopup="true"';
+            this._iconsAttributes.dropdown += ' role="button" aria-expanded="false" aria-haspopup="true"';
             if (cfg.disabled) {
                 this._iconsAttributes.dropdown += ' aria-hidden="true"';
             } else {


### PR DESCRIPTION
This commit enables the role="button" attribute on MultiSelect widget, so that MultiSelect icons will be included in the list of
buttons displayed by screen readers and become focusable by tab.