### PR TITLE
fix: adding metaKey event mapping for DomEvent wrapper (PTR30373522)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "14.17.3"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci
       - run: /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
       - run: npm run ci
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.coverage }}
           path: test/logs/*.json

--- a/src/aria/DomEvent.js
+++ b/src/aria/DomEvent.js
@@ -26,6 +26,7 @@ var ariaCoreBrowser = require("./core/Browser");
         "altKey" : "altKey",
         "ctrlKey" : "ctrlKey",
         "shiftKey" : "shiftKey",
+        "metaKey" : "metaKey",
         "pageX" : "pageX",
         "pageY" : "pageY",
         "relatedTarget" : "relatedTarget",


### PR DESCRIPTION
The DomEvent wrapper doesn't map the metaKey event corresponding to the Mac Command key, enabling a proper handling of key combinations on Mac (i.e. copy/cut/paste) Corresponding to SECO PTR 30373522